### PR TITLE
chore(release): 2.12.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.12.0"
+    "version": "2.12.1"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [2.12.1] - 2026-04-10
+
+### Changed
+- **beagle-analysis:** Improve strategy skill discoverability with expanded marketplace tags and refined trigger phrases ([#88](https://github.com/existential-birds/beagle/pull/88))
+
 ## [2.12.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,7 +335,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v2.11.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v2.12.1...HEAD
+[2.12.1]: https://github.com/existential-birds/beagle/compare/v2.12.0...v2.12.1
+[2.12.0]: https://github.com/existential-birds/beagle/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/existential-birds/beagle/compare/v2.10.1...v2.11.0
 [2.10.1]: https://github.com/existential-birds/beagle/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/existential-birds/beagle/compare/v2.9.0...v2.10.0

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge comparison.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 2.12.1
- Update CHANGELOG.md with changes since v2.12.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 2.12.1
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 1.2.1

## Post-merge Steps

After merging, run:
```
/release-tag 2.12.1
```

---

Generated with [Claude Code](https://claude.com/claude-code)