### PR TITLE
chore(release): 2.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.10.1"
+    "version": "2.11.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-04-04
+
+### Added
+- **beagle-rust:** Add `rust-best-practices` skill for idiomatic Rust patterns, ownership guidelines, and error handling conventions ([#83](https://github.com/existential-birds/beagle/pull/83))
+- **beagle-rust:** Add `rust-project-setup` skill for project scaffolding, Cargo workspace configuration, and toolchain setup ([#83](https://github.com/existential-birds/beagle/pull/83))
+
 ## [2.10.1] - 2026-04-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,6 +319,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v2.11.0...HEAD
+[2.11.0]: https://github.com/existential-birds/beagle/compare/v2.10.1...v2.11.0
 [2.10.1]: https://github.com/existential-birds/beagle/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/existential-birds/beagle/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/existential-birds/beagle/compare/v2.8.0...v2.9.0

--- a/plugins/beagle-rust/.claude-plugin/plugin.json
+++ b/plugins/beagle-rust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-rust",
   "description": "Rust code review and development skills covering ownership, lifetimes, error handling, async/tokio, serde, sqlx, axum, and testing patterns.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 2.11.0
- Update CHANGELOG.md with changes since v2.10.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 2.11.0
- [x] `plugins/beagle-rust/.claude-plugin/plugin.json` → 1.1.0

## Post-merge Steps

After merging, run:
```
/release-tag 2.11.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)