### PR TITLE
chore(release): 3.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "3.1.0"
+    "version": "3.2.0"
   },
   "plugins": [
     {

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -96,6 +96,29 @@ Run `/beagle:gen-release-notes ${PREV_TAG}` to:
 
 **Do not proceed** until CHANGELOG.md is updated with the new version.
 
+### Step 3.5: Verify CHANGELOG footer reference links
+
+Every prior release PR has been flagged by CodeRabbit for missing footer compare links. This step is the gate that prevents that recurring feedback. After `gen-release-notes` runs, confirm the footer at the bottom of `CHANGELOG.md` contains both:
+
+1. An updated `[Unreleased]` line pointing at the **new** version (not the previous one).
+2. A new `[NEW_VERSION]` line comparing the previous tag to the new tag.
+
+```bash
+NEW_VERSION=$(grep -E '^\#\# \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed 's/.*\[\(.*\)\].*/\1/')
+echo "Verifying footer links for v${NEW_VERSION}..."
+
+# Both checks must pass before proceeding.
+grep -qE "^\[Unreleased\]: .*compare/v${NEW_VERSION}\.\.\.HEAD" CHANGELOG.md \
+  || { echo "MISSING: [Unreleased] is not pointing at v${NEW_VERSION}"; exit 1; }
+
+grep -qE "^\[${NEW_VERSION}\]: .*compare/v.*\.\.\.v${NEW_VERSION}" CHANGELOG.md \
+  || { echo "MISSING: [${NEW_VERSION}] footer line not found"; exit 1; }
+
+echo "Footer links verified."
+```
+
+If either check fails, edit `CHANGELOG.md` to add the missing lines using the format documented in `gen-release-notes` Step 5 item 3, then re-run the checks. **Do not proceed to Step 4 until both checks pass.**
+
 ## Step 4: Update Versions
 
 After determining the new version from the changelog analysis:

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -107,11 +107,14 @@ Every prior release PR has been flagged by CodeRabbit for missing footer compare
 NEW_VERSION=$(grep -E '^\#\# \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | head -1 | sed 's/.*\[\(.*\)\].*/\1/')
 echo "Verifying footer links for v${NEW_VERSION}..."
 
+# Escape dots so they match literally in the ERE patterns below.
+NEW_VERSION_RE=${NEW_VERSION//./\\.}
+
 # Both checks must pass before proceeding.
-grep -qE "^\[Unreleased\]: .*compare/v${NEW_VERSION}\.\.\.HEAD" CHANGELOG.md \
+grep -qE "^\[Unreleased\]: .*compare/v${NEW_VERSION_RE}\.\.\.HEAD" CHANGELOG.md \
   || { echo "MISSING: [Unreleased] is not pointing at v${NEW_VERSION}"; exit 1; }
 
-grep -qE "^\[${NEW_VERSION}\]: .*compare/v.*\.\.\.v${NEW_VERSION}" CHANGELOG.md \
+grep -qE "^\[${NEW_VERSION_RE}\]: .*compare/v.*\.\.\.v${NEW_VERSION_RE}" CHANGELOG.md \
   || { echo "MISSING: [${NEW_VERSION}] footer line not found"; exit 1; }
 
 echo "Footer links verified."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [3.2.0] - 2026-04-18
+
+### Added
+- **beagle-analysis:** Add `resolve-beagle` skill — follow-up to `brainstorm-beagle` that orchestrates parallel research subagents (with sequential inline fallback) to close Open Questions and latent gaps in a spec, presents proposals one at a time for approval, and rewrites the spec in place ([#94](https://github.com/existential-birds/beagle/pull/94))
+
 ## [3.1.0] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 ### Added
 - **beagle-analysis:** Add `resolve-beagle` skill — follow-up to `brainstorm-beagle` that orchestrates parallel research subagents (with sequential inline fallback) to close Open Questions and latent gaps in a spec, presents proposals one at a time for approval, and rewrites the spec in place ([#94](https://github.com/existential-birds/beagle/pull/94))
 
+### Fixed
+- **beagle-core:** Make `gen-release-notes` Step 5 explicit about updating `[Unreleased]` and inserting the new `[VERSION]` footer compare links, with an example diff and a verification grep — prevents the recurring CodeRabbit feedback that release PRs were missing footer reference links ([#95](https://github.com/existential-birds/beagle/pull/95))
+- **release command:** Add Step 3.5 verification gate that fails the release flow if CHANGELOG footer compare links for the new version are missing ([#95](https://github.com/existential-birds/beagle/pull/95))
+
 ## [3.1.0] - 2026-04-11
 
 ### Added
@@ -365,7 +369,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.1.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/existential-birds/beagle/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/existential-birds/beagle/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/existential-birds/beagle/compare/v2.12.1...v3.0.0
 [2.12.1]: https://github.com/existential-birds/beagle/compare/v2.12.0...v2.12.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 11 focused plugins with 126 skills.
+Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 11 focused plugins with 127 skills.
 
 ## Marketplace Architecture
 
@@ -22,7 +22,7 @@ beagle/
     ├── beagle-rust/            # Rust, tokio, axum, sqlx, serde (10 skills)
     ├── beagle-ai/               # Pydantic AI, LangGraph, DeepAgents, Vercel AI SDK (13 skills)
     ├── beagle-docs/             # Documentation quality, AI writing detection (10 skills)
-    ├── beagle-analysis/         # Brainstorming, 12-Factor, ADRs, strategy, LLM-as-judge (10 skills)
+    ├── beagle-analysis/         # Brainstorming, ADRs, strategy, LLM-as-judge, spec resolution (11 skills)
     └── beagle-testing/          # Test plan generation and execution (2 skills)
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *Image: NASA, Public Domain. [Source](https://www.nasa.gov/multimedia/imagegallery/image_feature_572.html)*
 
-Beagle is a Claude Code plugin marketplace with 126 skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, iOS/Swift, and AI frameworks.
+Beagle is a Claude Code plugin marketplace with 127 skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, iOS/Swift, and AI frameworks.
 
 Used with [Amelia](https://github.com/existential-birds/amelia) for agent-based workflows and [Daydream](https://github.com/existential-birds/daydream) for automated review-fix-test loops.
 
@@ -62,9 +62,9 @@ This downloads the skills and configures them for your agent.
 | **beagle-rust** | 10 | Rust, tokio, axum, sqlx, serde |
 | **beagle-ai** | 13 | Pydantic AI, LangGraph, DeepAgents |
 | **beagle-docs** | 10 | Documentation quality, AI writing detection (Diataxis) |
-| **beagle-analysis** | 10 | Brainstorming, 12-Factor, ADRs, strategy, LLM-as-judge |
+| **beagle-analysis** | 11 | Brainstorming, ADRs, strategy, LLM-as-judge, spec gap resolution |
 | **beagle-testing** | 2 | Test plan generation and execution |
-| **Total** | **126** | — |
+| **Total** | **127** | — |
 
 ## Skills
 
@@ -109,6 +109,8 @@ These are the canonical skill entry points for Beagle.
 | `humanize-beagle` | beagle-docs | Fix AI writing with safe/risky classification |
 | `llm-judge` | beagle-analysis | Compare implementations |
 | `write-adr` | beagle-analysis | Generate ADRs from decisions |
+| `brainstorm-beagle` | beagle-analysis | Turn fuzzy ideas into structured project specs |
+| `resolve-beagle` | beagle-analysis | Close Open Questions and latent gaps in a brainstorm-beagle spec |
 | `strategy-interview` | beagle-analysis | Build strategy through guided conversation |
 | `strategy-review` | beagle-analysis | Pressure-test existing strategy documents |
 

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
-  "description": "Architecture analysis, brainstorming, 12-Factor compliance, ADR generation, and LLM-as-judge comparison.",
-  "version": "2.0.0",
+  "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
+  "version": "2.1.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"
@@ -11,6 +11,7 @@
     "12-factor",
     "architecture",
     "brainstorm-beagle",
+    "resolve-beagle",
     "adr",
     "llm-judge",
     "analysis",

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-core/skills/gen-release-notes/SKILL.md
+++ b/plugins/beagle-core/skills/gen-release-notes/SKILL.md
@@ -175,7 +175,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ```
 
-3. Add version comparison links at the bottom of the file using the detected repo URL.
+3. **Update the footer reference links at the bottom of the file.** This step is mandatory — CodeRabbit and other reviewers will flag the changelog as incomplete if these are missing. Two edits are required:
+
+   a. **Advance `[Unreleased]`** so it compares against the new version instead of the previous one.
+   b. **Insert a new `[NEW_VERSION]` line** right below `[Unreleased]`, comparing the previous tag to the new one.
+
+   Example diff (releasing `3.2.0` after `3.1.0`):
+
+   ```diff
+   -[Unreleased]: https://github.com/OWNER/REPO/compare/v3.1.0...HEAD
+   +[Unreleased]: https://github.com/OWNER/REPO/compare/v3.2.0...HEAD
+   +[3.2.0]: https://github.com/OWNER/REPO/compare/v3.1.0...v3.2.0
+    [3.1.0]: https://github.com/OWNER/REPO/compare/v3.0.0...v3.1.0
+   ```
+
+   After editing, verify with: `grep -E '^\[(Unreleased|NEW_VERSION)\]:' CHANGELOG.md` — both lines must be present and `[Unreleased]` must point at the new tag, not the old one.
 
 ## Step 6: Output Summary
 


### PR DESCRIPTION
## Summary

- Bump version to 3.2.0
- Update CHANGELOG.md with changes since v3.1.0
- Update README.md and CLAUDE.md with new skill count (126 → 127), beagle-analysis skill count (10 → 11), and add `brainstorm-beagle` + `resolve-beagle` to the Documentation & Analysis skills table

## Changes Since v3.1.0

- **beagle-analysis:** Added `resolve-beagle` skill — orchestrator that closes Open Questions and latent gaps in a `brainstorm-beagle` spec via parallel research subagents (#94)

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 3.2.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.1.0 (also added `resolve-beagle` keyword and refreshed description)

## Post-merge Steps

After merging, run:
```
/release-tag 3.2.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)