### PR TITLE
docs(beagle-analysis): improve strategy skill discoverability

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -128,7 +128,9 @@
         "brainstorm",
         "adr",
         "llm-judge",
-        "strategy"
+        "strategy",
+        "strategic-planning",
+        "competitive-analysis"
       ]
     },
     {

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -15,6 +15,14 @@
     "llm-judge",
     "analysis",
     "strategy",
-    "strategic-planning"
+    "strategic-planning",
+    "wardley-mapping",
+    "blue-ocean",
+    "porter-five-forces",
+    "mckinsey-7s",
+    "balanced-scorecard",
+    "competitive-analysis",
+    "business-strategy",
+    "strategy-review"
   ]
 }

--- a/plugins/beagle-analysis/skills/strategy-interview/SKILL.md
+++ b/plugins/beagle-analysis/skills/strategy-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: strategy-interview
-description: "Use when developing or refining a strategy through guided conversation for a company, product, team, career, or initiative. Triggers on: strategic planning, building a strategy, where-to-play/how-to-win choices, competitive positioning, market mapping, value innovation, blue ocean, uncontested market space, diagnosing goals masquerading as strategy. For reviewing or critiquing an existing strategy document, use beagle-analysis:strategy-review instead."
+description: "Build strategies through guided conversation using the kernel framework (diagnosis, guiding policy, coherent action) with Wardley mapping, Playing to Win cascade, and Blue Ocean value innovation lenses. For companies, products, teams, careers, or initiatives. Detects bad-strategy patterns: fluff, goals masquerading as strategy, laundry-list objectives, strategy-by-analogy. Triggers on: strategic planning, business strategy, product strategy, competitive positioning, go-to-market strategy, market mapping, where-to-play/how-to-win, value innovation, blue ocean, uncontested market space."
 user-invocable: true
 ---
 

--- a/plugins/beagle-analysis/skills/strategy-review/SKILL.md
+++ b/plugins/beagle-analysis/skills/strategy-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: strategy-review
-description: "Review and pressure-test strategy documents for kernel integrity, bad-strategy patterns, coherence gaps, and untested assumptions. Use when the user asks to review, critique, evaluate, or stress-test a strategy document, strategy-draft.md, strategy-notes.md, strategic plan, or any document claiming to be a strategy. Also triggers on: 'is this strategy any good', 'what's weak in this strategy', 'poke holes in this', 'red team this strategy', 'second opinion on our strategy'. Complements the strategy-interview skill — use strategy-interview to build a strategy through conversation, use strategy-review to evaluate one that already exists."
+description: "Pressure-test strategy documents using seven evaluation dimensions with optional McKinsey 7S, Porter's Five Forces, Balanced Scorecard, and Hoshin Kanri lenses. Finds structural gaps, hidden failure paths, untested assumptions, and bad-strategy patterns. Use when reviewing, critiquing, auditing, or stress-testing any strategic plan. Triggers on: review strategy, evaluate strategy, strategy audit, red team this strategy, poke holes in this, what's weak in this strategy, second opinion on strategy."
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

Improves marketplace discoverability for the strategy-interview and strategy-review skills by front-loading searchable framework names and expanding keywords/tags.

## Changes

### Changed
- **strategy-interview SKILL.md** — description now leads with kernel framework, Wardley mapping, Playing to Win, and Blue Ocean lens names; adds broader trigger terms (business strategy, product strategy, go-to-market); removes routing note that wasted search-indexed space
- **strategy-review SKILL.md** — description now leads with seven evaluation dimensions and names McKinsey 7S, Porter's Five Forces, Balanced Scorecard, and Hoshin Kanri lenses; adds "strategy audit" and evaluation trigger terms; removes routing note
- **plugin.json** — keywords expanded from 8 to 16, adding framework names (`wardley-mapping`, `blue-ocean`, `porter-five-forces`, `mckinsey-7s`, `balanced-scorecard`) and use-case terms (`competitive-analysis`, `business-strategy`, `strategy-review`)
- **marketplace.json** — beagle-analysis tags expanded with `strategic-planning` and `competitive-analysis`

## Motivation

The strategy skills were recently added but their descriptions were optimized for Claude Code's auto-trigger system rather than marketplace search. Framework names — the strongest differentiators — were buried in skill body text instead of the indexed description and keyword fields. This makes the skills harder to find on sites like ClaHub and skills.sh where users search by methodology name.

## Testing

- [x] Verified all four files parse correctly after edits
- [x] YAML frontmatter structure preserved in both SKILL.md files
- [x] JSON validity preserved in plugin.json and marketplace.json

---

Generated with [Claude Code](https://claude.com/claude-code)