### PR TITLE
fix(commands): add explicit Skill tool instructions for loading skills

### DIFF
--- a/commands/fetch-pr-feedback.md
+++ b/commands/fetch-pr-feedback.md
@@ -75,7 +75,9 @@ If no comments found, output: "No comments from {bot} found on this PR."
 
 ### 5. Evaluate with receive-feedback
 
-Load the **receive-feedback** skill and process the formatted feedback document:
+Use the Skill tool to load the receive-feedback skill: `Skill(skill: "beagle:receive-feedback")`
+
+Then process the formatted feedback document:
 
 1. Parse each actionable item from the formatted document
 2. Process each item through verify → evaluate → execute

--- a/commands/receive-feedback.md
+++ b/commands/receive-feedback.md
@@ -16,9 +16,9 @@ Process external code review feedback using the receive-feedback skill.
 
 1. **Read** the feedback file at `$ARGUMENTS`
 2. **Parse** individual feedback items (numbered, bulleted, or freeform)
-3. **Load** the receive-feedback skill
-4. **Process** each item through verify → evaluate → execute
-5. **Produce** structured response summary (see RESPONSE.md)
+3. **Load skill** using the Skill tool: `Skill(skill: "beagle:receive-feedback")`
+4. **Process** each item through verify → evaluate → execute (as defined in the skill)
+5. **Produce** structured response summary (per skill's RESPONSE.md)
 6. **Prompt** whether to log to `.feedback-log.csv`
 
 ## Expected Feedback File Format

--- a/commands/review-frontend.md
+++ b/commands/review-frontend.md
@@ -33,6 +33,8 @@ git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E '\.test\.tsx?$'
 
 ## Step 3: Load Skills
 
+Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle:react-router-code-review")`).
+
 **Always load:**
 - `beagle:react-router-code-review`
 - `beagle:shadcn-code-review`

--- a/commands/review-go.md
+++ b/commands/review-go.md
@@ -36,6 +36,8 @@ git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E '_test\.go$'
 
 ## Step 3: Load Skills
 
+Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle:go-code-review")`).
+
 **Always load:**
 - `beagle:go-code-review`
 

--- a/commands/review-plan.md
+++ b/commands/review-plan.md
@@ -29,6 +29,8 @@ Read the plan file and extract:
 
 ## Step 2: Load Skills
 
+Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle:python-code-review")`).
+
 Based on detected tech stack, load relevant skills:
 
 | Detected | Skill |

--- a/commands/review-python.md
+++ b/commands/review-python.md
@@ -56,6 +56,8 @@ git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E 'test.*\.py$'
 
 ## Step 4: Load Skills
 
+Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle:python-code-review")`).
+
 **Always load:**
 - `beagle:python-code-review`
 - `beagle:fastapi-code-review`

--- a/commands/review-tui.md
+++ b/commands/review-tui.md
@@ -36,6 +36,8 @@ git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E '_test\.go$'
 
 ## Step 3: Load Skills
 
+Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle:go-code-review")`).
+
 **Always load:**
 - `beagle:go-code-review`
 - `beagle:bubbletea-code-review`

--- a/skills/receive-feedback/references/skill-integration.md
+++ b/skills/receive-feedback/references/skill-integration.md
@@ -23,7 +23,7 @@ to verify against established codebase patterns.
 ## Integration Workflow
 
 1. **Identify domain** - What technology does the feedback concern?
-2. **Load skill** - Use Skill tool to load relevant skill
+2. **Load skill** - Use Skill tool: `Skill(skill: "beagle:<skill-name>")`
 3. **Cross-reference** - Does feedback align with skill guidance?
 4. **Resolve conflicts** - If feedback contradicts skill, flag for discussion
 


### PR DESCRIPTION
## Summary

Commands used vague language like "Load the skill" without specifying HOW to load it. This caused Claude Code to manually search for skill files using `find` and `grep` instead of properly using the `Skill` tool.

## Changes

### Fixed
- `commands/receive-feedback.md` - Added explicit `Skill(skill: "beagle:receive-feedback")` syntax
- `commands/fetch-pr-feedback.md` - Added explicit Skill tool usage instruction
- `commands/review-python.md` - Added Skill tool loading instruction
- `commands/review-frontend.md` - Added Skill tool loading instruction
- `commands/review-go.md` - Added Skill tool loading instruction
- `commands/review-tui.md` - Added Skill tool loading instruction
- `commands/review-plan.md` - Added Skill tool loading instruction
- `skills/receive-feedback/references/skill-integration.md` - Added explicit syntax example

## Motivation

When a user ran `/beagle:receive-feedback` in another repo, Claude Code tried to manually locate the skill files:

```
⏺ Read(~/.claude/skills/existential-birds/beagle/receive-feedback.md)
  ⎿  Error reading file

⏺ Bash(find ~/.claude -name "*.md" -type f 2>/dev/null | xargs grep -l "receive-feedback" ...)
```

The root cause was that commands said "Load the receive-feedback skill" without specifying the mechanism (`Skill` tool with proper naming).

## Testing

- [x] Verified all modified commands now include explicit `Skill(skill: "beagle:<name>")` syntax
- [x] Changes are consistent across all affected files

### Manual Testing Steps

1. Install the updated plugin
2. Run `/beagle:receive-feedback` with a feedback file
3. Verify Claude uses `Skill` tool instead of file searches

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workflow documentation with explicit instructions for using the Skill tool to load and process skills.
  * Added inline code examples demonstrating proper skill invocation syntax.
  * Clarified execution semantics across multiple review and feedback workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->