### PR TITLE
chore(release): 2.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.9.0"
+    "version": "2.10.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-04-03
+
+### Added
+- **beagle-testing:** Enforce E2E-only test plans — prohibit wrapping automated test suites (cargo test, pytest, npm test) and require real user-facing actions ([#79](https://github.com/existential-birds/beagle/pull/79))
+- **beagle-testing:** Add Rust and Elixir stack detection, CLI/database test templates, and structured setup format ([#79](https://github.com/existential-birds/beagle/pull/79))
+
+### Changed
+- **beagle-testing:** `run-test-plan` updated to handle both new and legacy setup formats ([#79](https://github.com/existential-birds/beagle/pull/79))
+
 ## [2.9.0] - 2026-03-30
 
 ### Added

--- a/plugins/beagle-testing/.claude-plugin/plugin.json
+++ b/plugins/beagle-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-testing",
   "description": "Language-agnostic test plan generation and execution.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 2.10.0
- Update CHANGELOG.md with changes since v2.8.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 2.10.0
- [x] `plugins/beagle-testing/.claude-plugin/plugin.json` → 1.1.0

## Post-merge Steps

After merging, run:
```
/release-tag 2.10.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)