### PR TITLE
chore(release): 3.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "3.3.0"
+    "version": "3.4.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-05-02
+
+### Added
+- **beagle-core:** Add `verify-llm-artifacts` skill — second-pass adjudication of `review-llm-artifacts` JSON that classifies each finding as confirmed, false positive, or inconclusive before deletes happen, and carries the original `fix_action` field through to `fix-llm-artifacts` unchanged. Includes a verification checklist with mechanical detection rules (e.g. monorepo trigger fires when `[workspace]`, `workspaces`, `pnpm-workspace.yaml`, `lerna.json`, or `turbo.json` is present) instead of judgment-call prose ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-core:** Add `--all` flag to `review-llm-artifacts` for opt-in full-project scans; default remains files changed since merge-base with `main` ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-core:** Extend `review-llm-artifacts` JSON schema with `scope` and `target` fields so downstream skills can reproduce the original invocation ([#98](https://github.com/existential-birds/beagle/pull/98))
+
+### Changed
+- **all plugins:** Roll out rule→gate sequencing across every `SKILL.md` in the marketplace (130+ files). Soft rules become sequenced Gates with objective pass conditions backed by evidence on disk or in tool output, and each gate blocks the next step until its condition is met. Background: <https://blog.fsck.com/2026/04/07/rules-and-gates/> ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-core:** `fix-llm-artifacts` now reads `scope` and `target` from the stale review JSON and re-invokes `review-llm-artifacts` with the original arguments (preserving `--all` or narrowed paths) instead of falling back to the default scope. Pre-schema review JSON without those fields falls back to a full-project re-run with a cancellable warning ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-core:** `review-llm-artifacts` full scan replaces `find ! -path` filters with `-type d ... -prune` so `node_modules`, `.git`, `target`, `build`, etc. are never descended into — prevents minutes-long hangs on large repos ([#98](https://github.com/existential-birds/beagle/pull/98))
+
+### Fixed
+- **beagle-core:** `fetch-pr-feedback` no longer drops sections after the first `---` separator. The `clean_body` jq filter previously stripped everything from `\n---\n` to EOF to remove bot footer boilerplate, silently dropping real findings from claude[bot] and human reviewers who use `---` as a section separator. Replaced with a marker-guarded version that only removes a trailing `---` block when it begins with a known bot-footer signature ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-core:** `review-llm-artifacts --since-main` resolves `main`/`origin/main`/`master`/`origin/master` explicitly and exits non-zero when none exist, instead of wrapping `git merge-base` in `|| true` and silently reporting "no files to scan" in repos without a local main ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-testing:** `gen-test-plan` Gate 3 swaps `grep -E` alternation (passed if any one key matched) for a python YAML parse plus explicit four-key presence check, so plans missing `metadata`, `setup`, or `tests` can no longer slip through. Also parameterizes `BASE_BRANCH` so Gate 1 evidence matches commands for non-main bases ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-testing:** `run-test-plan` Step 1 parameterizes `PLAN_PATH` so `--plan` works before Step 3's gate runs ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-docs:** `improve-doc` Gate replaces spot-check with full block equality so mid-section edits in `skip` sections cannot pass unnoticed ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-elixir, beagle-ios, beagle-python, beagle-go:** Require canonical `[FILE:LINE] ISSUE_TITLE` header on review evidence gates (`elixir-docs-review`, `swiftdata-code-review`, `swiftui-code-review`, `python-code-review`, `wish-ssh-code-review`); symbols and snippets supplement but cannot replace the anchor ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-ai:** `deepagents-code-review` SKILL.md trimmed back under the 500-line cap (509 → 476) by extracting the Code Review Checklist to `references/checklist.md` ([#98](https://github.com/existential-birds/beagle/pull/98))
+- **beagle-rust:** `ffi-code-review` resolves an "at minimum Gate 4" / "in order" contradiction by requiring Gates 1–4 in order ([#98](https://github.com/existential-birds/beagle/pull/98))
+
 ## [3.3.0] - 2026-04-18
 
 ### Added
@@ -379,7 +401,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.3.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.4.0...HEAD
+[3.4.0]: https://github.com/existential-birds/beagle/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/existential-birds/beagle/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/existential-birds/beagle/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/existential-birds/beagle/compare/v3.0.0...v3.1.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *Image: NASA, Public Domain. [Source](https://www.nasa.gov/multimedia/imagegallery/image_feature_572.html)*
 
-Beagle is a Claude Code plugin marketplace with 127 skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, iOS/Swift, and AI frameworks.
+Beagle is a Claude Code plugin marketplace with 131 skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, iOS/Swift, and AI frameworks.
 
 Used with [Amelia](https://github.com/existential-birds/amelia) for agent-based workflows and [Daydream](https://github.com/existential-birds/daydream) for automated review-fix-test loops.
 
@@ -53,18 +53,18 @@ This downloads the skills and configures them for your agent.
 
 | Plugin | Skills | Category |
 |--------|--------|----------|
-| **beagle-core** | 18 | Shared workflows, verification, git |
+| **beagle-core** | 19 | Shared workflows, verification, git |
 | **beagle-python** | 7 | Python, FastAPI, SQLAlchemy, pytest |
 | **beagle-go** | 13 | Go, BubbleTea, Wish SSH, Prometheus |
 | **beagle-elixir** | 11 | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
 | **beagle-ios** | 16 | Swift, SwiftUI, SwiftData, iOS frameworks |
 | **beagle-react** | 16 | React, React Flow, shadcn/ui, Tailwind |
-| **beagle-rust** | 10 | Rust, tokio, axum, sqlx, serde |
+| **beagle-rust** | 12 | Rust, tokio, axum, sqlx, serde |
 | **beagle-ai** | 13 | Pydantic AI, LangGraph, DeepAgents |
 | **beagle-docs** | 10 | Documentation quality, AI writing detection (Diataxis) |
-| **beagle-analysis** | 11 | Brainstorming, ADRs, strategy, LLM-as-judge, spec gap resolution |
+| **beagle-analysis** | 12 | Brainstorming, ADRs, strategy, LLM-as-judge, spec gap resolution |
 | **beagle-testing** | 2 | Test plan generation and execution |
-| **Total** | **127** | — |
+| **Total** | **131** | — |
 
 ## Skills
 
@@ -76,6 +76,7 @@ These are the canonical skill entry points for Beagle.
 |---------|-------------|
 | `review-plan <path>` | Review implementation plans |
 | `review-llm-artifacts` | Detect LLM coding artifacts |
+| `verify-llm-artifacts` | Confirm or reject review findings before deletes |
 | `fix-llm-artifacts` | Fix detected artifacts |
 | `commit-push` | Commit and push changes |
 | `create-pr` | Create PR with template |

--- a/plugins/beagle-ai/.claude-plugin/plugin.json
+++ b/plugins/beagle-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-ai",
   "description": "Pydantic AI, LangGraph, DeepAgents, and Vercel AI SDK skills for building and reviewing AI applications.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-docs/.claude-plugin/plugin.json
+++ b/plugins/beagle-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-docs",
   "description": "Documentation quality, generation, and improvement using Diataxis principles. Pairs with beagle-core for full workflow.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-elixir/.claude-plugin/plugin.json
+++ b/plugins/beagle-elixir/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-elixir",
   "description": "Elixir, Phoenix, and LiveView code review and documentation skills",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-go/.claude-plugin/plugin.json
+++ b/plugins/beagle-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-go",
   "description": "Go code review and development skills covering architecture, middleware, data persistence, concurrency, and framework-specific patterns for BubbleTea, Wish SSH, and Prometheus.",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-ios/.claude-plugin/plugin.json
+++ b/plugins/beagle-ios/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-ios",
   "description": "Swift, SwiftUI, SwiftData, iOS animation design/implementation/review, and framework code review (HealthKit, CloudKit, WidgetKit, watchOS, App Intents). Pairs with beagle-core for full workflow.",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-python/.claude-plugin/plugin.json
+++ b/plugins/beagle-python/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-python",
   "description": "Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review. Pairs with beagle-core for full workflow.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-react/.claude-plugin/plugin.json
+++ b/plugins/beagle-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-react",
   "description": "React, React Flow, React Router, shadcn/ui, Tailwind v4, Vitest, and Zustand code review. Pairs with beagle-core for full workflow.",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-rust/.claude-plugin/plugin.json
+++ b/plugins/beagle-rust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-rust",
   "description": "Rust code review and development skills covering ownership, lifetimes, error handling, async/tokio, serde, sqlx, axum, macros, FFI, unsafe, concurrency, and testing patterns.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-testing/.claude-plugin/plugin.json
+++ b/plugins/beagle-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-testing",
   "description": "Language-agnostic test plan generation and execution.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 3.4.0
- Update CHANGELOG.md with changes since v3.3.0

## Highlights

- **New skill:** `beagle-core:verify-llm-artifacts` — second-pass adjudication of review findings (confirmed / false positive / inconclusive) before deletes happen
- **Cross-marketplace refactor:** rule→gate sequencing rolled out across all 130+ `SKILL.md` files. Soft rules become sequenced Gates with objective pass conditions; each gate blocks the next step until its evidence-on-disk pass condition is met
- **`fetch-pr-feedback` fix:** stop dropping review sections that follow `---` separators (claude[bot] / human reviewers)
- **`review-llm-artifacts` perf:** `find -type d ... -prune` instead of `! -path` filters; never descends into `node_modules`/`.git`/`target`/`build`
- **`gen-test-plan` Gate 3:** explicit YAML key-presence check instead of `grep -E` alternation that passed on any one match

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 3.4.0
- [x] `plugins/beagle-ai/plugin.json` → 1.1.0
- [x] `plugins/beagle-analysis/plugin.json` → 2.3.0
- [x] `plugins/beagle-core/plugin.json` → 1.2.0
- [x] `plugins/beagle-docs/plugin.json` → 2.1.0
- [x] `plugins/beagle-elixir/plugin.json` → 1.3.0
- [x] `plugins/beagle-go/plugin.json` → 2.4.0
- [x] `plugins/beagle-ios/plugin.json` → 1.3.0
- [x] `plugins/beagle-python/plugin.json` → 1.2.0
- [x] `plugins/beagle-react/plugin.json` → 1.2.0
- [x] `plugins/beagle-rust/plugin.json` → 1.4.0
- [x] `plugins/beagle-testing/plugin.json` → 1.2.0

## Post-merge Steps

After merging, run:

```
/release-tag 3.4.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)