### PR TITLE
fix(adr): resolve decision display, numbering, and frontmatter issues

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle",
   "description": "Code review skills and verification workflows for Python, Go, React, and AI frameworks",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/skills/adr-writing/SKILL.md
+++ b/skills/adr-writing/SKILL.md
@@ -37,11 +37,22 @@ Generate Architectural Decision Records (ADRs) following the MADR template with 
 
 ### Step 1: Get Sequence Number
 
+**If a number was pre-assigned** (e.g., when called from `/beagle:write-adr` with parallel writes):
+- Use the pre-assigned number directly
+- Do NOT call the script - this prevents duplicate numbers in parallel execution
+
+**If no number was pre-assigned** (standalone use):
 ```bash
 python scripts/next_adr_number.py
 ```
 
 This outputs the next available ADR number (e.g., `0003`).
+
+For parallel allocation (used by parent commands):
+```bash
+python scripts/next_adr_number.py --count 3
+# Outputs: 0003, 0004, 0005 (one per line)
+```
 
 ### Step 2: Explore Context
 
@@ -93,6 +104,29 @@ These prompts signal incomplete sections for later follow-up.
 
 ### Step 7: Write File
 
+**IMPORTANT: Every ADR MUST start with YAML frontmatter.**
+
+The frontmatter block is REQUIRED and must include at minimum:
+```yaml
+---
+status: draft
+date: YYYY-MM-DD
+---
+```
+
+Full frontmatter template:
+```yaml
+---
+status: draft
+date: 2024-01-15
+decision-makers: [alice, bob]
+consulted: []
+informed: []
+---
+```
+
+**Validation:** Before writing the file, verify the content starts with `---` followed by valid YAML frontmatter. If frontmatter is missing, add it before writing.
+
 Save to `docs/adrs/NNNN-slugified-title.md`:
 
 ```
@@ -101,13 +135,13 @@ docs/adrs/0004-adopt-event-sourcing-pattern.md
 docs/adrs/0005-migrate-to-kubernetes.md
 ```
 
-### Step 8: Set Status
+### Step 8: Verify Frontmatter
 
-In frontmatter, always set initial status:
-
-```yaml
-status: draft
-```
+After writing, confirm the file:
+1. Starts with `---` on the first line
+2. Contains `status: draft` (or other valid status)
+3. Contains `date: YYYY-MM-DD` with actual date
+4. Ends frontmatter with `---` before the title
 
 ## File Naming Convention
 

--- a/skills/adr-writing/scripts/next_adr_number.py
+++ b/skills/adr-writing/scripts/next_adr_number.py
@@ -6,6 +6,7 @@ Scans docs/adrs/ for existing ADRs and returns the next available number.
 Usage:
     python scripts/next_adr_number.py
     python scripts/next_adr_number.py --dir /path/to/docs/adrs
+    python scripts/next_adr_number.py --count 3  # Pre-allocate 3 numbers for parallel writes
 """
 
 import argparse
@@ -88,6 +89,12 @@ def main() -> int:
         action="store_true",
         help="List existing ADR numbers",
     )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=1,
+        help="Number of sequential ADR numbers to allocate (for parallel writes)",
+    )
     args = parser.parse_args()
 
     adr_dir = args.dir or find_adr_directory()
@@ -102,7 +109,14 @@ def main() -> int:
         return 0
 
     next_num = next_number(existing)
-    print(format_number(next_num))
+
+    if args.count == 1:
+        print(format_number(next_num))
+    else:
+        # Output multiple numbers, one per line, for parallel allocation
+        allocated = [format_number(next_num + i) for i in range(args.count)]
+        print("\n".join(allocated))
+
     return 0
 
 


### PR DESCRIPTION
## Summary

- Display full decision details before user confirmation in `/beagle:write-adr`
- Add `--count` option to `next_adr_number.py` for parallel ADR number allocation
- Make YAML frontmatter explicitly required with validation steps

## Test plan

- [ ] Run `/beagle:write-adr` and verify full decision details shown before selection
- [ ] Test `python scripts/next_adr_number.py --count 3` outputs 3 sequential numbers
- [ ] Generate multiple ADRs in parallel and verify unique filenames
- [ ] Check all generated ADRs have frontmatter with `status` and `date`

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ADR numbering script now supports batch allocation of multiple numbers in a single run.
  * Pre-allocation of ADR sequence numbers for parallel workflows.
  * Enhanced decision presentation with detailed structured display (problem, decision, alternatives, rationale, confidence).
  * YAML frontmatter requirement for ADR files.

* **Documentation**
  * Updated ADR writing guidance and MADR format reference.

* **Chores**
  * Version bumped to 1.6.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->