### PR TITLE
chore(release): bump version to 1.5.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle",
   "description": "Code review skills and verification workflows for Python, Go, React, and AI frameworks",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Beagle are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 2025-12-31
+
+### Fixed
+
+- **commands:** Add explicit `Skill` tool instructions to all commands that load skills, fixing issue where Claude Code would manually search for skill files instead of using the Skill tool ([#11](https://github.com/existential-birds/beagle/pull/11))
+
 ## [1.5.0] - 2025-12-31
 
 ### Added
@@ -57,6 +63,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
+[1.5.1]: https://github.com/existential-birds/beagle/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/existential-birds/beagle/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/existential-birds/beagle/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/existential-birds/beagle/compare/v1.2.0...v1.3.0


### PR DESCRIPTION
## Summary

Release version 1.5.1 with bug fix for explicit Skill tool instructions.

## Changes

- Updated CHANGELOG.md with 1.5.1 entry
- Bumped version in `.claude-plugin/plugin.json` to 1.5.1

## Release Notes

### Fixed

- **commands:** Add explicit `Skill` tool instructions to all commands that load skills, fixing issue where Claude Code would manually search for skill files instead of using the Skill tool (#11)

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill loading behavior to properly utilize the Skill tool instead of manual file searching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->