### PR TITLE
chore(release): 2.10.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.10.0"
+    "version": "2.10.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
+[2.10.1]: https://github.com/existential-birds/beagle/compare/v2.10.0...v2.10.1
+[2.10.0]: https://github.com/existential-birds/beagle/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/existential-birds/beagle/compare/v2.8.0...v2.9.0
 [2.8.0]: https://github.com/existential-birds/beagle/compare/v2.7.1...v2.8.0
 [2.7.0]: https://github.com/existential-birds/beagle/compare/v2.6.0...v2.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-04-04
+
+### Fixed
+- **beagle-core:** Allow `receive-feedback` skill to be invoked by other skills ([#81](https://github.com/existential-birds/beagle/pull/81))
+
 ## [2.10.0] - 2026-04-03
 
 ### Added

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 2.10.1
- Update CHANGELOG.md with changes since v2.10.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 2.10.1
- [x] `plugins/beagle-core/.claude-plugin/plugin.json` → 1.1.5

## Post-merge Steps

After merging, run:
```
/release-tag 2.10.1
```

---

Generated with [Claude Code](https://claude.com/claude-code)