### PR TITLE
feat(beagle-testing): enforce E2E-only test plans and expand stack coverage

### DIFF
--- a/plugins/beagle-testing/skills/gen-test-plan/SKILL.md
+++ b/plugins/beagle-testing/skills/gen-test-plan/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze repo, detect stack, trace changes to user-facing entry points, generate YAML test plan
+description: Analyze repo, detect stack, trace changes to user-facing entry points, generate E2E YAML test plan
 name: gen-test-plan
 disable-model-invocation: true
 ---
@@ -7,6 +7,24 @@ disable-model-invocation: true
 # Generate Test Plan
 
 Analyze the repository's tech stack, branch changes vs default, and generate an executable YAML test plan focused on user-facing impact.
+
+**This is an E2E test plan — not an automated test wrapper.** The generated plan will be executed by an autonomous agent acting exactly as a human QA tester would: launching real binaries, hitting real endpoints, interacting with real databases, and verifying real observable behavior.
+
+## Critical Rule: No Automated Test Duplication
+
+**NEVER generate test steps that re-run the project's existing automated test suite.** This means:
+- No `cargo test`, `pytest`, `npm test`, `go test`, `mix test`, or equivalent commands as test steps
+- No wrapping unit/integration test modules in a test case
+- No "run the tests and check they pass" — that's CI's job, not QA's
+
+If you find yourself writing a test step that invokes the project's test runner, **stop and rethink**. Ask: "What would a human tester do to verify this feature works?" The answer is never "run the unit tests."
+
+**What E2E test steps look like:**
+- Build the binary and run it with real arguments, check stdout/stderr/exit code
+- Start a server and hit it with curl
+- Run a CLI command that writes to a real database, then query the database to verify
+- Launch the TUI and verify it renders (via screenshot or process lifecycle)
+- Chain multiple commands that exercise a full user workflow end-to-end
 
 ## Arguments
 
@@ -41,7 +59,27 @@ See [references/stack-discovery.md](references/stack-discovery.md) for stack det
 
 ## Step 3: Discover User-Facing Entry Points
 
-Grep for route definitions based on detected stack:
+A "user-facing entry point" is anything a human interacts with: CLI subcommands, HTTP endpoints, UI routes, TUI screens, gRPC services, database migrations, or configuration files that affect runtime behavior.
+
+### CLI Applications (Rust/clap, Python/argparse/click, Go/cobra)
+
+```bash
+# Rust (clap) — look for Subcommand derives and command enums
+grep -rn "Subcommand\|#\[command\]" --include="*.rs" | head -20
+
+# Python (click/typer/argparse)
+grep -rn "@click.command\|@app.command\|add_parser\|add_subparser" --include="*.py" | head -20
+
+# Go (cobra)
+grep -rn "cobra.Command\|AddCommand" --include="*.go" | head -20
+```
+
+Build a map of:
+- CLI subcommands: command name + description + file:line
+- Required arguments and flags per subcommand
+- Environment variables the binary reads (grep for `env`, `std::env::var`, `os.Getenv`, `os.environ`)
+
+### HTTP/API Services
 
 **Python (FastAPI/Flask):**
 ```bash
@@ -55,9 +93,9 @@ grep -rn "app\.\(get\|post\|put\|delete\)" --include="*.ts" --include="*.js" | h
 grep -rn "router\.\(get\|post\|put\|delete\)" --include="*.ts" --include="*.js" | head -20
 ```
 
-**React Router:**
+**Rust (axum/actix/rocket):**
 ```bash
-grep -rn "createBrowserRouter\|<Route\|path=" --include="*.tsx" --include="*.jsx" | head -20
+grep -rn "Router::new\|\.route(\|#\[get\]\|#\[post\]\|HttpServer" --include="*.rs" | head -20
 ```
 
 **Go (net/http, gin, chi):**
@@ -65,9 +103,32 @@ grep -rn "createBrowserRouter\|<Route\|path=" --include="*.tsx" --include="*.jsx
 grep -rn "http.HandleFunc\|r.GET\|r.POST\|router.Get\|router.Post" --include="*.go" | head -20
 ```
 
-Build a map of:
+**Elixir (Phoenix):**
+```bash
+grep -rn "get \"/\|post \"/\|pipe_through\|live \"/\|scope \"/\"" --include="*.ex" | head -20
+```
+
+### Browser UI Routes
+
+```bash
+grep -rn "createBrowserRouter\|<Route\|path=" --include="*.tsx" --include="*.jsx" | head -20
+```
+
+### Database and Migrations
+
+```bash
+# SQL migrations
+ls migrations/ db/migrate/ priv/repo/migrations/ 2>/dev/null
+# Schema files
+ls schema.sql schema.prisma 2>/dev/null
+```
+
+### Build a consolidated map of:
+- CLI subcommands: name + args + file:line
 - API endpoints: method + path + file:line
 - UI routes: path + component + file:line
+- Database migrations: filename + what they create/alter
+- Configuration: env vars and config files that affect behavior
 
 ## Step 4: Trace Changes to Entry Points
 
@@ -81,6 +142,10 @@ For each changed file, determine if it affects user-facing functionality:
 ### Import Chain Analysis by Ecosystem
 
 ```bash
+# Rust — use/mod/crate references and workspace deps
+grep -rn "use.*<crate>\|mod <module>" --include="*.rs"
+grep -rn "<crate-name>" --include="Cargo.toml"
+
 # Python — from/import
 grep -rn "from.*<module>\|import.*<module>" --include="*.py"
 
@@ -144,20 +209,40 @@ metadata:
 
 setup:
   stack:
-    - type: <node|python|go|docker>
-      package_manager: <pnpm|npm|yarn|uv|poetry|none>
-  commands:
-    - <install command>
-    - <run command>
-  health_checks:
-    - url: http://localhost:<port>/health
-      timeout: 30
-    - url: http://localhost:<frontend_port>
-      timeout: 30
+    - type: <rust|node|python|go|elixir|docker>
+      package_manager: <cargo|pnpm|npm|yarn|uv|poetry|mix|none>
+  prerequisites:
+    # Services or infrastructure the tests need running
+    - name: <e.g., PostgreSQL>
+      check: <command to verify it's available, e.g., "pg_isready -h localhost">
+  build:
+    # Commands to build the project artifacts (binaries, assets, etc.)
+    - <build command, e.g., "cargo build --workspace">
+  services:
+    # Long-running processes to start before tests (servers, watchers, etc.)
+    # Omit if the project is a CLI tool or library with no server component
+    - command: <start command>
+      health_check:
+        url: http://localhost:<port>/health
+        timeout: 30
+  env:
+    # Environment variables needed by tests (use ${VAR} for secrets)
+    DATABASE_URL: "${DATABASE_URL}"
 
 tests:
-  # API test example:
+  # CLI test example — run the built binary with real arguments:
   - id: TC-01
+    name: <CLI test name>
+    context: |
+      <Why this test exists, which changes affect it>
+    steps:
+      - run: <command that a human would type in their terminal>
+      - run: <follow-up command to verify the effect>
+    expected: |
+      <Expected behavior: exit code, stdout content, side effects>
+
+  # API test example:
+  - id: TC-02
     name: <API test name>
     context: |
       <Why this test exists, which changes affect it>
@@ -168,8 +253,19 @@ tests:
     expected: |
       <Expected behavior in natural language>
 
+  # Database verification example:
+  - id: TC-03
+    name: <Database test name>
+    context: |
+      <Why this test exists, which changes affect it>
+    steps:
+      - run: <command that writes to the database>
+      - run: psql "${DATABASE_URL}" -c "SELECT ... FROM ... WHERE ..."
+    expected: |
+      <Expected rows, schema state, or migration effect>
+
   # Browser test example (always use agent-browser CLI commands):
-  - id: TC-02
+  - id: TC-04
     name: <UI test name>
     context: |
       <Why this test exists, which changes affect it>
@@ -178,11 +274,11 @@ tests:
       - run: agent-browser snapshot -i
       - run: agent-browser click @<ref>
       - run: agent-browser snapshot -i
-      - run: agent-browser screenshot evidence/tc-02.png
+      - run: agent-browser screenshot evidence/tc-04.png
     expected: |
       <Expected behavior in natural language>
     evidence:
-      screenshot: evidence/tc-02.png
+      screenshot: evidence/tc-04.png
 ```
 
 ## Step 7: Report Summary
@@ -242,17 +338,21 @@ grep -E "^version:|^metadata:|^setup:|^tests:" docs/testing/test-plan.yaml
 - [ ] YAML is syntactically valid
 - [ ] At least one test case generated
 - [ ] Setup commands match detected stack
-- [ ] Health checks point to valid endpoints
 - [ ] Each test has id, name, steps, and expected fields
+- [ ] **No automated test duplication:** Grep every `run:` and `command:` step in the plan for test runner invocations (`cargo test`, `pytest`, `npm test`, `go test`, `mix test`, `jest`, `vitest`, `mocha`, etc.). If ANY step invokes the project's test runner, the plan **fails verification**. Remove those steps and replace them with real E2E actions.
 - [ ] **Behavioral coverage:** At least one test exercises the primary behavioral change described in `changes_summary`. Re-read the `changes_summary` and commit messages — if they describe a capability (e.g., "adds Claude Code as a new LLM provider") but no test invokes that capability (e.g., sends a message through the provider), the plan fails verification. Add the missing core functionality test before completing.
 - [ ] **No config-only plans:** If all tests target configuration/admin entry points and zero tests target core functionality entry points, the plan is incomplete. Go back to Step 4, identify the core functionality entry points, and add tests for them.
 
 ## Rules
 
+- **E2E only** — every test step must exercise the real built artifact (binary, server, UI) as a human would. Never wrap automated test suites.
 - Always create `docs/testing/` directory if it doesn't exist
 - Generate at least one test per affected entry point
 - Include context explaining why each test matters (trace from changes)
 - Use natural language for `expected` field (agent will interpret)
+- **CLI projects:** Test steps should invoke the actual binary with real arguments and verify stdout, stderr, exit codes, and side effects (files created, database rows written, processes spawned)
+- **Server projects:** Start the server in setup, test via curl/agent-browser
+- **Library-only projects with no binary or server:** If the change is purely internal library code with no user-facing entry point (no CLI, no server, no UI), state this explicitly and generate tests that exercise the library through its public API via a small driver script — not by running the test suite
 - Default to conservative port detection (8000 for API, 5173/3000 for frontend)
 - **Browser automation steps MUST use `agent-browser` CLI commands** (e.g., `agent-browser open`, `agent-browser snapshot -i`, `agent-browser click @ref`) — never use abstract action syntax
 - Always `agent-browser snapshot -i` before interacting with elements and after navigation/DOM changes

--- a/plugins/beagle-testing/skills/gen-test-plan/references/stack-discovery.md
+++ b/plugins/beagle-testing/skills/gen-test-plan/references/stack-discovery.md
@@ -7,6 +7,12 @@ This reference keeps the detailed stack-detection and entry-point tracing logic 
 Scan for project configuration files to determine the stack:
 
 ```bash
+# Rust detection
+ls Cargo.toml Cargo.lock 2>/dev/null
+
+# Elixir detection
+ls mix.exs mix.lock 2>/dev/null
+
 # Node.js detection
 ls package.json pnpm-lock.yaml package-lock.json yarn.lock 2>/dev/null
 
@@ -22,27 +28,62 @@ ls docker-compose.yml docker-compose.yaml Dockerfile 2>/dev/null
 
 # Makefile detection
 ls Makefile 2>/dev/null && grep -q "dev:" Makefile && echo "has-dev-target"
+
+# Database detection
+ls migrations/ db/migrate/ priv/repo/migrations/ 2>/dev/null
+grep -rl "DATABASE_URL\|postgres\|PgPool\|sqlx\|Ecto.Repo" --include="*.rs" --include="*.ex" --include="*.py" --include="*.ts" --include="*.go" 2>/dev/null | head -5
 ```
 
 ### Stack Detection Rules
 
-| Files Found | Stack | Setup Commands | Default Port |
+| Files Found | Stack | Build Commands | Default Port |
 |-------------|-------|----------------|--------------|
-| `package.json` + `pnpm-lock.yaml` | Node.js (pnpm) | `pnpm install && pnpm run dev` | 5173, 3000 |
-| `package.json` + `package-lock.json` | Node.js (npm) | `npm install && npm run dev` | 5173, 3000 |
-| `package.json` + `yarn.lock` | Node.js (yarn) | `yarn install && yarn dev` | 5173, 3000 |
-| `pyproject.toml` + `uv.lock` | Python (uv) | `uv sync && uv run <entrypoint>` | 8000 |
-| `pyproject.toml` + `poetry.lock` | Python (poetry) | `poetry install && poetry run <entrypoint>` | 8000 |
-| `go.mod` | Go | `go run .` or `make dev` | 8080 |
+| `Cargo.toml` | Rust (cargo) | `cargo build --release` | N/A (CLI) or 8080 |
+| `mix.exs` | Elixir (mix) | `mix deps.get && mix compile` | 4000 |
+| `package.json` + `pnpm-lock.yaml` | Node.js (pnpm) | `pnpm install && pnpm run build` | 5173, 3000 |
+| `package.json` + `package-lock.json` | Node.js (npm) | `npm install && npm run build` | 5173, 3000 |
+| `package.json` + `yarn.lock` | Node.js (yarn) | `yarn install && yarn build` | 5173, 3000 |
+| `pyproject.toml` + `uv.lock` | Python (uv) | `uv sync` | 8000 |
+| `pyproject.toml` + `poetry.lock` | Python (poetry) | `poetry install` | 8000 |
+| `go.mod` | Go | `go build ./...` | 8080 |
 | `docker-compose.yml` | Docker | `docker-compose up -d` | Parse from compose |
 | `Makefile` with `dev:` target | Make-based | `make dev` | Infer from Makefile |
 
+### Determine Project Type
+
+After detecting the stack, classify the project:
+
+| Type | How to detect | E2E test approach |
+|------|--------------|-------------------|
+| **CLI tool** | Has `fn main` / `if __name__` / binary targets, no HTTP listener | Build binary, invoke subcommands with real args, check stdout/stderr/exit code/side effects |
+| **HTTP server** | Has route definitions, listens on a port | Start server, hit endpoints with curl, verify responses and database state |
+| **Web app (frontend)** | Has React/Vue/Svelte routes, serves HTML | Start dev server, use agent-browser for UI interactions |
+| **Full-stack** | Has both server and frontend | Start both, test API + UI |
+| **Library only** | No binary, no server, no main — only `lib.rs`/`__init__.py`/package exports | Write a small driver script that exercises the public API, or test through a downstream consumer |
+
 ### Entrypoint Discovery
+
+**Rust (clap CLI):**
+```bash
+# Find CLI subcommands
+grep -rn "Subcommand\|#\[command\]" --include="*.rs" | head -20
+# Find binary targets
+grep -rn "\[\[bin\]\]\|fn main" --include="*.rs" --include="*.toml" | head -20
+# Find HTTP routes (axum/actix/rocket)
+grep -rn "Router::new\|\.route(\|#\[get\]\|#\[post\]\|HttpServer" --include="*.rs" | head -20
+```
+
+**Elixir (Phoenix):**
+```bash
+grep -rn "get \"/\|post \"/\|pipe_through\|live \"/\|scope \"/\"" --include="*.ex" | head -20
+grep -rn "def handle_event\|def mount" --include="*.ex" | head -20
+```
 
 **Python:**
 ```bash
 grep -rn "@app\.\(get\|post\|put\|delete\|patch\)" --include="*.py" | head -20
 grep -rn "@router\.\(get\|post\|put\|delete\|patch\)" --include="*.py" | head -20
+grep -rn "@click.command\|@app.command\|add_parser" --include="*.py" | head -20
 ```
 
 **Node.js (Express/Fastify):**
@@ -59,11 +100,14 @@ grep -rn "createBrowserRouter\|<Route\|path=" --include="*.tsx" --include="*.jsx
 **Go (net/http, gin, chi):**
 ```bash
 grep -rn "http.HandleFunc\|r.GET\|r.POST\|router.Get\|router.Post" --include="*.go" | head -20
+grep -rn "cobra.Command\|AddCommand" --include="*.go" | head -20
 ```
 
 Build a map of:
+- CLI subcommands: name + args + description + file:line
 - API endpoints: method + path + file:line
 - UI routes: path + component + file:line
+- Database migrations: filename + tables affected
 
 ### Port Discovery
 
@@ -85,6 +129,11 @@ For each changed file, determine if it affects user-facing functionality:
 ### Import Chain Analysis by Ecosystem
 
 ```bash
+# Rust — use/mod/crate references
+grep -rn "use.*<crate>\|mod <module>" --include="*.rs"
+# Also check Cargo.toml dependencies between workspace crates
+grep -rn "<crate-name>" --include="Cargo.toml"
+
 # Python
 grep -rn "from.*<module>\|import.*<module>" --include="*.py"
 

--- a/plugins/beagle-testing/skills/gen-test-plan/references/test-case-generation.md
+++ b/plugins/beagle-testing/skills/gen-test-plan/references/test-case-generation.md
@@ -2,14 +2,73 @@
 
 This reference keeps the long test-template examples and prioritization guidance out of `SKILL.md`.
 
+## Critical: E2E Only
+
+Every test case must exercise the **real built artifact** — the actual binary, server, or UI — exactly as a human QA tester would. A test case that invokes the project's automated test runner (`cargo test`, `pytest`, `npm test`, `go test`, `mix test`, etc.) is **never valid**. Those tests already run in CI. The purpose of this plan is to verify behavior that automated tests cannot: real end-to-end workflows through the actual user interface (CLI, HTTP, browser).
+
 ## Step 5: Generate Test Cases
 
 Before generating test cases, answer: "What does this change do for the end user?"
 
+Then ask: "How would a human tester — who has never seen the code — verify this works?"
+
 Generate tests in this order:
 
-1. Core functionality tests first - exercise the primary behavioral change through a user-facing entry point.
+1. Core functionality tests first - exercise the primary behavioral change through the actual user-facing interface.
 2. Configuration/admin tests second - support the feature but do not replace the core test.
+
+### CLI Applications (shell tests)
+
+```yaml
+- id: TC-XX
+  name: <Describe what user action this represents>
+  context: |
+    <Which files changed and why this subcommand is affected>
+  steps:
+    # Build the binary first (or reference it from setup.build)
+    - run: <invoke the CLI binary with real arguments>
+    - run: <verify the effect — check stdout, query database, inspect files>
+  expected: |
+    <Exit code, stdout content, side effects (files created, DB rows, etc.)>
+```
+
+**CLI test examples by scenario:**
+
+```yaml
+# Subcommand that writes to a database
+- id: TC-01
+  name: "volant plan creates a workflow in PostgreSQL"
+  steps:
+    - run: ./target/debug/volant plan "Fix login bug" --description "Users can't log in" --sandbox local
+    - run: psql "${DATABASE_URL}" -c "SELECT id, state FROM workflows ORDER BY created_at DESC LIMIT 1"
+  expected: |
+    Exit code 0. A new workflow row exists with state 'pending' or further.
+
+# Subcommand that outputs to stdout
+- id: TC-02
+  name: "volant status lists workflows"
+  steps:
+    - run: ./target/debug/volant status --all
+  expected: |
+    Exit code 0. Outputs a table or list of workflows. Does not crash on empty database.
+
+# Subcommand with --dry-run
+- id: TC-03
+  name: "volant run --dry-run validates without executing"
+  steps:
+    - run: ./target/debug/volant run example.toml --dry-run
+  expected: |
+    Exit code 0. Prints the resolved workflow structure. Does not execute any nodes.
+
+# Error handling — missing config
+- id: TC-04
+  name: "volant plan errors gracefully without API key"
+  steps:
+    - run: env -u ANTHROPIC_API_KEY ./target/debug/volant plan "test" 2>&1 || true
+  expected: |
+    Non-zero exit code. Stderr contains a meaningful error about missing configuration,
+    not a panic or stack trace.
+```
 
 ### API Endpoints (curl tests)
 
@@ -26,7 +85,43 @@ Generate tests in this order:
         Content-Type: application/json
       body: <JSON body if needed>
   expected: |
-    <Natural language description of expected behavior>
+    <HTTP status code, response body shape, side effects>
+```
+
+### Database Verification
+
+```yaml
+- id: TC-XX
+  name: <Describe what data change this verifies>
+  context: |
+    <Which migration or data-writing code changed>
+  steps:
+    - run: <command that triggers the data write>
+    - run: psql "${DATABASE_URL}" -c "<SQL query to verify>"
+  expected: |
+    <Expected rows, column values, or schema state>
+```
+
+**Database test examples:**
+
+```yaml
+# Migration applies cleanly
+- id: TC-05
+  name: "Session tables migration creates expected schema"
+  steps:
+    - run: psql "${DATABASE_URL}" -c "\dt sessions"
+    - run: psql "${DATABASE_URL}" -c "\d sessions"
+  expected: |
+    The 'sessions' table exists with columns matching the migration definition.
+
+# Data roundtrip through the application
+- id: TC-06
+  name: "Checkpoint save and resume preserves workflow state"
+  steps:
+    - run: ./target/debug/volant plan "test checkpoint" --sandbox local
+    - run: psql "${DATABASE_URL}" -c "SELECT workflow_id, state FROM checkpoints ORDER BY created_at DESC LIMIT 1"
+  expected: |
+    A checkpoint row exists for the workflow with the expected state payload.
 ```
 
 ### UI Routes (agent-browser CLI tests)
@@ -52,18 +147,35 @@ Generate tests in this order:
     screenshot: docs/testing/evidence/tc-XX.png
 ```
 
+### Process Lifecycle (TUI / long-running)
+
+```yaml
+- id: TC-XX
+  name: <Describe the process behavior>
+  steps:
+    # Start the process in background, give it time to initialize, then verify
+    - run: timeout 5 ./target/debug/volant 2>&1 || true
+    - run: <verify it started correctly — check stderr output, temp files, etc.>
+  expected: |
+    Process starts without crash. Produces expected initial output.
+    Exits cleanly on timeout/interrupt.
+```
+
 ### Test Case Guidelines
 
-- At least one test per affected entry point
-- API tests for backend-only changes
-- Browser tests for UI changes - always use real CLI commands
-- Both when full-stack changes
-- Include authentication steps if endpoints are protected
+- **Never invoke the project's test runner** — every step must be a real user action
+- At least one test per affected user-facing entry point
+- CLI tests for command-line tools — invoke the binary directly
+- curl tests for HTTP servers
+- Browser tests for web UIs — always use real `agent-browser` CLI commands
+- Database tests when migrations or data-writing code changed
+- Include authentication/config steps if commands require credentials
+- Test error paths — missing config, bad input, unreachable services
 - Always snapshot before interacting and re-snapshot after navigation or DOM changes
 
 ## Step 6: Write YAML Test Plan
 
-Create `docs/testing/test-plan.yaml` with metadata, setup, health checks, and the generated tests.
+Create `docs/testing/test-plan.yaml` with metadata, setup, prerequisites, and the generated tests.
 
 ## Step 7: Report Summary
 
@@ -72,3 +184,5 @@ Report the generated file, detected stack, tests generated, entry-point coverage
 ## Step 8: Verification
 
 Verify the YAML file exists, parses successfully, and includes the required top-level keys.
+
+**Additional verification:** Grep every `run:` step for test runner commands (`cargo test`, `pytest`, `npm test`, `go test`, `mix test`, `jest`, `vitest`). If any are found, the plan fails — replace with real E2E actions.

--- a/plugins/beagle-testing/skills/run-test-plan/SKILL.md
+++ b/plugins/beagle-testing/skills/run-test-plan/SKILL.md
@@ -34,34 +34,50 @@ Extract from the YAML:
 - `setup.health_checks`: List of URLs to poll
 - `tests`: Array of test cases
 
-## Step 2: Run Setup Commands (unless --skip-setup)
+## Step 2: Run Setup (unless --skip-setup)
 
-Execute setup commands sequentially:
+### 2a. Check Prerequisites
+
+If `setup.prerequisites` exists, verify each one:
 
 ```bash
-# For each command in setup.commands
-<command> || { echo "Setup failed: <command>"; exit 1; }
+# For each prerequisite in setup.prerequisites
+<prerequisite.check> || { echo "Prerequisite not met: <prerequisite.name>"; exit 1; }
 ```
 
-For commands that start services (e.g., `pnpm run dev`, `docker-compose up -d`):
-- Run in background
-- Capture PID for cleanup
-- Continue to health checks
+### 2b. Set Environment Variables
+
+If `setup.env` exists, export each variable. Variables using `${VAR}` syntax should be resolved from the current environment:
 
 ```bash
-# Start dev servers in background
-nohup <dev_command> > .beagle/dev-server.log 2>&1 &
-echo $! > .beagle/dev-server.pid
+# For each key/value in setup.env
+export <key>="<value>"
 ```
 
-## Step 3: Run Health Checks
+### 2c. Build
 
-Poll each health check URL until healthy or timeout:
+If `setup.build` exists, execute build commands sequentially:
 
 ```bash
-# For each health_check
-timeout=<health_check.timeout or 30>
-url=<health_check.url>
+# For each command in setup.build
+<command> || { echo "Build failed: <command>"; exit 1; }
+```
+
+### 2d. Start Services
+
+If `setup.services` exists, start long-running processes and wait for health checks:
+
+```bash
+# For each service in setup.services
+nohup <service.command> > .beagle/service-<index>.log 2>&1 &
+echo $! > .beagle/service-<index>.pid
+```
+
+For each service with a `health_check`, poll until ready:
+
+```bash
+timeout=<service.health_check.timeout or 30>
+url=<service.health_check.url>
 elapsed=0
 
 while [ $elapsed -lt $timeout ]; do
@@ -79,6 +95,10 @@ if [ $elapsed -ge $timeout ]; then
 fi
 ```
 
+### 2e. Legacy Setup Format
+
+If the plan uses the older flat format (`setup.commands` + `setup.health_checks` instead of `prerequisites`/`build`/`services`), fall back to executing `setup.commands` sequentially and polling `setup.health_checks` as before.
+
 ## Step 4: Execute Tests Sequentially
 
 For each test in the plan:
@@ -93,9 +113,27 @@ Context: <test.context>
 
 ### 4b. Execute Steps
 
-For each step in `test.steps`:
+For each step in `test.steps`, determine the step type and execute accordingly:
 
-**curl actions:**
+**Shell commands (`run:` steps):**
+
+The most common step type. Execute the command via Bash and capture stdout, stderr, and exit code:
+
+```bash
+# Execute the command, capture output and exit code
+<command> 2>&1
+echo "EXIT_CODE: $?"
+```
+
+Capture all output for evaluation in step 4c. Shell steps cover:
+- CLI binary invocations (e.g., `./target/debug/myapp status --all`)
+- Database queries (e.g., `psql "${DATABASE_URL}" -c "SELECT ..."`)
+- File inspection (e.g., `ls -la /path/to/expected/output`)
+- Process lifecycle checks (e.g., `timeout 5 ./myapp 2>&1 || true`)
+- Any other command a human would type in a terminal
+
+**curl actions (`action: curl` steps):**
+
 ```bash
 curl -X <method> \
   -H "Content-Type: application/json" \
@@ -112,7 +150,7 @@ cat status_code.txt
 
 **agent-browser CLI actions:**
 
-Execute browser steps as `agent-browser` CLI commands via Bash. Each `run:` step in the test plan is a CLI command:
+Steps starting with `agent-browser` are browser automation commands:
 
 ```bash
 # Navigate
@@ -182,11 +220,13 @@ Stopping background services...
 
 Clean up:
 ```bash
-# Kill dev servers
-if [ -f .beagle/dev-server.pid ]; then
-  kill $(cat .beagle/dev-server.pid) 2>/dev/null
-  rm .beagle/dev-server.pid
-fi
+# Kill background services
+for pidfile in .beagle/service-*.pid .beagle/dev-server.pid; do
+  if [ -f "$pidfile" ]; then
+    kill $(cat "$pidfile") 2>/dev/null
+    rm "$pidfile"
+  fi
+done
 ```
 
 ## Step 6: On Failure - Generate Debug Prompt
@@ -284,11 +324,13 @@ EOF
 ### 6d. Cleanup and Exit
 
 ```bash
-# Kill dev servers
-if [ -f .beagle/dev-server.pid ]; then
-  kill $(cat .beagle/dev-server.pid) 2>/dev/null
-  rm .beagle/dev-server.pid
-fi
+# Kill background services
+for pidfile in .beagle/service-*.pid .beagle/dev-server.pid; do
+  if [ -f "$pidfile" ]; then
+    kill $(cat "$pidfile") 2>/dev/null
+    rm "$pidfile"
+  fi
+done
 ```
 
 ## Test Results Summary Table


### PR DESCRIPTION
## Summary
- Enforce E2E-only test plans — prohibit wrapping automated test suites (`cargo test`, `pytest`, `npm test`, etc.) as test steps
- Add Rust and Elixir stack detection, CLI application test patterns, and database verification templates
- Restructure setup format into `prerequisites`/`build`/`services`/`env` sections with legacy fallback in run-test-plan

## Test plan
- [ ] Install plugin locally and run `/beagle-testing:gen-test-plan` against a Rust CLI project — verify no `cargo test` steps appear
- [ ] Run against a Python web project — verify E2E curl tests generated, not `pytest` wrappers
- [ ] Run `/beagle-testing:run-test-plan` with a plan using the new setup format (prerequisites/build/services)
- [ ] Run `/beagle-testing:run-test-plan` with a plan using the legacy setup format (commands/health_checks) — verify fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)