### PR TITLE
docs(readme): make README more concise and fix skill categorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,205 +1,65 @@
 # beagle
 
-![Apollo 10 astronaut Thomas P. Stafford pats the nose of a stuffed Snoopy held by a member of the launch pad closeout crew](assets/Stafford_and_Snoopy.jpg)
+![Apollo 10 astronaut Thomas P. Stafford pats the nose of a stuffed Snoopy](assets/Stafford_and_Snoopy.jpg)
 
-*Image: NASA, Public Domain. [Source](https://www.nasa.gov/multimedia/imagegallery/image_feature_572.html) | [Snoopy in Space](https://airandspace.si.edu/air-and-space-quarterly/winter-2024/snoopy-in-space)*
+*Image: NASA, Public Domain. [Source](https://www.nasa.gov/multimedia/imagegallery/image_feature_572.html)*
 
-Code review skills and verification workflows for Python, Go, React, and AI frameworks. Designed to complement [superpowers](https://github.com/obra/superpowers) with pre-push reviews and GitHub bot feedback handling.
+Code review skills and verification workflows for Python, Go, React, and AI frameworks. Designed to complement [superpowers](https://github.com/obra/superpowers).
 
 ## Installation
-
-Run this command in your terminal:
 
 ```bash
 claude plugin marketplace add https://github.com/existential-birds/beagle && claude plugin install beagle
 ```
 
-Or manually add the marketplace to `~/.claude/settings.json`:
-
-```json
-{
-  "marketplaces": ["https://github.com/existential-birds/beagle"]
-}
-```
-
-Then restart Claude Code and run `/plugin install beagle`.
-
-For more on Claude Code plugins, see [Plugin documentation](https://docs.claude.com/en/docs/claude-code/plugins).
-
-## Updating
-
-To update to the latest version:
-
-```bash
-claude plugin update beagle
-```
-
-Or reinstall the plugin:
-
-```bash
-claude plugin install beagle
-```
-
-To update the marketplace index:
-
-```bash
-claude plugin marketplace update https://github.com/existential-birds/beagle
-```
-
-To enable automatic marketplace updates, add to `~/.claude/settings.json`:
-
-```json
-{
-  "autoUpdateMarketplaces": true
-}
-```
+To update: `claude plugin update beagle`
 
 ## Skills
 
-Claude loads skills automatically when relevant. See [Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview) for how skills work.
+Auto-loaded by Claude when relevant. See [Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview).
 
-<details>
-<summary><strong>Frontend</strong></summary>
-
-| Skill | Triggers |
-|-------|----------|
-| `react-flow` | Graph visualization, workflow nodes, custom edges |
-| `react-router-v7` | Routing, loaders, actions, navigation |
-| `tailwind-v4` | Styling, theming, dark mode |
-| `shadcn-ui` | Component library, CVA variants |
-| `zustand-state` | State management, middleware |
-| `dagre-react-flow` | Auto-layout for graphs |
-
-</details>
-
-<details>
-<summary><strong>Backend (Python)</strong></summary>
-
-| Skill | Triggers |
-|-------|----------|
-| `python-code-review` | Type hints, async patterns, error handling |
-| `fastapi-code-review` | Endpoints, dependencies, validation |
-| `sqlalchemy-code-review` | ORM patterns, relationships, queries |
-| `postgres-code-review` | Postgres-specific patterns, JSONB, GIN |
-| `pytest-code-review` | Test patterns, fixtures, mocking |
-
-</details>
-
-<details>
-<summary><strong>Backend (Go)</strong></summary>
-
-| Skill | Triggers |
-|-------|----------|
-| `go-code-review` | Error handling, concurrency, interfaces |
-| `bubbletea-code-review` | TUI patterns, Model/Update/View, Lipgloss |
-| `wish-ssh-code-review` | SSH server, middleware, sessions |
-| `prometheus-go-code-review` | Metrics, labels, instrumentation |
-| `go-testing-code-review` | Table-driven tests, mocking, parallel tests |
-
-</details>
-
-<details>
-<summary><strong>AI Frameworks</strong></summary>
-
-| Skill | Triggers |
-|-------|----------|
-| `pydantic-ai-*` | Agent creation, tools, dependency injection, testing |
-| `langgraph-*` | Graph architecture, implementation patterns |
-| `vercel-ai-sdk` | Streaming, use-chat, tools |
-| `deepagents-*` | Architecture, implementation, code review for Deep Agents |
-
-</details>
-
-<details>
-<summary><strong>Utilities</strong></summary>
-
-| Skill | Triggers |
-|-------|----------|
-| `vitest-testing` | Test configuration, mocking patterns |
-| `docling` | Document parsing, chunking |
-| `sqlite-vec` | Vector search, embeddings |
-| `github-projects` | Project management via GraphQL |
-| `ai-elements` | AI visualization components |
-| `receive-feedback` | Processing code review feedback |
-| `agent-architecture-analysis` | Analyzing agent system architecture |
-| `12-factor-apps` | 12-Factor App compliance patterns |
-| `review-feedback-schema` | Schema for tracking review outcomes |
-| `review-skill-improver` | Analyze feedback to improve review skills |
-| `adr-decision-extraction` | Extract architectural decisions from conversation |
-| `adr-writing` | Write MADR-formatted ADRs |
-| `llm-artifacts-detection` | Criteria for detecting LLM coding artifacts |
-
-</details>
+| Category | Skills |
+|----------|--------|
+| **Frontend** | react-flow-\*, react-router-\*, tailwind-v4, shadcn-\*, zustand-state, dagre-react-flow, vitest-testing, ai-elements |
+| **Backend (Python)** | python-code-review, fastapi-code-review, sqlalchemy-code-review, postgres-code-review, pytest-code-review, docling, sqlite-vec |
+| **Backend (Go)** | go-code-review, go-testing-code-review, bubbletea-code-review, wish-ssh-code-review, prometheus-go-code-review |
+| **AI Frameworks** | pydantic-ai-\* (6), langgraph-\* (3), vercel-ai-sdk, deepagents-\* (3) |
+| **Workflow** | receive-feedback, review-feedback-schema, review-skill-improver, llm-artifacts-detection |
+| **Architecture** | 12-factor-apps, agent-architecture-analysis, adr-\*, github-projects |
 
 ## Commands
 
-Run commands with `/beagle:<command>`. See [Slash commands](https://docs.claude.com/en/docs/claude-code/slash-commands) for how commands work.
-
-<details>
-<summary><strong>Code review</strong></summary>
+Run with `/beagle:<command>`. See [Slash commands](https://docs.claude.com/en/docs/claude-code/slash-commands).
 
 | Command | Description |
 |---------|-------------|
-| `/beagle:review-python` | Python/FastAPI code review with tech detection |
-| `/beagle:review-frontend` | React/TypeScript code review with tech detection |
-| `/beagle:review-go` | Go code review with BubbleTea/Wish/Prometheus detection |
-| `/beagle:review-tui` | BubbleTea TUI code review with Elm architecture focus |
-| `/beagle:review-plan <path>` | Review implementation plans before execution |
-| `/beagle:review-llm-artifacts` | Detect LLM coding artifacts (dead code, over-abstraction) |
-
-</details>
-
-<details>
-<summary><strong>Git workflows</strong></summary>
-
-| Command | Description |
-|---------|-------------|
-| `/beagle:commit-push` | Commit staged changes and push |
-| `/beagle:create-pr` | Create PR with standardized template |
-| `/beagle:gen-release-notes <tag>` | Generate release notes since tag |
-
-</details>
-
-<details>
-<summary><strong>Other</strong></summary>
-
-| Command | Description |
-|---------|-------------|
-| `/beagle:skill-builder` | Create skills following best practices |
-| `/beagle:write-adr` | Generate ADRs from session decisions |
-| `/beagle:12-factor-apps-analysis` | Analyze codebase for 12-Factor compliance |
-| `/beagle:receive-feedback <path>` | Process code review feedback |
-| `/beagle:fetch-pr-feedback` | Fetch bot review comments from PR |
-| `/beagle:respond-pr-feedback` | Reply to bot review comments |
-| `/beagle:fix-llm-artifacts` | Fix detected LLM artifacts with safe/risky classification |
-| `/beagle:ensure-docs` | Verify documentation coverage and generate missing docs |
-| `/beagle:prompt-improver` | Optimize prompts for code-related tasks |
-
-</details>
+| `review-python` | Python/FastAPI code review |
+| `review-frontend` | React/TypeScript code review |
+| `review-go` | Go code review |
+| `review-tui` | BubbleTea TUI code review |
+| `review-plan <path>` | Review implementation plans |
+| `review-llm-artifacts` | Detect LLM coding artifacts |
+| `fix-llm-artifacts` | Fix detected artifacts |
+| `commit-push` | Commit and push changes |
+| `create-pr` | Create PR with template |
+| `gen-release-notes <tag>` | Generate release notes |
+| `write-adr` | Generate ADRs from decisions |
+| `12-factor-apps-analysis` | 12-Factor compliance check |
+| `receive-feedback <path>` | Process review feedback |
+| `fetch-pr-feedback` | Fetch bot comments from PR |
+| `respond-pr-feedback` | Reply to bot comments |
+| `ensure-docs` | Documentation coverage check |
+| `skill-builder` | Create new skills |
+| `prompt-improver` | Optimize prompts |
 
 ## Cursor IDE
 
-Commands are also available for Cursor. Copy the `.cursor/commands/` folder to your project:
+Copy commands to your project:
 
 ```bash
 curl -L https://github.com/existential-birds/beagle/archive/refs/heads/main.tar.gz | tar -xz --strip-components=1 beagle-main/.cursor
 ```
 
-See [Cursor documentation](https://cursor.com/docs/agent/chat/commands) for command usage.
-
 ## Troubleshooting
 
-### "Marketplace file not found" error
-
-If you see an error like:
-
-```
-Warning: Failed to load marketplace 'xyz': Marketplace file not found at /path/to/plugin
-```
-
-This means a marketplace entry in `~/.claude/plugins/known_marketplaces.json` points to a directory that no longer exists. To fix:
-
-1. Open `~/.claude/plugins/known_marketplaces.json`
-2. Remove the stale marketplace entry
-3. Also check `~/.claude/settings.json` for any `enabledPlugins` referencing that marketplace
-4. Restart Claude Code
+**"Marketplace file not found"**: Remove stale entries from `~/.claude/plugins/known_marketplaces.json` and restart Claude Code.


### PR DESCRIPTION
## Summary
- Reduced README from 205 to 65 lines (68% reduction)
- Fixed skill categorization: ai-elements and vitest-testing moved to Frontend; docling and sqlite-vec moved to Backend Python
- Added new categories (Workflow, Architecture) instead of generic "Utilities"
- Consolidated collapsible sections into clean tables

## Changes
- Skills: 5 collapsible sections → 1 table with 6 categories
- Commands: 3 collapsible sections → 1 table with all 18 commands
- Installation: removed manual JSON config instructions
- Troubleshooting: condensed to single line

🤖 Generated with [Claude Code](https://claude.com/claude-code)