### PR TITLE
docs(readme): add missing commands and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Claude loads skills automatically when relevant. See [Agent Skills](https://docs
 | `review-skill-improver` | Analyze feedback to improve review skills |
 | `adr-decision-extraction` | Extract architectural decisions from conversation |
 | `adr-writing` | Write MADR-formatted ADRs |
+| `llm-artifacts-detection` | Criteria for detecting LLM coding artifacts |
 
 </details>
 
@@ -144,6 +145,7 @@ Run commands with `/beagle:<command>`. See [Slash commands](https://docs.claude.
 | `/beagle:review-go` | Go code review with BubbleTea/Wish/Prometheus detection |
 | `/beagle:review-tui` | BubbleTea TUI code review with Elm architecture focus |
 | `/beagle:review-plan <path>` | Review implementation plans before execution |
+| `/beagle:review-llm-artifacts` | Detect LLM coding artifacts (dead code, over-abstraction) |
 
 </details>
 
@@ -169,6 +171,9 @@ Run commands with `/beagle:<command>`. See [Slash commands](https://docs.claude.
 | `/beagle:receive-feedback <path>` | Process code review feedback |
 | `/beagle:fetch-pr-feedback` | Fetch bot review comments from PR |
 | `/beagle:respond-pr-feedback` | Reply to bot review comments |
+| `/beagle:fix-llm-artifacts` | Fix detected LLM artifacts with safe/risky classification |
+| `/beagle:ensure-docs` | Verify documentation coverage and generate missing docs |
+| `/beagle:prompt-improver` | Optimize prompts for code-related tasks |
 
 </details>
 


### PR DESCRIPTION
## Summary

- Add 4 missing commands to README: `review-llm-artifacts`, `fix-llm-artifacts`, `ensure-docs`, `prompt-improver`
- Add 1 missing skill to README: `llm-artifacts-detection`

These items existed in the codebase but were not documented in README.md.

## Test plan

- [ ] Verify all listed commands exist in `commands/` folder
- [ ] Verify all listed skills exist in `skills/` folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new LLM artifacts detection utility skill
  * Documented four new commands for code review, artifact detection and fixing, documentation verification, and prompt optimization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->