### PR TITLE
chore(release): bump version to 1.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle",
   "description": "Code review skills and verification workflows for Python, Go, React, and AI frameworks",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Beagle are documented here.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] - 2026-01-03
+
+### Added
+
+- **llm-artifacts-detection:** New skill for detecting common LLM coding agent artifacts (over-abstraction, dead code, DRY violations, verbose comments, defensive overkill)
+- **review-llm-artifacts:** New command to detect LLM artifacts using 4 parallel subagents (tests, dead code, abstraction, style) with JSON report output
+- **fix-llm-artifacts:** New command to apply fixes from review with safe/risky classification, dry-run support, and post-fix verification
+
+## [1.6.1] - 2026-01-03
+
+### Fixed
+
+- **adr:** Resolve decision display, numbering, and frontmatter issues ([#18](https://github.com/existential-birds/beagle/pull/18))
+
+## [1.6.0] - 2026-01-02
+
+### Added
+
+- **adr-decision-extraction:** New skill for extracting architectural decisions from conversation context
+- **adr-writing:** New skill for writing MADR-formatted Architecture Decision Records with templates and validation
+- **write-adr:** New command to generate ADRs from decisions made in the current session ([#15](https://github.com/existential-birds/beagle/pull/15))
+
 ## [1.5.1] - 2025-12-31
 
 ### Fixed
@@ -63,6 +85,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
+[1.7.0]: https://github.com/existential-birds/beagle/compare/v1.6.1...v1.7.0
+[1.6.1]: https://github.com/existential-birds/beagle/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/existential-birds/beagle/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/existential-birds/beagle/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/existential-birds/beagle/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/existential-birds/beagle/compare/v1.3.0...v1.4.0

--- a/commands/review-llm-artifacts.md
+++ b/commands/review-llm-artifacts.md
@@ -210,9 +210,32 @@ Write findings to `.beagle/llm-artifacts-review.json`:
 - Review the JSON report at `.beagle/llm-artifacts-review.json`
 ```
 
+## Step 7: Verification
+
+Before completing, verify the review executed correctly:
+
+1. **JSON validity:** Confirm `.beagle/llm-artifacts-review.json` exists and is parseable
+2. **Subagent success:** All 4 subagents completed without errors
+3. **Git HEAD captured:** The `git_head` field is non-empty in the report
+4. **Staleness check:** If a previous report exists, compare stored `git_head` to current HEAD and warn if different
+
+```bash
+# Verify JSON is valid
+python3 -c "import json; json.load(open('.beagle/llm-artifacts-review.json'))" 2>/dev/null && echo "✓ Valid JSON" || echo "✗ Invalid JSON"
+
+# Check for staleness (if previous report exists)
+STORED_HEAD=$(jq -r '.git_head' .beagle/llm-artifacts-review.json 2>/dev/null)
+CURRENT_HEAD=$(git rev-parse --short HEAD)
+if [ "$STORED_HEAD" != "$CURRENT_HEAD" ]; then
+  echo "⚠️ Report was generated on $STORED_HEAD, current HEAD is $CURRENT_HEAD"
+fi
+```
+
+If any verification fails, report the error and do not proceed.
+
 ## Output Format for Each Finding
 
-```
+```text
 [FILE:LINE] **ISSUE_TYPE** (Risk, Fix Safety)
 - Description
 - Suggestion: Specific fix recommendation


### PR DESCRIPTION
## Summary

- Bump version to 1.7.0 in plugin.json
- Add CHANGELOG entries for releases 1.6.0, 1.6.1, and 1.7.0
- Add verification step to review-llm-artifacts command

## After Merge

Create release tags:
```bash
git tag -a v1.6.0 -m "Release v1.6.0 - ADR skills and write-adr command" cadfd01
git tag -a v1.6.1 -m "Release v1.6.1 - ADR fixes" 0fe5cf5
git tag -a v1.7.0 -m "Release v1.7.0 - LLM artifacts detection"
git push origin v1.6.0 v1.6.1 v1.7.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced three new LLM artifact capabilities: detection, review workflow, and fix functionality.
  * Added comprehensive verification step for artifact reviews, including JSON format validation, subagent execution confirmation, git HEAD tracking, and staleness detection.

* **Documentation**
  * Enhanced command documentation with detailed verification procedures and validation checks prior to processing findings.

* **Chores**
  * Bumped plugin version from 1.6.1 to 1.7.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->