### PR TITLE
chore(release): 3.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "3.4.0"
+    "version": "3.5.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-05-03
+
 ### Added
 - **beagle-analysis:** Extend `strategy-review` judge artifact schema to v1.1 — adds optional `strengths`, `recommended_next_steps`, `review_id`, and `notes_cross_reference` fields. Backward compatible: `schema_version` stays `"1.0"` ([#86](https://github.com/existential-birds/beagle/issues/86))
 - **beagle-analysis:** Add two `strategy-review` pressure-test scenarios — happy-path (all Strong) and durable-state + judge-mode interaction ([#86](https://github.com/existential-birds/beagle/issues/86))
@@ -405,7 +407,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.4.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.5.0...HEAD
+[3.5.0]: https://github.com/existential-birds/beagle/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/existential-birds/beagle/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/existential-birds/beagle/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/existential-birds/beagle/compare/v3.1.0...v3.2.0

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 3.5.0
- Update CHANGELOG.md with changes since v3.4.0

## Changes Included

- **beagle-analysis:** Extend `strategy-review` judge artifact schema to v1.1 — adds optional `strengths`, `recommended_next_steps`, `review_id`, and `notes_cross_reference` fields. Backward compatible: `schema_version` stays `"1.0"` (#86)
- **beagle-analysis:** Add two `strategy-review` pressure-test scenarios — happy-path (all Strong) and durable-state + judge-mode interaction (#86)

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 3.5.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.4.0

## Post-merge Steps

After merging, run:

```
/release-tag 3.5.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)