### PR TITLE
chore(release): 2.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.11.0"
+    "version": "2.12.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-04-10
+
+### Added
+- **beagle-analysis:** Add `strategy-interview` skill for structured strategy interviews using kernel framework with landscape mapping, choice cascade, and value innovation lenses ([#85](https://github.com/existential-birds/beagle/pull/85))
+- **beagle-analysis:** Add `strategy-review` skill to pressure-test strategy documents for kernel integrity, bad-strategy patterns, coherence gaps, and untested assumptions ([#85](https://github.com/existential-birds/beagle/pull/85))
+
+### Changed
+- **beagle-docs:** Refactor `humanize` skill to use `references/` directory for vocabulary swaps, fix strategies, and developer voice guidelines ([#85](https://github.com/existential-birds/beagle/pull/85))
+- **beagle-docs:** Add 10 new humanize fix categories: em dash overuse, thematic breaks, title case headings, curly quotes, negative parallelism, challenges-and-prospects formula, rule of three, inline-header lists, unnecessary tables, regression to mean ([#85](https://github.com/existential-birds/beagle/pull/85))
+- Remove deprecated `beagle` plugin entry from marketplace manifest ([#85](https://github.com/existential-birds/beagle/pull/85))
+
 ## [2.11.0] - 2026-04-04
 
 ### Added

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge comparison.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-docs/.claude-plugin/plugin.json
+++ b/plugins/beagle-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-docs",
   "description": "Documentation quality, generation, and improvement using Diataxis principles. Pairs with beagle-core for full workflow.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 2.12.0
- Update CHANGELOG.md with changes since v2.11.0

### Added
- **beagle-analysis:** `strategy-interview` and `strategy-review` skills for structured strategy work
### Changed
- **beagle-docs:** Refactored `humanize` skill with references/ directory and 10 new fix categories
- Removed deprecated `beagle` plugin entry from marketplace manifest

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 2.12.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 1.2.0
- [x] `plugins/beagle-docs/.claude-plugin/plugin.json` → 1.2.0

## Post-merge Steps

After merging, run:
```
/release-tag 2.12.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)