### PR TITLE
chore(release): 3.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "2.12.1"
+    "version": "3.0.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,7 +348,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v2.12.1...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/existential-birds/beagle/compare/v2.12.1...v3.0.0
 [2.12.1]: https://github.com/existential-birds/beagle/compare/v2.12.0...v2.12.1
 [2.12.0]: https://github.com/existential-birds/beagle/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/existential-birds/beagle/compare/v2.10.1...v2.11.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-04-11
+
+### Removed
+- **beagle-analysis:** Remove deprecated `12-factor-apps` and `12-factor-apps-analysis` skills, superseded by `agent-architecture-analysis` ([#90](https://github.com/existential-birds/beagle/pull/90))
+
+### Changed
+- **BREAKING:** Rename `brainstorm` skill to `brainstorm-beagle` to resolve ClawHub slug conflict ([#90](https://github.com/existential-birds/beagle/pull/90))
+- **BREAKING:** Rename `humanize` skill to `humanize-beagle` to resolve ClawHub slug conflict ([#90](https://github.com/existential-birds/beagle/pull/90))
+- **beagle-analysis:** Optimize skill descriptions for improved triggering accuracy ([#90](https://github.com/existential-birds/beagle/pull/90))
+
+### Fixed
+- **beagle-analysis:** Remove stale reference to deleted `12-factor-apps` skill in `agent-architecture-analysis` description ([#90](https://github.com/existential-birds/beagle/pull/90))
+
 ## [2.12.1] - 2026-04-10
 
 ### Changed

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge comparison.",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-docs/.claude-plugin/plugin.json
+++ b/plugins/beagle-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-docs",
   "description": "Documentation quality, generation, and improvement using Diataxis principles. Pairs with beagle-core for full workflow.",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 3.0.0
- Update CHANGELOG.md with changes since v2.12.1

## Breaking Changes

- `brainstorm` skill renamed to `brainstorm-beagle` (ClawHub slug conflict)
- `humanize` skill renamed to `humanize-beagle` (ClawHub slug conflict)
- `12-factor-apps` and `12-factor-apps-analysis` skills removed (use `agent-architecture-analysis`)

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 3.0.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.0.0
- [x] `plugins/beagle-docs/.claude-plugin/plugin.json` → 2.0.0

## Post-merge Steps

After merging, run:
```
/release-tag 3.0.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)