### PR TITLE
fix(beagle-core): allow receive-feedback skill to be invoked by other skills

### DIFF
--- a/plugins/beagle-core/skills/receive-feedback/SKILL.md
+++ b/plugins/beagle-core/skills/receive-feedback/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: receive-feedback
 description: Process external code review feedback with technical rigor. Use when receiving feedback from another LLM, human reviewer, or CI tool. Verifies claims before implementing, tracks disposition.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Receive Feedback


### PR DESCRIPTION
## Summary

Fixes `receive-feedback` skill having `disable-model-invocation: true`, which blocked the `fetch-pr-feedback` skill from invoking it via the Skill tool — producing the error: "Error: Skill beagle-core:receive-feedback cannot be used with Skill tool due to disable-model-invocation".

## Changes

### Fixed
- Changed `disable-model-invocation` from `true` to `false` on the `receive-feedback` skill so it can be programmatically invoked by `fetch-pr-feedback` (and any other composing skill)

## Motivation

`fetch-pr-feedback` step 5 calls `Skill(skill: "beagle-core:receive-feedback")` to process fetched PR comments. With `disable-model-invocation: true`, that call is blocked entirely — the skill description isn't even loaded into context. `receive-feedback` is a processing workflow, not a dangerous side-effect action, so there's no reason to restrict programmatic invocation.

## Testing

- [ ] Manual testing: invoke `/beagle-core:fetch-pr-feedback` on a PR with review comments and verify it no longer errors when calling receive-feedback

---

Generated with [Claude Code](https://claude.com/claude-code)