### PR TITLE
chore(release): 2.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.8.0"
+    "version": "2.9.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "name": "beagle-core",
       "source": "./plugins/beagle-core",
       "description": "Shared code review workflows, verification protocol, git commands, and feedback handling",
-      "version": "1.1.2",
+      "version": "1.1.4",
       "category": "workflow",
       "tags": [
         "code-review",
@@ -36,7 +36,7 @@
       "name": "beagle-python",
       "source": "./plugins/beagle-python",
       "description": "Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "backend",
       "tags": [
         "python",
@@ -51,7 +51,7 @@
       "name": "beagle-go",
       "source": "./plugins/beagle-go",
       "description": "Go, BubbleTea TUI, Wish SSH, and Prometheus code review",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "backend",
       "tags": [
         "go",
@@ -66,7 +66,7 @@
       "name": "beagle-elixir",
       "source": "./plugins/beagle-elixir",
       "description": "Elixir, Phoenix, LiveView, and ExUnit code review",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "category": "backend",
       "tags": [
         "elixir",
@@ -80,7 +80,7 @@
       "name": "beagle-ios",
       "source": "./plugins/beagle-ios",
       "description": "Swift, SwiftUI, SwiftData, and iOS framework code review",
-      "version": "1.1.0",
+      "version": "1.2.1",
       "category": "mobile",
       "tags": [
         "swift",
@@ -96,7 +96,7 @@
       "name": "beagle-react",
       "source": "./plugins/beagle-react",
       "description": "React, React Flow, React Router, shadcn/ui, Tailwind, Vitest, and Zustand code review",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "frontend",
       "tags": [
         "react",
@@ -125,7 +125,7 @@
       "name": "beagle-docs",
       "source": "./plugins/beagle-docs",
       "description": "Documentation quality, AI writing detection, and humanization using Diataxis principles",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "documentation",
       "tags": [
         "documentation",
@@ -139,7 +139,7 @@
       "name": "beagle-analysis",
       "source": "./plugins/beagle-analysis",
       "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "analysis",
       "tags": [
         "12-factor",
@@ -153,7 +153,7 @@
       "name": "beagle-rust",
       "source": "./plugins/beagle-rust",
       "description": "Rust, tokio, axum, serde, sqlx, and async concurrency code review",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "category": "backend",
       "tags": [
         "rust",
@@ -169,7 +169,7 @@
       "name": "beagle-testing",
       "source": "./plugins/beagle-testing",
       "description": "Language-agnostic test plan generation and execution",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "category": "testing",
       "tags": [
         "testing",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,6 @@
       "name": "beagle",
       "source": "./plugins/beagle",
       "description": "Deprecated: split into beagle-core, beagle-react, etc. You can safely disable this plugin.",
-      "version": "2.0.0",
       "category": "deprecated",
       "tags": [
         "deprecated"
@@ -23,7 +22,6 @@
       "name": "beagle-core",
       "source": "./plugins/beagle-core",
       "description": "Shared code review workflows, verification protocol, git commands, and feedback handling",
-      "version": "1.1.4",
       "category": "workflow",
       "tags": [
         "code-review",
@@ -36,7 +34,6 @@
       "name": "beagle-python",
       "source": "./plugins/beagle-python",
       "description": "Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review",
-      "version": "1.1.1",
       "category": "backend",
       "tags": [
         "python",
@@ -51,7 +48,6 @@
       "name": "beagle-go",
       "source": "./plugins/beagle-go",
       "description": "Go, BubbleTea TUI, Wish SSH, and Prometheus code review",
-      "version": "2.3.1",
       "category": "backend",
       "tags": [
         "go",
@@ -66,7 +62,6 @@
       "name": "beagle-elixir",
       "source": "./plugins/beagle-elixir",
       "description": "Elixir, Phoenix, LiveView, and ExUnit code review",
-      "version": "1.2.1",
       "category": "backend",
       "tags": [
         "elixir",
@@ -80,7 +75,6 @@
       "name": "beagle-ios",
       "source": "./plugins/beagle-ios",
       "description": "Swift, SwiftUI, SwiftData, and iOS framework code review",
-      "version": "1.2.1",
       "category": "mobile",
       "tags": [
         "swift",
@@ -96,7 +90,6 @@
       "name": "beagle-react",
       "source": "./plugins/beagle-react",
       "description": "React, React Flow, React Router, shadcn/ui, Tailwind, Vitest, and Zustand code review",
-      "version": "1.1.1",
       "category": "frontend",
       "tags": [
         "react",
@@ -111,7 +104,6 @@
       "name": "beagle-ai",
       "source": "./plugins/beagle-ai",
       "description": "Pydantic AI, LangGraph, DeepAgents, and Vercel AI SDK skills",
-      "version": "1.0.0",
       "category": "ai",
       "tags": [
         "pydantic-ai",
@@ -125,7 +117,6 @@
       "name": "beagle-docs",
       "source": "./plugins/beagle-docs",
       "description": "Documentation quality, AI writing detection, and humanization using Diataxis principles",
-      "version": "1.1.1",
       "category": "documentation",
       "tags": [
         "documentation",
@@ -139,7 +130,6 @@
       "name": "beagle-analysis",
       "source": "./plugins/beagle-analysis",
       "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge",
-      "version": "1.1.1",
       "category": "analysis",
       "tags": [
         "12-factor",
@@ -153,7 +143,6 @@
       "name": "beagle-rust",
       "source": "./plugins/beagle-rust",
       "description": "Rust, tokio, axum, serde, sqlx, and async concurrency code review",
-      "version": "1.0.1",
       "category": "backend",
       "tags": [
         "rust",
@@ -169,7 +158,6 @@
       "name": "beagle-testing",
       "source": "./plugins/beagle-testing",
       "description": "Language-agnostic test plan generation and execution",
-      "version": "1.0.2",
       "category": "testing",
       "tags": [
         "testing",

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -12,12 +12,11 @@ No arguments required - automatically detects the previous tag.
 
 ## Versioning Overview
 
-Beagle has three version locations:
+Beagle has two version locations:
 1. **marketplace.json metadata.version** (`.claude-plugin/marketplace.json`) - Main release version, matches repo tags
 2. **Per-plugin plugin.json version** (`plugins/<name>/.claude-plugin/plugin.json`) - Individual plugin versions, bumped when that plugin's files change
-3. **marketplace.json plugins[].version** - Plugin version in marketplace listing (only update when marketplace structure changes)
 
-This command updates **marketplace.json metadata.version** and **affected plugin.json versions**. The marketplace `plugins[].version` entries are updated manually when the marketplace structure changes.
+The `marketplace.json plugins[].version` entries are synced from each plugin's `plugin.json` during release (plugin.json is the source of truth).
 
 ## Prerequisites
 

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -16,8 +16,6 @@ Beagle has two version locations:
 1. **marketplace.json metadata.version** (`.claude-plugin/marketplace.json`) - Main release version, matches repo tags
 2. **Per-plugin plugin.json version** (`plugins/<name>/.claude-plugin/plugin.json`) - Individual plugin versions, bumped when that plugin's files change
 
-The `marketplace.json plugins[].version` entries are synced from each plugin's `plugin.json` during release (plugin.json is the source of truth).
-
 ## Prerequisites
 
 Verify we're on main and it's clean:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-03-30
+
+### Added
+- **codex:** Add OpenAI Codex support with install guide and skill linking instructions ([#77](https://github.com/existential-birds/beagle/pull/77))
+- **codex:** Add `AGENTS.md` for Codex agent discovery ([#77](https://github.com/existential-birds/beagle/pull/77))
+
 ### Changed
-- Unified the marketplace's command-style workflows into skills across all plugins, bringing the repository to 122 skills total and making skills the canonical format.
-- Added Codex support docs at `.codex/INSTALL.md` and `docs/README.codex.md` for linking Beagle skills into Codex's skill path.
-- Marked workflow skills with `disable-model-invocation: true` and internal-only reference skills with `user-invocable: false`.
+- Unify all command workflows into skills format across all plugins, making skills the canonical format ([#77](https://github.com/existential-birds/beagle/pull/77))
 
 ## [2.8.0] - 2026-03-27
 
@@ -295,6 +299,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
+[2.9.0]: https://github.com/existential-birds/beagle/compare/v2.8.0...v2.9.0
+[2.8.0]: https://github.com/existential-birds/beagle/compare/v2.7.1...v2.8.0
+[2.7.0]: https://github.com/existential-birds/beagle/compare/v2.6.0...v2.7.0
 [2.6.0]: https://github.com/existential-birds/beagle/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/existential-birds/beagle/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/existential-birds/beagle/compare/v2.3.1...v2.4.0

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge comparison.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-docs/.claude-plugin/plugin.json
+++ b/plugins/beagle-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-docs",
   "description": "Documentation quality, generation, and improvement using Diataxis principles. Pairs with beagle-core for full workflow.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-elixir/.claude-plugin/plugin.json
+++ b/plugins/beagle-elixir/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-elixir",
   "description": "Elixir, Phoenix, and LiveView code review and documentation skills",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-go/.claude-plugin/plugin.json
+++ b/plugins/beagle-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-go",
   "description": "Go code review and development skills covering architecture, middleware, data persistence, concurrency, and framework-specific patterns for BubbleTea, Wish SSH, and Prometheus.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-ios/.claude-plugin/plugin.json
+++ b/plugins/beagle-ios/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-ios",
   "description": "Swift, SwiftUI, SwiftData, iOS animation design/implementation/review, and framework code review (HealthKit, CloudKit, WidgetKit, watchOS, App Intents). Pairs with beagle-core for full workflow.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-python/.claude-plugin/plugin.json
+++ b/plugins/beagle-python/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-python",
   "description": "Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review. Pairs with beagle-core for full workflow.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-react/.claude-plugin/plugin.json
+++ b/plugins/beagle-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-react",
   "description": "React, React Flow, React Router, shadcn/ui, Tailwind v4, Vitest, and Zustand code review. Pairs with beagle-core for full workflow.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-rust/.claude-plugin/plugin.json
+++ b/plugins/beagle-rust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-rust",
   "description": "Rust code review and development skills covering ownership, lifetimes, error handling, async/tokio, serde, sqlx, axum, and testing patterns.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-testing/.claude-plugin/plugin.json
+++ b/plugins/beagle-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-testing",
   "description": "Language-agnostic test plan generation and execution.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 2.9.0
- Update CHANGELOG.md with changes since v2.8.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 2.9.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 1.1.1
- [x] `plugins/beagle-core/.claude-plugin/plugin.json` → 1.1.4
- [x] `plugins/beagle-docs/.claude-plugin/plugin.json` → 1.1.1
- [x] `plugins/beagle-elixir/.claude-plugin/plugin.json` → 1.2.1
- [x] `plugins/beagle-go/.claude-plugin/plugin.json` → 2.3.1
- [x] `plugins/beagle-ios/.claude-plugin/plugin.json` → 1.2.1
- [x] `plugins/beagle-python/.claude-plugin/plugin.json` → 1.1.1
- [x] `plugins/beagle-react/.claude-plugin/plugin.json` → 1.1.1
- [x] `plugins/beagle-rust/.claude-plugin/plugin.json` → 1.0.1
- [x] `plugins/beagle-testing/.claude-plugin/plugin.json` → 1.0.2

## Post-merge Steps

After merging, run:
```
/release-tag 2.9.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)