### PR TITLE
feat(beagle-remix-v2): add plugin for Remix v2 code review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -92,6 +92,21 @@
       ]
     },
     {
+      "name": "beagle-remix-v2",
+      "source": "./plugins/beagle-remix-v2",
+      "description": "Remix v2 (route modules + React Router v6) code review and best-practice skills",
+      "category": "frontend",
+      "tags": [
+        "remix",
+        "remix-v2",
+        "react-router",
+        "react-router-v6",
+        "loaders",
+        "actions",
+        "code-review"
+      ]
+    },
+    {
       "name": "beagle-ai",
       "source": "./plugins/beagle-ai",
       "description": "Pydantic AI, LangGraph, DeepAgents, and Vercel AI SDK skills",

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -7,7 +7,7 @@ repo=/path/to/beagle
 dest="$HOME/.agents/skills"
 mkdir -p "$dest"
 
-for plugin in beagle-ai beagle-analysis beagle-core beagle-docs beagle-elixir beagle-go beagle-ios beagle-python beagle-react beagle-rust beagle-testing; do
+for plugin in beagle-ai beagle-analysis beagle-core beagle-docs beagle-elixir beagle-go beagle-ios beagle-python beagle-react beagle-remix-v2 beagle-rust beagle-testing; do
   ln -sfn "$repo/plugins/$plugin/skills" "$dest/$plugin"
 done
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,26 @@ This file provides guidance to Codex when working with code in this repository.
 
 ## What This Is
 
-Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 11 focused plugins with 122 skills.
+Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 12 focused plugins with 143 skills.
 
 ## Marketplace Architecture
 
 ```text
 beagle/
 ├── .claude-plugin/
-│   └── marketplace.json         # Marketplace manifest (11 plugins)
+│   └── marketplace.json         # Marketplace manifest (12 plugins)
 └── plugins/
-    ├── beagle-core/             # Shared workflows, verification, git workflows (18 skills)
+    ├── beagle-core/             # Shared workflows, verification, git workflows (19 skills)
     ├── beagle-python/           # Python, FastAPI, SQLAlchemy, PostgreSQL, pytest (7 skills)
     ├── beagle-go/               # Go, BubbleTea, Wish SSH, Prometheus (13 skills)
     ├── beagle-elixir/           # Elixir, Phoenix, LiveView, ExUnit, ExDoc (11 skills)
     ├── beagle-ios/              # Swift, SwiftUI, SwiftData, iOS frameworks (16 skills)
     ├── beagle-react/            # React, React Flow, shadcn/ui, Tailwind, Vitest (16 skills)
-    ├── beagle-rust/             # Rust, tokio, axum, sqlx, serde (8 skills)
+    ├── beagle-remix-v2/         # Remix v2 routing, loaders/actions, forms, sessions, perf/SSR (12 skills)
+    ├── beagle-rust/             # Rust, tokio, axum, sqlx, serde (12 skills)
     ├── beagle-ai/               # Pydantic AI, LangGraph, DeepAgents, Vercel AI SDK (13 skills)
     ├── beagle-docs/             # Documentation quality, AI writing detection (10 skills)
-    ├── beagle-analysis/         # Brainstorming, 12-Factor, ADRs, LLM-as-judge (8 skills)
+    ├── beagle-analysis/         # Brainstorming, ADRs, strategy, LLM-as-judge, spec resolution, PRFAQ filter (12 skills)
     └── beagle-testing/          # Test plan generation and execution (2 skills)
 ```
 
@@ -71,6 +72,8 @@ Beagle-specific:
 | beagle-go | `review-tui` | BubbleTea TUI code review with Elm architecture focus |
 | beagle-ios | `review-ios` | iOS/SwiftUI code review |
 | beagle-elixir | `review-elixir` | Elixir/Phoenix/LiveView code review |
+| beagle-rust | `review-rust` | Rust/tokio/axum/sqlx/serde code review |
+| beagle-remix-v2 | `review-remix-v2` | Remix v2 code review (loaders, actions, forms, sessions, perf/SSR) |
 | beagle-core | `review-plan` | Review implementation plans before execution |
 | beagle-core | `commit-push` | Commit with Conventional Commits format |
 | beagle-core | `create-pr` | Create PR with structured template |
@@ -80,10 +83,18 @@ Beagle-specific:
 | beagle-core | `fetch-pr-feedback` | Fetch and evaluate bot review comments from PR |
 | beagle-core | `respond-pr-feedback` | Post replies to bot review comments |
 | beagle-core | `review-llm-artifacts` | Detect LLM coding artifacts |
+| beagle-core | `verify-llm-artifacts` | Adjudicate review findings (confirm/false-positive/inconclusive) before deletes |
 | beagle-core | `fix-llm-artifacts` | Fix detected artifacts |
 | beagle-core | `prompt-improver` | Optimize prompts |
 | beagle-analysis | `llm-judge` | Compare implementations using LLM-as-judge |
 | beagle-analysis | `write-adr` | Generate ADRs from decisions |
+| beagle-analysis | `brainstorm-beagle` | Turn fuzzy ideas into structured project specs |
+| beagle-analysis | `resolve-beagle` | Close Open Questions and latent gaps in a brainstorm-beagle spec |
+| beagle-analysis | `strategy-interview` | Build strategy through guided conversation |
+| beagle-analysis | `strategy-review` | Pressure-test existing strategy documents |
+| beagle-analysis | `prfaq-beagle` | Working Backwards PRFAQ filter — pass/fail concepts before brainstorming |
+| beagle-analysis | `web-research` | Parallel web-search research with cited synthesis report |
+| beagle-analysis | `artifact-analysis` | Parallel-subagent scan of local docs with cited extraction |
 | beagle-docs | `draft-docs` | Generate documentation drafts |
 | beagle-docs | `improve-doc` | Improve docs using Diataxis principles |
 | beagle-docs | `ensure-docs` | Documentation coverage check |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 11 focused plugins with 129 skills.
+Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 12 focused plugins with 143 skills.
 
 ## Marketplace Architecture
 
 ```text
 beagle/
 ├── .claude-plugin/
-│   └── marketplace.json         # Marketplace manifest (11 plugins)
+│   └── marketplace.json         # Marketplace manifest (12 plugins)
 └── plugins/
-    ├── beagle-core/             # Shared workflows, verification, git workflows (18 skills)
+    ├── beagle-core/             # Shared workflows, verification, git workflows (19 skills)
     ├── beagle-python/           # Python, FastAPI, SQLAlchemy, PostgreSQL, pytest (7 skills)
     ├── beagle-go/               # Go, BubbleTea, Wish SSH, Prometheus (13 skills)
     ├── beagle-elixir/           # Elixir, Phoenix, LiveView, ExUnit, ExDoc (11 skills)
     ├── beagle-ios/              # Swift, SwiftUI, SwiftData, iOS frameworks (16 skills)
-    ├── beagle-react/           # React, React Flow, shadcn/ui, Tailwind, Vitest (16 skills)
-    ├── beagle-rust/            # Rust, tokio, axum, sqlx, serde (10 skills)
+    ├── beagle-react/            # React, React Flow, shadcn/ui, Tailwind, Vitest (16 skills)
+    ├── beagle-remix-v2/         # Remix v2 routing, loaders/actions, forms, sessions, perf/SSR (12 skills)
+    ├── beagle-rust/             # Rust, tokio, axum, sqlx, serde (12 skills)
     ├── beagle-ai/               # Pydantic AI, LangGraph, DeepAgents, Vercel AI SDK (13 skills)
     ├── beagle-docs/             # Documentation quality, AI writing detection (10 skills)
     ├── beagle-analysis/         # Brainstorming, ADRs, strategy, LLM-as-judge, spec resolution, PRFAQ filter (12 skills)
@@ -73,6 +74,8 @@ Beagle-specific:
 | beagle-go | `review-tui` | BubbleTea TUI code review with Elm architecture focus |
 | beagle-ios | `review-ios` | iOS/SwiftUI code review |
 | beagle-elixir | `review-elixir` | Elixir/Phoenix/LiveView code review |
+| beagle-rust | `review-rust` | Rust/tokio/axum/sqlx/serde code review |
+| beagle-remix-v2 | `review-remix-v2` | Remix v2 code review (loaders, actions, forms, sessions, perf/SSR) |
 | beagle-core | `review-plan` | Review implementation plans before execution |
 | beagle-core | `commit-push` | Commit with Conventional Commits format |
 | beagle-core | `create-pr` | Create PR with structured template |
@@ -82,6 +85,7 @@ Beagle-specific:
 | beagle-core | `fetch-pr-feedback` | Fetch and evaluate bot review comments from PR |
 | beagle-core | `respond-pr-feedback` | Post replies to bot review comments |
 | beagle-core | `review-llm-artifacts` | Detect LLM coding artifacts |
+| beagle-core | `verify-llm-artifacts` | Adjudicate review findings (confirm/false-positive/inconclusive) before deletes |
 | beagle-core | `fix-llm-artifacts` | Fix detected artifacts |
 | beagle-core | `prompt-improver` | Optimize prompts |
 | beagle-analysis | `llm-judge` | Compare implementations using LLM-as-judge |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *Image: NASA, Public Domain. [Source](https://www.nasa.gov/multimedia/imagegallery/image_feature_572.html)*
 
-Beagle is a Claude Code plugin marketplace with 131 skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, iOS/Swift, and AI frameworks.
+Beagle is a Claude Code plugin marketplace with 143 skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, Remix v2, iOS/Swift, and AI frameworks.
 
 Used with [Amelia](https://github.com/existential-birds/amelia) for agent-based workflows and [Daydream](https://github.com/existential-birds/daydream) for automated review-fix-test loops.
 
@@ -59,12 +59,13 @@ This downloads the skills and configures them for your agent.
 | **beagle-elixir** | 11 | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
 | **beagle-ios** | 16 | Swift, SwiftUI, SwiftData, iOS frameworks |
 | **beagle-react** | 16 | React, React Flow, shadcn/ui, Tailwind |
+| **beagle-remix-v2** | 12 | Remix v2 route modules, loaders/actions, forms, sessions |
 | **beagle-rust** | 12 | Rust, tokio, axum, sqlx, serde |
 | **beagle-ai** | 13 | Pydantic AI, LangGraph, DeepAgents |
 | **beagle-docs** | 10 | Documentation quality, AI writing detection (Diataxis) |
 | **beagle-analysis** | 12 | Brainstorming, ADRs, strategy, LLM-as-judge, spec gap resolution |
 | **beagle-testing** | 2 | Test plan generation and execution |
-| **Total** | **131** | — |
+| **Total** | **143** | — |
 
 ## Skills
 
@@ -98,6 +99,7 @@ These are the canonical skill entry points for Beagle.
 | `review-ios` | beagle-ios | iOS/SwiftUI code review |
 | `review-elixir` | beagle-elixir | Elixir/Phoenix code review |
 | `review-rust` | beagle-rust | Rust/tokio/axum code review |
+| `review-remix-v2` | beagle-remix-v2 | Remix v2 code review (loaders, actions, forms, sessions) |
 
 ### Documentation & Analysis Skills
 
@@ -114,6 +116,9 @@ These are the canonical skill entry points for Beagle.
 | `resolve-beagle` | beagle-analysis | Close Open Questions and latent gaps in a brainstorm-beagle spec |
 | `strategy-interview` | beagle-analysis | Build strategy through guided conversation |
 | `strategy-review` | beagle-analysis | Pressure-test existing strategy documents |
+| `prfaq-beagle` | beagle-analysis | Working Backwards PRFAQ filter — pass/fail concepts before brainstorming |
+| `web-research` | beagle-analysis | Parallel-subagent web research with cited synthesis report |
+| `artifact-analysis` | beagle-analysis | Parallel-subagent scan of local docs with cited extraction |
 
 ### Testing Skills
 

--- a/plugins/beagle-remix-v2/.claude-plugin/plugin.json
+++ b/plugins/beagle-remix-v2/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "beagle-remix-v2",
+  "description": "Remix v2 (route modules + React Router v6) code review and best-practice skills. Pairs with beagle-core for full workflow.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Existential Birds, LLC",
+    "email": "tech@existentialbirds.com"
+  },
+  "repository": "https://github.com/existential-birds/beagle",
+  "keywords": [
+    "remix",
+    "remix-v2",
+    "react-router",
+    "react-router-v6",
+    "loaders",
+    "actions",
+    "code-review"
+  ]
+}

--- a/plugins/beagle-remix-v2/README.md
+++ b/plugins/beagle-remix-v2/README.md
@@ -1,0 +1,50 @@
+# beagle-remix-v2
+
+Remix v2 (route modules + React Router v6) code review and best-practice skills for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+
+> **Scope**: This plugin targets **Remix v2** (`@remix-run/*` v2.x). It does **not** cover Remix 3 (the new web-standards monorepo). For React Router v7 framework-mode (the merged Remix v2 codebase shipped under the React Router name), see `beagle-react:react-router-v7`.
+
+## Installation
+
+```bash
+# Add the marketplace (if not already added)
+claude plugin marketplace add https://github.com/existential-birds/beagle
+
+# Install the plugin
+claude plugin install beagle-remix-v2@existential-birds
+```
+
+## Commands
+
+| Command | Usage | Description |
+|---------|-------|-------------|
+| **review-remix-v2** | `/beagle-remix-v2:review-remix-v2` | Comprehensive Remix v2 code review. Detects Remix v2 in package.json, loads relevant review skills, runs verification protocol. |
+
+## Skills
+
+### Knowledge skills (auto-invoked when writing Remix v2 code)
+
+| Skill | Description |
+|-------|-------------|
+| **remix-v2-routing** | Flat-routes v2 conventions, `_layout`/`_index`/`$param`, `root.tsx` scaffold, resource routes |
+| **remix-v2-data-flow** | `loader`, `action`, `useLoaderData`, `useActionData`, `defer`/`Await`, revalidation, `useNavigation` |
+| **remix-v2-forms** | `<Form>`, `useFetcher`, `useSubmit`, optimistic UI, intent-based multi-action, multipart upload |
+| **remix-v2-perf-ssr** | `headers` + SWR caching, streaming, `.server.ts`/`.client.ts`, `useHydrated`, `<PrefetchPageLinks>` |
+| **remix-v2-meta-sessions** | v2 `meta` array API, `links`, `createCookieSessionStorage`, auth gates, CSRF |
+
+### Code-review skills (loaded by the umbrella reviewer)
+
+| Skill | Description |
+|-------|-------------|
+| **remix-v2-routing-review** | Reviews route-file naming, nested layouts, resource-route shape, v1-holdover detection |
+| **remix-v2-data-flow-review** | Reviews loaders/actions for mutations-in-loader, missing validation, leaked server fields, missing pending state |
+| **remix-v2-forms-review** | Reviews mutation primitives: flags manual `fetch()`, native `<form>`, wrong `useNavigation`/`useFetcher` choice |
+| **remix-v2-error-boundaries-review** | Reviews `ErrorBoundary` (v2 unified), `isRouteErrorResponse` narrowing, v1 `CatchBoundary` holdovers |
+| **remix-v2-perf-ssr-review** | Reviews caching headers, prefetch hygiene, server/client split, hydration mismatches |
+| **remix-v2-meta-sessions-review** | Reviews v2 meta array shape, cookie security flags, auth-in-loader, CSRF wiring |
+
+## See Also
+
+- [beagle-core](../beagle-core) — Shared workflows, verification protocol, and git commands
+- [beagle-react](../beagle-react) — React, React Router v7, shadcn/ui, Tailwind, Vitest, Zustand
+- [beagle marketplace](https://github.com/existential-birds/beagle) — Full plugin marketplace

--- a/plugins/beagle-remix-v2/README.md
+++ b/plugins/beagle-remix-v2/README.md
@@ -29,7 +29,7 @@ claude plugin install beagle-remix-v2@existential-birds
 | **remix-v2-routing** | Flat-routes v2 conventions, `_layout`/`_index`/`$param`, `root.tsx` scaffold, resource routes |
 | **remix-v2-data-flow** | `loader`, `action`, `useLoaderData`, `useActionData`, `defer`/`Await`, revalidation, `useNavigation` |
 | **remix-v2-forms** | `<Form>`, `useFetcher`, `useSubmit`, optimistic UI, intent-based multi-action, multipart upload |
-| **remix-v2-perf-ssr** | `headers` + SWR caching, streaming, `.server.ts`/`.client.ts`, `useHydrated`, `<PrefetchPageLinks>` |
+| **remix-v2-perf-ssr** | `headers`/caching policy, streaming via `defer`+`<Await>`, `.server.ts`/`.client.ts` split, hydration safety, `<Link prefetch>`/`<PrefetchPageLinks>` |
 | **remix-v2-meta-sessions** | v2 `meta` array API, `links`, `createCookieSessionStorage`, auth gates, CSRF |
 
 ### Code-review skills (loaded by the umbrella reviewer)

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/SKILL.md
@@ -38,6 +38,7 @@ Targets TypeScript route modules importing from `@remix-run/*`. See [beagle-remi
 - [ ] `shouldRevalidate` returns `defaultShouldRevalidate` by default; opt-outs are narrow and justified
 - [ ] `defer()` is used only when at least one promise streams (no `await` before passing it)
 - [ ] Every `<Await>` is wrapped in `<Suspense>` and has an `errorElement`
+- [ ] `useRevalidator().revalidate()` is reserved for focus/polling/SSE — not called immediately after a `<Form>` post or `fetcher.submit` (Remix already revalidates).
 
 ## Valid Patterns (Do NOT Flag)
 
@@ -49,7 +50,6 @@ These are correct Remix v2 usage and must not be reported as issues:
 - **Bare `new Response(body, init)` returns** — v2 routes may return any `Response`; `json()` is an ergonomic wrapper, not a requirement. Non-JSON bodies (binary, text, streams) correctly skip `json()`.
 - **`return redirect(...)` from an action** — Both `return redirect(...)` and `throw redirect(...)` are legal in actions; throwing is required only from non-action helpers when you want to exit the calling function.
 - **`loader` declared without the `request` arg** — Loaders may destructure only what they need (`{ params }`, `{ context }`, or `()` with no args); the unused arg is not a bug.
-- **`useFetcher` data read without checking `fetcher.state`** — May be intentional when stale data is acceptable during revalidation.
 - **Parent `loader` revalidated after an unrelated action** — This is default Remix behavior, not a smell. Flag only if `shouldRevalidate` exists and is wrong.
 - **Action returning `json({ errors }, { status: 400 })`** — This is the canonical validation-error pattern (keeps the form route rendered with field errors). Not the same as the "no redirect on success" anti-pattern.
 - **`useRevalidator` for focus / polling / cross-tab sync** — These are the documented use cases; only flag manual `revalidate()` calls that immediately follow a `<Form>` post or `fetcher.submit` Remix would already revalidate.
@@ -79,7 +79,7 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 
 3. **Type-annotation vs type-assertion check** — **Pass:** Before flagging an "unsafe cast" on loader/action consumption, confirm the code uses `as` (assertion) — not `useLoaderData<typeof loader>()` (annotation) and not `useActionData<typeof action>()` (annotation). The generic form is the documented safe path and must not be flagged.
 
-4. **v1 holdover check** — **Pass:** Before flagging "missing pending state," grep the file for `useTransition`, `transition.submission`, `fetcher.type`, `formMethod === "post"` (lowercase), and `LoaderArgs` / `ActionArgs`. If present, the finding is a v1-holdover migration issue, not a missing-feature issue — label it accordingly.
+4. **v1 holdover check** — **Pass:** Before flagging "missing pending state," grep the file for `useTransition`, `transition.submission`, `fetcher.type`, `formMethod === "post"` or `formMethod==='post'` (lowercase, any whitespace/quote variation), and `LoaderArgs` / `ActionArgs`. If present, the finding is a v1-holdover migration issue, not a missing-feature issue — label it accordingly.
 
 5. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/SKILL.md
@@ -81,7 +81,7 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 
 4. **v1 holdover check** — **Pass:** Before flagging "missing pending state," grep the file for `useTransition`, `transition.submission`, `fetcher.type`, `formMethod === "post"` or `formMethod==='post'` (lowercase, any whitespace/quote variation), and `LoaderArgs` / `ActionArgs`. If present, the finding is a v1-holdover migration issue, not a missing-feature issue — label it accordingly.
 
-5. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
+5. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [beagle-core:review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
 
 ## When to Load References
 
@@ -104,8 +104,8 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 ## Additional Documentation
 
 - Canonical Remix v2 data-flow patterns and v1 → v2 diff → [beagle-remix-v2:remix-v2-data-flow](../remix-v2-data-flow/SKILL.md)
-- Pre-report verification checklist → [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md)
+- Pre-report verification checklist → [beagle-core:review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md)
 
 ## Before Submitting Findings
 
-Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 5), then report only issues that still pass the [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) pre-report checks.
+Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 5), then report only issues that still pass the [beagle-core:review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) pre-report checks.

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: remix-v2-data-flow-review
+description: Reviews Remix v2 loaders and actions for mutations-in-loader, missing validation, leaked server fields, wrong return helpers, v1 useTransition holdovers, and revalidation traps. Use when reviewing loader/action code in a Remix v2 codebase.
+---
+
+# Remix v2 Data Flow Code Review
+
+Targets TypeScript route modules importing from `@remix-run/*`. See [beagle-remix-v2:remix-v2-data-flow](../remix-v2-data-flow/SKILL.md) for canonical patterns.
+
+## Scope
+
+- **In scope**: route modules under `app/routes/` exporting `loader`, `action`, `shouldRevalidate`, or `headers`; components that consume `useLoaderData`, `useActionData`, `useNavigation`, `useFetcher`, `useRevalidator`, `<Await>`.
+- **Out of scope**: form ergonomics (`<Form>` markup, accessibility, `useFetcher` UI patterns) → covered by `remix-v2-forms-review`. Route module conventions, file naming, nested routing, error boundary placement → covered by `remix-v2-routing-review`.
+- **Imports expected**: `@remix-run/node` (or `@remix-run/cloudflare` / `@remix-run/deno`) for server utilities; `@remix-run/react` for hooks and components.
+
+## Quick Reference
+
+| Issue Type | Reference |
+|------------|-----------|
+| Mutations in loader, missing validation, leaked server fields, throwing primitives, missing param checks | [references/loaders.md](references/loaders.md) |
+| Unvalidated FormData, `json` instead of `redirect` on success, missing error case, leaked actionData | [references/actions.md](references/actions.md) |
+| `useTransition` v1 holdover, missing pending state, blanket `shouldRevalidate: false`, misused `useRevalidator` | [references/revalidation.md](references/revalidation.md) |
+| `defer` for already-fast data, missing `<Suspense>`, no `errorElement` on `<Await>`, awaiting what should stream | [references/defer-await.md](references/defer-await.md) |
+
+## Review Checklist
+
+- [ ] Data needed for first render is in `loader`, not `useEffect`
+- [ ] Loaders only read; writes live in `action`
+- [ ] `request.formData()` results are validated (zod/valibot/invariant) before use
+- [ ] Loader/action return values are projected DTOs — no password hashes, tokens, or `internal_*` fields
+- [ ] `useLoaderData<typeof loader>()` uses the type annotation form (not `as Foo`)
+- [ ] 404 / auth short-circuits `throw` a `Response` (or `json`/`redirect`), never a plain `Error` or string
+- [ ] Successful action returns `redirect(...)` (PRG); validation failures return `json({ errors }, { status: 400 })`
+- [ ] Action handles both success and error branches; no silent `return null`
+- [ ] `params.foo` is checked with `invariant` / zod before use
+- [ ] Pending UI reads `useNavigation()` / `fetcher.state` — no `useTransition`
+- [ ] `formMethod` comparisons use UPPERCASE (`"POST"`, not `"post"`)
+- [ ] `shouldRevalidate` returns `defaultShouldRevalidate` by default; opt-outs are narrow and justified
+- [ ] `defer()` is used only when at least one promise streams (no `await` before passing it)
+- [ ] Every `<Await>` is wrapped in `<Suspense>` and has an `errorElement`
+
+## Valid Patterns (Do NOT Flag)
+
+These are correct Remix v2 usage and must not be reported as issues:
+
+- **`useEffect` for client-only data** — Loaders run server-side; `localStorage`, `window` dimensions, `IntersectionObserver`, and browser-only APIs belong in `useEffect`.
+- **`loader` returning `null`** — A loader may legitimately return `null` (e.g. optional resource not present); flag only if it should be a 404 `throw`.
+- **`useLoaderData<typeof loader>()` as type annotation** — The `<typeof loader>` is a generic parameter feeding `SerializeFrom<T>`, not a `as`-style type assertion. Do not flag it as "unsafe cast."
+- **Bare `new Response(body, init)` returns** — v2 routes may return any `Response`; `json()` is an ergonomic wrapper, not a requirement. Non-JSON bodies (binary, text, streams) correctly skip `json()`.
+- **`return redirect(...)` from an action** — Both `return redirect(...)` and `throw redirect(...)` are legal in actions; throwing is required only from non-action helpers when you want to exit the calling function.
+- **`loader` declared without the `request` arg** — Loaders may destructure only what they need (`{ params }`, `{ context }`, or `()` with no args); the unused arg is not a bug.
+- **`useFetcher` data read without checking `fetcher.state`** — May be intentional when stale data is acceptable during revalidation.
+- **Parent `loader` revalidated after an unrelated action** — This is default Remix behavior, not a smell. Flag only if `shouldRevalidate` exists and is wrong.
+- **Action returning `json({ errors }, { status: 400 })`** — This is the canonical validation-error pattern (keeps the form route rendered with field errors). Not the same as the "no redirect on success" anti-pattern.
+- **`useRevalidator` for focus / polling / cross-tab sync** — These are the documented use cases; only flag manual `revalidate()` calls that immediately follow a `<Form>` post or `fetcher.submit` Remix would already revalidate.
+- **`SerializeFrom`-induced type changes** — `Date` typed as `string`, `Map` typed as `{}` after deserialization is correct wire-format behavior, not a typing bug.
+
+## Context-Sensitive Rules
+
+Only flag these issues when the specific context applies:
+
+| Issue | Flag ONLY IF |
+|-------|--------------|
+| Missing loader (using `useEffect` instead) | Data is available server-side and is NOT a browser-only API read |
+| `loader` returns a raw ORM object | The object contains fields a reviewer would not paste into a screenshot (passwords, tokens, internal flags) |
+| Action returns `json` on success | The action is invoked via `<Form>` causing a URL change — NOT via `useFetcher` |
+| Missing pending UI | No `nav.state` / `fetcher.state` reference exists elsewhere in the file driving the same surface |
+| `shouldRevalidate` returns `false` | The body has no condition or never references `formAction` / `currentParams` / `nextParams` |
+| Manual `useRevalidator().revalidate()` | The call follows a Remix-managed mutation (`<Form>` post, `fetcher.submit`) — not focus / polling / websocket |
+| `defer()` used | Every promise in the `defer({...})` payload was already `await`ed before the call |
+
+## Hard gates (before writing findings)
+
+Run these in order. **Do not draft user-facing findings until every gate passes** for the batch you are about to report.
+
+1. **Location evidence** — **Pass:** Each issue lists the repo path to the route module and either a line range or a short verbatim quote from the file you read (not from memory or diff-only guesswork). Loader/action issues without a path to the `export async function loader|action` are not reportable.
+
+2. **Exemption check** — **Pass:** For each issue, you can state in one line why it is *not* covered by [Valid Patterns (Do NOT Flag)](#valid-patterns-do-not-flag). In particular: confirm `useEffect` is not loading client-only data; confirm a bare `Response` return is not intentionally non-JSON; confirm a `loader` returning `null` is not a legitimate optional read.
+
+3. **Type-annotation vs type-assertion check** — **Pass:** Before flagging an "unsafe cast" on loader/action consumption, confirm the code uses `as` (assertion) — not `useLoaderData<typeof loader>()` (annotation) and not `useActionData<typeof action>()` (annotation). The generic form is the documented safe path and must not be flagged.
+
+4. **v1 holdover check** — **Pass:** Before flagging "missing pending state," grep the file for `useTransition`, `transition.submission`, `fetcher.type`, `formMethod === "post"` (lowercase), and `LoaderArgs` / `ActionArgs`. If present, the finding is a v1-holdover migration issue, not a missing-feature issue — label it accordingly.
+
+5. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
+
+## When to Load References
+
+- Reviewing a `loader` body, return shape, params, throws, or sensitive-field leaks → [references/loaders.md](references/loaders.md)
+- Reviewing an `action` body, FormData validation, success/error branches, or PRG redirect → [references/actions.md](references/actions.md)
+- Reviewing `useNavigation` / `useTransition` migrations, `shouldRevalidate`, or `useRevalidator` use → [references/revalidation.md](references/revalidation.md)
+- Reviewing `defer()`, `<Await>`, `<Suspense>`, or streaming decisions → [references/defer-await.md](references/defer-await.md)
+
+## Review Questions
+
+1. Is data needed for first render fetched in a `loader`, or is it stuck in a `useEffect` that defeats SSR and revalidation?
+2. Does every loader return a projected DTO, or do raw ORM records (with `password`, `token`, `internal_*` fields) leak to the browser?
+3. Does every action validate `request.formData()` with a schema before touching the database?
+4. Does the success branch of each action `redirect(...)` so refresh / back behaves correctly (PRG)?
+5. Is the consumer code using `useLoaderData<typeof loader>()` (annotation) — not `useLoaderData() as Foo` (assertion)?
+6. Do any v1 holdovers remain (`useTransition`, `transition.submission`, `fetcher.type`, lowercase `formMethod`, `LoaderArgs` / `ActionArgs`)?
+7. Does `shouldRevalidate` return a literal `false`, or does it reach for `defaultShouldRevalidate` and opt out narrowly?
+8. Is `defer()` used only when at least one promise is passed unresolved, and is every `<Await>` wrapped in `<Suspense>` with an `errorElement`?
+
+## Additional Documentation
+
+- Canonical Remix v2 data-flow patterns and v1 → v2 diff → [beagle-remix-v2:remix-v2-data-flow](../remix-v2-data-flow/SKILL.md)
+- Pre-report verification checklist → [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md)
+
+## Before Submitting Findings
+
+Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 5), then report only issues that still pass the [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) pre-report checks.

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/actions.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/actions.md
@@ -1,0 +1,176 @@
+# Action Review Reference
+
+Anti-patterns and review prompts for `export async function action` in Remix v2 route modules. See [beagle-remix-v2:remix-v2-data-flow](../../remix-v2-data-flow/SKILL.md) for canonical action patterns.
+
+## 1. Unvalidated FormData
+
+**Smell**:
+
+```tsx
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const title = form.get("title") as string;
+  await db.project.create({ data: { title } });
+  return redirect("/projects");
+}
+```
+
+**Why bad**:
+
+- `form.get("title")` is `FormDataEntryValue | null` (`string | File | null`). The `as string` assertion hides the `null` and `File` cases.
+- Client-side validation is bypassable; the docs explicitly warn against trusting it.
+- An attacker can submit empty strings, oversized payloads, or `File` objects where strings were expected. Schema validation is mandatory on the server.
+
+**Fix**:
+
+```tsx
+import { z } from "zod";
+
+const NewProject = z.object({
+  title: z.string().min(1).max(120),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const parsed = NewProject.safeParse(Object.fromEntries(form));
+  if (!parsed.success) {
+    return json(
+      { errors: parsed.error.flatten().fieldErrors, values: Object.fromEntries(form) },
+      { status: 400 },
+    );
+  }
+  const project = await db.project.create({ data: parsed.data });
+  return redirect(`/projects/${project.id}`);
+}
+```
+
+`Object.fromEntries(formData)` collapses repeated fields — for checkbox groups / multi-selects, use `formData.getAll("tag")` and feed it into the schema explicitly.
+
+## 2. Returning `json` instead of `redirect` on success (broken PRG)
+
+**Smell**:
+
+```tsx
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const project = await db.project.create({ data: { title: form.get("title") as string } });
+  return json({ project }); // success → no redirect
+}
+```
+
+**Why bad**: Without a redirect, the browser's URL stays on the form-submitting route. Pressing refresh re-POSTs the form (browser prompt "Confirm form resubmission?"), and the back button replays the mutation. This is the classic Post/Redirect/Get problem — Remix actions are designed to redirect on success.
+
+**Fix**: `return redirect(\`/projects/\${project.id}\`);` on success. Keep `return json(...)` only for the validation-error branch where you want the user to stay on the form.
+
+**Do not flag when**:
+
+- The action is invoked via `useFetcher` and the route was never navigated to (fetcher actions do not change the URL, so PRG is not at stake).
+- The action intentionally returns optimistic / interim data for an inline-edit UI consumed via `fetcher.data` — the URL never changed and refresh has no meaning.
+
+## 3. Missing error branch / silent `return null`
+
+**Smell**:
+
+```tsx
+export async function action({ request }: ActionFunctionArgs) {
+  try {
+    const form = await request.formData();
+    await db.project.create({ data: { title: form.get("title") as string } });
+    return redirect("/projects");
+  } catch {
+    return null; // swallowed
+  }
+}
+```
+
+**Why bad**: `useActionData()` becomes `undefined`, the UI shows no feedback, and the user retries blindly. `ErrorBoundary` cannot catch a returned value — only thrown ones.
+
+**Fix**: Either let exceptions propagate (so `ErrorBoundary` handles them) or return a structured error:
+
+```tsx
+return json(
+  { errors: { _form: "Could not create project. Please try again." } },
+  { status: 500 },
+);
+```
+
+For "this should never happen" cases: `throw json({ message }, { status: 500 })`.
+
+## 4. Leaking server-only fields in `actionData`
+
+**Smell**:
+
+```tsx
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const user = await db.user.findUnique({ where: { email: form.get("email") as string } });
+  if (!user) return json({ error: "Not found" }, { status: 404 });
+  return json({ user }); // ships passwordHash, etc.
+}
+```
+
+**Why bad**: Action return values ship to the client just like loader return values. Returning a raw ORM record exposes password hashes, session tokens, API keys, and `internal_*` flags via `useActionData`.
+
+**Fix**: Project to a safe DTO before returning:
+
+```tsx
+return json({ user: { id: user.id, email: user.email, name: user.name } });
+```
+
+**Field-name red flags** to grep for in action return values: `password`, `passwordHash`, `apiKey`, `secret`, `token`, `internal_`, `__`, `salt`, `mfaSeed`, `webhookSecret`, `csrfSecret`.
+
+## 5. Manual `fetch()` to a Remix route from a component
+
+**Smell**:
+
+```tsx
+function StarButton({ id }: { id: string }) {
+  return (
+    <button
+      onClick={() =>
+        fetch(`/projects/${id}/star`, { method: "POST" })
+      }
+    >
+      Star
+    </button>
+  );
+}
+```
+
+**Why bad**: Bypasses automatic revalidation, pending state (`fetcher.state`), progressive enhancement, and the CSRF / cookie flow built into `<Form>` and `useFetcher`. Errors are not surfaced via `useActionData`.
+
+**Fix**: Use `useFetcher().submit()` or `<fetcher.Form>`:
+
+```tsx
+const fetcher = useFetcher<typeof action>();
+return (
+  <fetcher.Form method="post" action={`/projects/${id}/star`}>
+    <button type="submit">Star</button>
+  </fetcher.Form>
+);
+```
+
+## 6. `ActionArgs` v1 type holdover
+
+**Smell**: `import type { ActionArgs } from "@remix-run/node";`
+
+**Why bad**: v2 renamed `ActionArgs` → `ActionFunctionArgs`. Old name may exist as a deprecated alias — flag during v2 review.
+
+**Fix**: `import type { ActionFunctionArgs } from "@remix-run/node";`
+
+## 7. `actionData` from the wrong route
+
+**Smell**: A parent layout reads `useActionData()` expecting results from a child route's action.
+
+**Why bad**: `useActionData` "cannot access data from other parent or child routes." The hook is scoped to the route module it is called from; results from a different route's action are unreachable here.
+
+**Fix**: Lift the action to the parent route, or use `useFetcher` with a shared `key` so multiple components see the same fetcher state.
+
+## Review prompts
+
+- Is every `formData.get(...)` value validated by a schema before reaching the DB?
+- Does the success branch end with `redirect(...)` (unless the action is a `useFetcher` target)?
+- Does the catch / failure branch return structured `json({ errors }, { status })` or throw — never silently return `null`?
+- Are any object literals in `return json(...)` derived from full ORM records without field projection?
+- Does the file still import `ActionArgs` from `@remix-run/node`?
+- Is there a manual `fetch("/route", { method: "POST" })` that should be a `useFetcher`?

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/defer-await.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/defer-await.md
@@ -1,0 +1,134 @@
+# Defer & Await Review Reference
+
+Anti-patterns and review prompts for `defer()`, `<Await>`, and `<Suspense>` in Remix v2. See [beagle-remix-v2:remix-v2-data-flow](../../remix-v2-data-flow/SKILL.md) for canonical streaming patterns.
+
+## 1. `defer` for already-fast data
+
+**Smell**:
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = db.product.findUnique({ where: { id: params.id! } }); // ~5ms query
+  return defer({ product });
+}
+```
+
+**Why bad**: `defer` exists to let the page render before slow data is ready. Streaming has overhead: an unresolved chunk, `<Suspense>` boundary work, an extra wire round-trip for the chunk. For sub-50ms queries this is pure overhead with no perceived-latency win — and it forces the consumer to add `<Suspense>` + `<Await>` for nothing.
+
+**Fix**: Await it and return via `json`:
+
+```tsx
+const product = await db.product.findUnique({ where: { id: params.id! } });
+return json({ product });
+```
+
+**Rule of thumb**: Use `defer` when (a) at least one promise is materially slower than the page's critical path *and* (b) the page can render usefully without it. Single-query routes should almost never `defer`.
+
+## 2. Awaiting in the loader what should be deferred
+
+**Smell**:
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = await db.product.findUnique({ where: { id: params.id! } });
+  const reviews = await db.review.findMany({ where: { productId: params.id! } }); // slow!
+  return defer({ product, reviews });
+}
+```
+
+**Why bad**: `await`-ing the slow promise before constructing `defer` defeats the entire purpose — nothing streams. The page waits on `reviews` exactly as it would with `json`. `defer` only streams promises that are passed **unresolved**.
+
+**Fix**: Drop the `await` on the slow query so the promise itself flows through `defer`:
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = await db.product.findUnique({ where: { id: params.id! } });
+  const reviews = db.review.findMany({ where: { productId: params.id! } }); // no await
+  return defer({ product, reviews });
+}
+```
+
+The component reads `reviews` as a promise via `useLoaderData<typeof loader>()` and renders it inside `<Suspense><Await>`.
+
+## 3. `<Await>` without a surrounding `<Suspense>`
+
+**Smell**:
+
+```tsx
+return (
+  <>
+    <ProductHeader product={product} />
+    <Await resolve={reviews}>
+      {(rs) => <ProductReviews reviews={rs} />}
+    </Await>
+  </>
+);
+```
+
+**Why bad**: `<Await>` suspends while its promise is pending. Without a `<Suspense>` ancestor, React has nothing to render as fallback and the page crashes. The docs say `<Await>` "must be rendered inside of a `<React.Suspense>` or `<React.SuspenseList>` parent."
+
+**Fix**:
+
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews}>
+    {(rs) => <ProductReviews reviews={rs} />}
+  </Await>
+</Suspense>
+```
+
+## 4. Missing `errorElement` on `<Await>`
+
+**Smell**:
+
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews}>
+    {(rs) => <ProductReviews reviews={rs} />}
+  </Await>
+</Suspense>
+```
+
+**Why bad**: If the deferred promise rejects (DB error, timeout), the rejection bubbles up to the route's `ErrorBoundary` and replaces the entire page with the error UI. The whole point of streaming was to keep the rest of the page useful while one section loads — a missing `errorElement` throws that away.
+
+**Fix**: Provide an inline error fallback so only the slow section degrades:
+
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await
+    resolve={reviews}
+    errorElement={<p role="alert">Could not load reviews.</p>}
+  >
+    {(rs) => <ProductReviews reviews={rs} />}
+  </Await>
+</Suspense>
+```
+
+## 5. `defer` returning sensitive fields
+
+**Smell**:
+
+```tsx
+return defer({ user: db.user.findUnique({ where: { id } }) });
+```
+
+**Why bad**: Deferred promises serialize to the client the same way `json` returns do — the resolved value is streamed as JSON. Returning a raw ORM record exposes password hashes, API keys, and `internal_*` fields once the promise resolves.
+
+**Fix**: Project to a DTO *inside* the promise chain so the resolved shape is safe:
+
+```tsx
+return defer({
+  user: db.user
+    .findUnique({ where: { id } })
+    .then((u) => u && { id: u.id, email: u.email, name: u.name }),
+});
+```
+
+## Review prompts
+
+- Is every `defer({ ... })` call accompanied by at least one promise passed **without** `await`?
+- For every `await` inside a loader that returns `defer`, is the awaited promise on the critical path (fast, must be ready before render)?
+- Is every `<Await resolve={...}>` wrapped in a `<Suspense fallback={...}>` ancestor?
+- Does every `<Await>` declare an `errorElement` so promise rejection degrades only that section?
+- Do deferred promises resolve to DTO shapes, or do they resolve to raw ORM records with sensitive fields?
+- Could the route be simplified to `json(...)` because no single query is slow enough to justify streaming?

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/loaders.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/loaders.md
@@ -1,0 +1,164 @@
+# Loader Review Reference
+
+Anti-patterns and review prompts for `export async function loader` in Remix v2 route modules. See [beagle-remix-v2:remix-v2-data-flow](../../remix-v2-data-flow/SKILL.md) for canonical loader patterns.
+
+## 1. `useEffect` data fetching that belongs in a loader
+
+**Smell**:
+
+```tsx
+// app/routes/invoices.tsx
+export default function Invoices() {
+  const [invoices, setInvoices] = useState<Invoice[]>([]);
+  useEffect(() => {
+    fetch("/api/invoices").then((r) => r.json()).then(setInvoices);
+  }, []);
+  return <InvoiceList invoices={invoices} />;
+}
+```
+
+**Why bad**: Defeats SSR, opens a fetch waterfall, skips automatic revalidation after actions, and breaks progressive enhancement. The docs say "Remix will call your loaders for you; in no case should you ever try to call your loader directly."
+
+**Fix**: Move into a `loader` and read with `useLoaderData<typeof loader>()`.
+
+**Do not flag when**: the fetch reads `localStorage`, `window.matchMedia`, `IntersectionObserver`, or any browser-only API — those legitimately stay in `useEffect`.
+
+## 2. Mutations inside a `loader`
+
+**Smell**:
+
+```tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getUser(request);
+  await db.session.update({ where: { id: user.sessionId }, data: { lastSeen: new Date() } });
+  return json({ user });
+}
+```
+
+**Why bad**: Loaders run on every GET navigation **and** speculatively on prefetch **and** during automatic revalidation after any action on the page. A write in a loader replays unpredictably and corrupts data.
+
+**Fix**: Move the write into an `action` or a non-route server module triggered by an explicit `<Form method="post">` / `fetcher.submit()`. Read-only logging that *must* live with the GET (e.g. analytics ping) belongs in a fire-and-forget call on the server response, not a synchronous `await` in the loader.
+
+## 3. Missing FormData / params validation
+
+**Smell**:
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const project = await db.project.findUnique({ where: { id: params.id } });
+  return json({ project });
+}
+```
+
+**Why bad**: `params.id` is `string | undefined`. Prisma silently passes `undefined`, returning an unintended record or null. Downstream code crashes on `.toLowerCase()` etc.
+
+**Fix**:
+
+```tsx
+import invariant from "tiny-invariant";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  invariant(params.id, "id required");
+  const project = await db.project.findUnique({ where: { id: params.id } });
+  if (!project) throw new Response("Not Found", { status: 404 });
+  return json({ project });
+}
+```
+
+Or parse `params` with a zod schema for slug/id format validation.
+
+## 4. Leaking server-only fields to the client
+
+**Smell**:
+
+```tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await db.user.findUnique({
+    where: { id: await getUserId(request) },
+  });
+  return json({ user }); // ships passwordHash, apiKey, internalRole, etc.
+}
+```
+
+**Why bad**: Everything returned from a loader travels to the browser as JSON. Password hashes, API keys, session tokens, and `internal_*` flags become visible in the Network panel and the SSR HTML payload.
+
+**Fix**: Project to a safe DTO before returning:
+
+```tsx
+return json({
+  user: { id: user.id, email: user.email, name: user.name },
+});
+```
+
+**Field-name red flags** to grep for in loader return values: `password`, `passwordHash`, `apiKey`, `secret`, `token`, `internal_`, `__`, `salt`, `mfaSeed`, `webhookSecret`.
+
+## 5. Wrong type assertion vs type annotation
+
+**Smell**:
+
+```tsx
+const data = useLoaderData() as { invoices: Invoice[] };
+```
+
+**Why bad**: An `as` assertion bypasses `SerializeFrom<T>`. The wire format collapses `Date → string`, `Map/Set → {}`, strips `undefined`, and removes class methods. The assertion will lie about the runtime shape.
+
+**Fix**:
+
+```tsx
+const { invoices } = useLoaderData<typeof loader>();
+```
+
+The `<typeof loader>` here is a generic parameter (type annotation), not an `as`-style assertion. Do not flag the annotation form as an "unsafe cast" — it is the documented safe path.
+
+## 6. Throwing primitives instead of Response
+
+**Smell**:
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const project = await db.project.findUnique({ where: { id: params.id! } });
+  if (!project) throw new Error("Not Found"); // or: throw "not found"
+  return json({ project });
+}
+```
+
+**Why bad**: `useRouteError()` + `isRouteErrorResponse()` only classify thrown `Response` objects as route responses. A plain `Error` hits the boundary as an unknown runtime error with no `status` / `statusText`; a thrown string is even worse.
+
+**Fix**:
+
+```tsx
+if (!project) throw new Response("Not Found", { status: 404 });
+// or: throw json({ message: "Not found" }, { status: 404 });
+```
+
+For auth guards, `throw redirect("/login")` from a helper short-circuits the loader cleanly.
+
+## 7. `LoaderArgs` v1 type holdover
+
+**Smell**:
+
+```tsx
+import type { LoaderArgs } from "@remix-run/node";
+export async function loader({ request }: LoaderArgs) { ... }
+```
+
+**Why bad**: v2 renamed `LoaderArgs` → `LoaderFunctionArgs`. The old name may exist as a deprecated alias but is a migration smell — flag it during a v2 review.
+
+**Fix**: `import type { LoaderFunctionArgs } from "@remix-run/node";`
+
+## 8. Re-defining the same data via parent + child loaders
+
+**Smell**: Both `app/routes/projects.tsx` and `app/routes/projects.$id.tsx` independently call `db.project.findMany`.
+
+**Why bad**: Two sources of truth, doubled DB queries, divergent shapes after revalidation.
+
+**Fix**: Load once at the highest matching route and read via `useRouteLoaderData("routes/projects")` in children.
+
+## Review prompts
+
+- Is every `params.x` access guarded by `invariant` or a schema parse?
+- Does the loader return any object that originates from an ORM `findUnique`/`findMany` without explicit field projection?
+- Is anything in the returned object named after a secret (`password`, `token`, `apiKey`, `internal_`)?
+- Are 404 / auth short-circuits using `throw new Response(...)` or `throw redirect(...)` (not `throw new Error(...)`)?
+- Is there a `useEffect` in the default export that fetches non-browser-API data?
+- Does the file still import `LoaderArgs` from `@remix-run/node`?

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/revalidation.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/revalidation.md
@@ -1,0 +1,161 @@
+# Revalidation & Pending State Review Reference
+
+Anti-patterns and review prompts for `useNavigation`, `useTransition` (v1 holdover), `shouldRevalidate`, and `useRevalidator` in Remix v2. See [beagle-remix-v2:remix-v2-data-flow](../../remix-v2-data-flow/SKILL.md) for canonical patterns.
+
+## 1. `useTransition` — v1 holdover
+
+**Smell**:
+
+```tsx
+import { useTransition } from "@remix-run/react";
+
+function SaveButton() {
+  const transition = useTransition();
+  const busy = transition.state === "submitting";
+  // ...
+}
+```
+
+**Why bad**: `useTransition` was removed in Remix v2; the hook is now `useNavigation`. The `submission` object was flattened — `transition.submission.formMethod` no longer exists; the fields are on the root: `nav.formMethod`, `nav.formData`, `nav.formAction`.
+
+**Fix**:
+
+```tsx
+import { useNavigation } from "@remix-run/react";
+
+function SaveButton() {
+  const nav = useNavigation();
+  const busy = nav.state !== "idle" && nav.formMethod === "POST";
+}
+```
+
+**Related holdovers to flag in the same review**:
+
+- `fetcher.type === "actionSubmission"` — `fetcher.type` is removed. Branch on `fetcher.state` plus presence of `fetcher.formData`.
+- `formMethod === "post"` (lowercase) — v2 returns UPPERCASE (`"POST"`, `"GET"`, `"DELETE"`); lowercase comparisons silently never match. Applies to `useNavigation`, `useFetcher`, and the `shouldRevalidate` arg.
+- `LoaderArgs` / `ActionArgs` — renamed to `LoaderFunctionArgs` / `ActionFunctionArgs`.
+
+## 2. Missing pending state
+
+**Smell**: A `<Form method="post">` submit button has no disabled / spinner / busy attribute. Users double-click and double-submit.
+
+**Why bad**: Long submits feel broken; double submits create duplicate records. Remix exposes `nav.state` and `fetcher.state` for exactly this.
+
+**Fix**:
+
+```tsx
+const nav = useNavigation();
+const busy = nav.state !== "idle" && nav.formMethod === "POST";
+return <button type="submit" disabled={busy}>{busy ? "Saving…" : "Save"}</button>;
+```
+
+For `useFetcher`-driven mutations, gate on `fetcher.state !== "idle"` instead. POST flow goes `idle → submitting → loading → idle`; GET flow goes `idle → loading → idle` — a spinner gated only on `"submitting"` will miss GET forms.
+
+**Do not flag when**:
+
+- The button uses CSS / `data-busy` attribute hooked into `nav.state` elsewhere (search the file for `nav.state` / `fetcher.state` before flagging "missing pending state").
+- The form posts to a `useFetcher` that drives optimistic UI from `fetcher.formData` — the optimistic state *is* the pending indicator.
+
+## 3. Blanket `shouldRevalidate` returning `false`
+
+**Smell**:
+
+```tsx
+export const shouldRevalidate: ShouldRevalidateFunction = () => false;
+```
+
+**Why bad**: The route now never revalidates — not after the user's own mutations on this route, not on params change, not when explicit `useRevalidator()` calls fire. The docs warn: "This makes it possible for your UI to get out of sync with your server if you do it wrong, so be careful." Users will see stale data after their own actions and not understand why.
+
+**Fix**: Start from `defaultShouldRevalidate` and opt out only for the narrow conditions that justify it:
+
+```tsx
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  currentParams,
+  nextParams,
+  defaultShouldRevalidate,
+}) => {
+  // Root loader carries static env vars; only revalidate if params change (they shouldn't here).
+  if (currentParams.userId !== nextParams.userId) return true;
+  return false;
+};
+```
+
+**Legitimate `return false`**: A root loader carrying purely static data (`{ env: { APP_URL } }`) that never changes for the page lifetime. Even there, prefer narrowing on `formAction` rather than a blanket `false`.
+
+**Red flags** to look for in `shouldRevalidate` bodies:
+
+- Return value is a literal `false` with no condition.
+- The function body never references `formAction`, `formMethod`, `currentParams`, or `nextParams`.
+- The function body never references `defaultShouldRevalidate`.
+
+## 4. `useRevalidator` when navigation would do
+
+**Smell**:
+
+```tsx
+function SaveButton() {
+  const fetcher = useFetcher();
+  const { revalidate } = useRevalidator();
+  return (
+    <button
+      onClick={async () => {
+        await fetcher.submit({ ... }, { method: "post", action: "/save" });
+        revalidate(); // manual refresh
+      }}
+    >
+      Save
+    </button>
+  );
+}
+```
+
+**Why bad**: After any action submitted via `<Form>` or `useFetcher`, Remix automatically revalidates all loaders for matching routes on the page. The manual `revalidate()` call duplicates the loader requests and races the automatic pass. The docs say: "If you find yourself using this for normal CRUD operations on your data… you're probably not taking advantage of the other APIs like `<Form>`, `useSubmit`, or `useFetcher`."
+
+**Fix**: Remove the `revalidate()` call. `useRevalidator` is for cases the framework cannot trigger automatically: cross-tab sync, focus-driven refresh, polling, websocket-pushed updates.
+
+**Legitimate uses (do not flag)**:
+
+```tsx
+const { revalidate, state } = useRevalidator();
+useEffect(() => {
+  function onFocus() {
+    if (state === "idle") revalidate();
+  }
+  window.addEventListener("focus", onFocus);
+  return () => window.removeEventListener("focus", onFocus);
+}, [revalidate, state]);
+```
+
+## 5. Polling with `useRevalidator` without guards
+
+**Smell**:
+
+```tsx
+useEffect(() => {
+  const id = setInterval(() => revalidate(), 5000);
+  return () => clearInterval(id);
+}, [revalidate]);
+```
+
+**Why bad**: Multiple revalidations can stack on top of each other — if the loader takes 6 seconds, a second call fires while the first is still in flight. Across many concurrent users this duplicates DB queries and can hammer the origin.
+
+**Fix**: Gate on `state === "idle"`, add jitter, pause when the tab is hidden:
+
+```tsx
+useEffect(() => {
+  const id = setInterval(() => {
+    if (state === "idle" && document.visibilityState === "visible") revalidate();
+  }, 5000 + Math.random() * 1000);
+  return () => clearInterval(id);
+}, [revalidate, state]);
+```
+
+## Review prompts
+
+- Does the file import `useTransition` from `@remix-run/react`?
+- Are there comparisons against lowercase `"post"` / `"get"` / `"delete"`?
+- Does any `fetcher.type === ...` switch survive?
+- Does `shouldRevalidate` always return a literal `false`?
+- Does any submit button lack a `disabled` or busy class tied to `nav.state` / `fetcher.state`?
+- Is `revalidate()` called manually right after a `fetcher.submit` / `<Form>` post that Remix would already revalidate?
+- Are polling `revalidate()` calls gated on `state === "idle"` and visibility?

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/revalidation.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow-review/references/revalidation.md
@@ -99,7 +99,7 @@ function SaveButton() {
   return (
     <button
       onClick={async () => {
-        await fetcher.submit({ ... }, { method: "post", action: "/save" });
+        await fetcher.submit({ ... }, { method: "POST", action: "/save" });
         revalidate(); // manual refresh
       }}
     >

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/SKILL.md
@@ -67,6 +67,23 @@ v2 did **not** change the underlying contract: loaders and actions must return a
 
 Throwing a `Response` from a loader or action exits the data function immediately. Use this for auth guards (`throw redirect("/login")`) and 404s (`throw new Response("Not Found", { status: 404 })` or `throw json({ message }, { status: 404 })`). Throwing a plain `Error` will not be classified as a route response by `useRouteError()` / `isRouteErrorResponse()`.
 
+## Streaming Rejections: `<Await errorElement>` + `useAsyncError()`
+
+When a promise passed through `defer()` rejects, an `<Await errorElement={...}>` boundary catches it inline — without it, the rejection bubbles to the route's `ErrorBoundary` and tears down the whole page, defeating the streaming benefit. Inside the `errorElement`, call `useAsyncError()` (from `@remix-run/react`) to read the rejection value — this is the streaming analogue of `useRouteError()`.
+
+```tsx
+function ReviewsError() {
+  const error = useAsyncError(); // typed as `unknown`
+  return <p>Failed to load reviews: {String(error)}</p>;
+}
+
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews} errorElement={<ReviewsError />}>
+    {(r) => <ReviewList reviews={r} />}
+  </Await>
+</Suspense>
+```
+
 ## Sensitive Data
 
 Everything returned from a loader travels to the browser as JSON. Project to a safe DTO (`{ id, email, name }`) before returning; never return the full Prisma `User`, password hashes, API keys, or internal flags. Loaders execute server-only — but the *return value* is shipped to the client wholesale.

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/SKILL.md
@@ -57,7 +57,7 @@ Imports: `@remix-run/node` for server utilities (`json`, `redirect`, `defer`, ty
 
 ## When `json()` Is Optional in v2
 
-v2 did **not** change the underlying contract: loaders and actions must return a `Response`. `json()` is the ergonomic wrapper that sets `application/json` and lets you supply status / headers. Returning a bare object is not the documented v2 contract — do not assume the auto-wrapping behavior introduced in Remix 3 / React Router `dataStrategy`. Reach for `json()` whenever you need:
+v2 did **not** change the underlying contract: loaders and actions must return a `Response`. `json()` is the ergonomic wrapper that sets `application/json` and lets you supply status / headers. Bare object returns work in v2 (Remix auto-wraps as `json()`), but `json()` is preferred for explicit status, headers, and clean `TypedResponse<T>` typing. Reach for `json()` whenever you need:
 
 - A non-200 status code (e.g. `{ status: 400 }` for validation errors).
 - Custom headers (caching, `Set-Cookie`).
@@ -84,9 +84,9 @@ Loaders run on every GET navigation and may be invoked speculatively by prefetch
 
 ## Pending State (v1 → v2)
 
-`useTransition` is removed in v2 — use `useNavigation`. The `submission` object is flattened directly onto the navigation/fetcher (no more `transition.submission.formMethod`). `formMethod` is now **UPPERCASE** in v2 (`"POST"`, not `"post"`); comparisons like `nav.formMethod === "post"` silently never match. `fetcher.type` is also gone — branch on `fetcher.state` plus presence of `fetcher.formData`.
+`useTransition` is removed in v2 — use `useNavigation`. The `submission` object is flattened directly onto the navigation in v2 (and the fetcher likewise; both `nav.formData`/`nav.formMethod` and `fetcher.formData`/`fetcher.formMethod` are flat). `formMethod` is now **UPPERCASE** in v2 (`"POST"`, not `"post"`); comparisons like `nav.formMethod === "post"` silently never match. `fetcher.type` is also gone — branch on `fetcher.state` plus presence of `fetcher.formData`.
 
-GET submissions go `idle → loading → idle`. POST flow goes `idle → submitting → loading → idle`. Spinners gated only on `"submitting"` will miss GET forms.
+GET submissions go `idle → loading → idle`. POST flow goes `idle → submitting → loading → idle`. Spinners gated only on `"submitting"` will miss GET forms. GET submissions still populate `nav.formData` and `nav.formMethod === "GET"` during the `loading` phase, so filter-form pending UI should branch on `formData` presence, not on `state === 'submitting'`. For `useFetcher`, `submitting` applies to BOTH GET (`<fetcher.Form method='get'>` and `fetcher.submit(..., {method:'get'})`) and non-GET; only `fetcher.load()` skips `submitting`. This is the inverse of `useNavigation`, which skips `submitting` for GET.
 
 ## Gates (decision sequencing)
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: remix-v2-data-flow
+description: Remix v2 data loading and mutations. Use when writing loaders, actions, deferred data, revalidation logic, or pending state. Triggers on loader, action, useLoaderData, useActionData, json(), defer(), <Await>, shouldRevalidate, useRevalidator, useNavigation, useTransition (v1 holdover).
+---
+
+# Remix v2 Data Flow
+
+## Quick Reference
+
+**Loader + typed read**:
+```tsx
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const invoices = await db.invoice.findMany();
+  return json({ invoices });
+}
+
+export default function Invoices() {
+  // typeof loader is a type ANNOTATION (not assertion) — drives SerializeFrom<T>.
+  const { invoices } = useLoaderData<typeof loader>();
+  return <InvoiceList invoices={invoices} />;
+}
+```
+
+**Action + redirect-after-success (PRG)**:
+```tsx
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { useActionData, Form } from "@remix-run/react";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const parsed = NewProject.safeParse(Object.fromEntries(form));
+  if (!parsed.success) return json({ errors: parsed.error.flatten().fieldErrors }, { status: 400 });
+  const project = await db.project.create({ data: parsed.data });
+  return redirect(`/projects/${project.id}`);
+}
+```
+
+## Canonical APIs
+
+Route modules export `loader` / `action`; components read results via `useLoaderData<typeof loader>()` and `useActionData<typeof action>()`. After every action, Remix automatically revalidates the loaders of all matching routes on the page, so the UI stays consistent with the server without manual cache invalidation.
+
+Signatures:
+
+- `loader: ({ request, params, context }: LoaderFunctionArgs) => Response | Promise<Response>` — server-only read, runs on SSR and on client navigations via fetch.
+- `action: ({ request, params, context }: ActionFunctionArgs) => Response | Promise<Response>` — server-only handler for non-GET requests (POST/PUT/PATCH/DELETE).
+- `json(data, init?: number | ResponseInit): TypedResponse<typeof data>` — ergonomic JSON `Response` wrapper with status/headers.
+- `redirect(url, init?: number | ResponseInit): TypedResponse<never>` — 30x response; default 302.
+
+Imports: `@remix-run/node` for server utilities (`json`, `redirect`, `defer`, type args) on Node; substitute `@remix-run/cloudflare` or `@remix-run/deno` for those targets. Hooks and components come from `@remix-run/react`.
+
+## Type Annotations, Not Assertions
+
+`useLoaderData<typeof loader>()` is a **type annotation**, not a `as`-style assertion. The generic feeds `SerializeFrom<typeof loader>`, which models the wire-format transformation: `Date` becomes `string`, `Map`/`Set` collapse, `undefined` fields are stripped, class methods vanish. If you call `data.createdAt.getFullYear()` on a `Date` field, that's a runtime bug — the type already says `string`.
+
+## When `json()` Is Optional in v2
+
+v2 did **not** change the underlying contract: loaders and actions must return a `Response`. `json()` is the ergonomic wrapper that sets `application/json` and lets you supply status / headers. Returning a bare object is not the documented v2 contract — do not assume the auto-wrapping behavior introduced in Remix 3 / React Router `dataStrategy`. Reach for `json()` whenever you need:
+
+- A non-200 status code (e.g. `{ status: 400 }` for validation errors).
+- Custom headers (caching, `Set-Cookie`).
+- An explicit `TypedResponse<T>` for clean `useLoaderData<typeof loader>()` inference.
+
+## Throwing for Short-Circuits
+
+Throwing a `Response` from a loader or action exits the data function immediately. Use this for auth guards (`throw redirect("/login")`) and 404s (`throw new Response("Not Found", { status: 404 })` or `throw json({ message }, { status: 404 })`). Throwing a plain `Error` will not be classified as a route response by `useRouteError()` / `isRouteErrorResponse()`.
+
+## Sensitive Data
+
+Everything returned from a loader travels to the browser as JSON. Project to a safe DTO (`{ id, email, name }`) before returning; never return the full Prisma `User`, password hashes, API keys, or internal flags. Loaders execute server-only — but the *return value* is shipped to the client wholesale.
+
+## Mutations Belong in Actions
+
+Loaders run on every GET navigation and may be invoked speculatively by prefetch; they also re-run during automatic revalidation. Anything that mutates persistent state must live in `action`, reached via `<Form method="post">` or `useFetcher`. Calling `fetch()` directly from a component to hit a Remix route bypasses revalidation, pending state, and progressive enhancement — use `useFetcher().submit()` / `useFetcher().load()` instead.
+
+## Routing Gotchas to Remember
+
+- **Only the deepest matching action runs.** Index routes nested under a layout collide unless you target them with `<Form action="/things?index" method="post" />`.
+- **`useActionData` is scoped to the current route.** It cannot access action results from parent or child routes; to share, lift the action or use a `useFetcher` with `key`.
+- **Headers from the leaf loader win.** Remix only uses the deepest matching `headers` export. Parent caching policies are ignored unless you explicitly merge `parentHeaders`.
+- **Default revalidation revalidates ALL routes on the page after an action** — even those whose params didn't change. Use `shouldRevalidate` to opt out of expensive parent loaders.
+
+## Pending State (v1 → v2)
+
+`useTransition` is removed in v2 — use `useNavigation`. The `submission` object is flattened directly onto the navigation/fetcher (no more `transition.submission.formMethod`). `formMethod` is now **UPPERCASE** in v2 (`"POST"`, not `"post"`); comparisons like `nav.formMethod === "post"` silently never match. `fetcher.type` is also gone — branch on `fetcher.state` plus presence of `fetcher.formData`.
+
+GET submissions go `idle → loading → idle`. POST flow goes `idle → submitting → loading → idle`. Spinners gated only on `"submitting"` will miss GET forms.
+
+## Gates (decision sequencing)
+
+Answer **in order**. **Pass** means the condition is true; pick the API on the same line and **stop**.
+
+### `loader` vs `useEffect`
+
+1. **Is the data needed for correct first render** of this route (SSR, prefetch, automatic revalidation after actions)?
+   - **Pass →** `loader` + `useLoaderData<typeof loader>()`. **Stop.**
+   - **Fail →** Step 2.
+2. **Is the fetch driven by post-mount user interaction, timer, or subscription** (not route entry)?
+   - **Pass →** `useEffect` / event handlers. **Stop.**
+   - **Fail →** Prefer loader + revalidation; do not mirror navigation inside an effect.
+
+### `json()` vs raw `Response` vs `defer()`
+
+1. **Do any returned fields need to stream** (slow query, expensive aggregation) while the page renders fast?
+   - **Pass →** `defer({ critical: await…, slow: promiseWithoutAwait })` + `<Suspense><Await>…</Await></Suspense>`. **Stop.**
+   - **Fail →** Step 2.
+2. **Do you need a custom status code, custom headers, or explicit `TypedResponse<T>` typing**?
+   - **Pass →** `json(data, init)` (or `redirect(url, init)` for 3xx). **Stop.**
+   - **Fail →** Step 3.
+3. **Do you need a non-JSON body** (binary, plain text, streamed file)?
+   - **Pass →** Build a raw `new Response(body, init)`. **Stop.**
+   - **Fail →** Default to `json(data)` — it's the documented v2 contract for object payloads.
+
+### `<Form>` / route action vs `useFetcher`
+
+1. **Should the URL or history stack change** (bookmark / share / back returns to prior screen)?
+   - **Pass →** `<Form method="post">` posting to a route `action`. **Stop.**
+   - **Fail →** Step 2.
+2. **Mutation stays on the same route** (inline edit, list-row toggle, popover, optimistic UI)?
+   - **Pass →** `useFetcher()` / `fetcher.Form` / `fetcher.submit()`. **Stop.**
+
+## Additional Documentation
+
+- **Loaders**: See [references/loaders.md](references/loaders.md) for `loader` signature, typed `useLoaderData`, `json()` vs raw `Response`, `redirect()`, throwing, sensitive-data filtering, params handling.
+- **Actions**: See [references/actions.md](references/actions.md) for `action` signature, FormData parsing, `useActionData<typeof action>()`, zod/valibot validation, redirect-after-success.
+- **Defer & Await**: See [references/defer-await.md](references/defer-await.md) for `defer()` + `<Await>` + `<Suspense>`, when streaming helps TTFB, error handling.
+- **Revalidation & Pending State**: See [references/revalidation.md](references/revalidation.md) for automatic revalidation, `shouldRevalidate`, `useRevalidator`, `useNavigation` (plus v1 `useTransition` rename).
+
+## v1 → v2 Quick Diff
+
+| Concern              | v1                                  | v2                                               |
+|----------------------|-------------------------------------|--------------------------------------------------|
+| Navigation hook      | `useTransition()`                   | `useNavigation()`                                |
+| Submission shape     | `transition.submission.formMethod`  | flat `nav.formMethod` / `nav.formData`           |
+| `formMethod` casing  | `"post"`                            | `"POST"` (UPPERCASE)                             |
+| Fetcher type field   | `fetcher.type === "actionSubmission"` | branch on `fetcher.state` + `fetcher.formData` |
+| Loader args type     | `LoaderArgs` / `ActionArgs`         | `LoaderFunctionArgs` / `ActionFunctionArgs`      |
+| Returning data       | `json(data)` required               | `json(data)` still the documented contract       |

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/actions.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/actions.md
@@ -14,7 +14,7 @@ export async function action(
 }
 ```
 
-The v2 type name is `ActionFunctionArgs`. The v1 alias `ActionArgs` is deprecated.
+Deprecated alias still exported by `@remix-run/node` in 2.x — prefer the v2 name (`LoaderFunctionArgs` / `ActionFunctionArgs`).
 
 ## Parsing FormData
 
@@ -175,6 +175,8 @@ export default function SaveButton() {
 ```
 
 Missing pending UI is a real UX bug — users double-click and double-submit. Gate on `nav.state !== "idle"` (or `fetcher.state !== "idle"` for non-navigating mutations).
+
+For `useFetcher`, `submitting` applies to BOTH GET (`<fetcher.Form method='get'>` and `fetcher.submit(..., {method:'get'})`) and non-GET; only `fetcher.load()` skips `submitting`. This is the inverse of `useNavigation`, which skips `submitting` for GET.
 
 ## Action Anti-Pattern Recap
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/actions.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/actions.md
@@ -1,0 +1,191 @@
+# Actions
+
+Actions are server-only handlers for non-GET requests (POST, PUT, PATCH, DELETE) targeting a route. They are where data mutations live. Actions and loaders co-locate in the same route module: "loader = read, action = write."
+
+## Signature
+
+```ts
+import { type ActionFunctionArgs } from "@remix-run/node";
+
+export async function action(
+  { request, params, context }: ActionFunctionArgs,
+): Promise<Response> {
+  // ...
+}
+```
+
+The v2 type name is `ActionFunctionArgs`. The v1 alias `ActionArgs` is deprecated.
+
+## Parsing FormData
+
+```ts
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const title = form.get("title");
+  // ...
+}
+```
+
+`request.formData()` returns a standard `FormData`. Every value is `FormDataEntryValue` (`string | File`) — never trust the static type, always validate. Type assertions like `form.get("title") as string` hide injection and type-confusion bugs.
+
+## Validation with zod (or valibot)
+
+Server-side validation is mandatory; client validation can always be bypassed.
+
+```tsx
+// app/routes/projects.new.tsx
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { useActionData, Form } from "@remix-run/react";
+import { z } from "zod";
+
+const NewProject = z.object({
+  title: z.string().min(1).max(120),
+  description: z.string().max(2000).optional(),
+});
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const parsed = NewProject.safeParse(Object.fromEntries(form));
+
+  if (!parsed.success) {
+    return json(
+      {
+        errors: parsed.error.flatten().fieldErrors,
+        values: Object.fromEntries(form),
+      },
+      { status: 400 },
+    );
+  }
+
+  const project = await db.project.create({ data: parsed.data });
+  return redirect(`/projects/${project.id}`);
+}
+```
+
+Two important moves above:
+
+1. **Return a 400 on validation failure** so the form route still renders and the user sees inline errors.
+2. **Echo `values` back** so the form can rehydrate after a failed submit.
+
+valibot follows the same shape; substitute `safeParse` / `flatten()` equivalents per its API.
+
+## Typed `useActionData`
+
+```tsx
+export default function NewProject() {
+  const actionData = useActionData<typeof action>();
+
+  return (
+    <Form method="post">
+      <input name="title" defaultValue={(actionData?.values?.title as string) ?? ""} />
+      {actionData?.errors?.title && <p role="alert">{actionData.errors.title}</p>}
+      <button type="submit">Create</button>
+    </Form>
+  );
+}
+```
+
+`useActionData<typeof action>()` returns `SerializeFrom<typeof action> | undefined`. The same serialization rules from loaders apply (Dates become strings, undefined is stripped). It is **scoped to the current route** — it cannot read data from parent or child actions. To share an action result up or down the tree, lift the action to a higher route or use a `useFetcher` with a `key`.
+
+## Redirect-After-Success (PRG)
+
+The Post/Redirect/Get pattern is the v2 default for successful mutations: an action that returns a `redirect()` causes the browser to navigate to the target route, which prevents accidental re-submission on refresh and naturally surfaces the freshly mutated state.
+
+```ts
+const project = await db.project.create({ data: parsed.data });
+return redirect(`/projects/${project.id}`);
+```
+
+If you want to stay on the same route after success (e.g. an inline editor), return `json({ ok: true, project })` instead — but then you own pending UI and reset logic via `useActionData`.
+
+## Error Returns vs Throws
+
+| Outcome              | Mechanism                                              | Where it surfaces                    |
+|----------------------|--------------------------------------------------------|--------------------------------------|
+| Validation error     | `return json({ errors }, { status: 400 })`             | `useActionData<typeof action>()`     |
+| Auth failure         | `throw redirect("/login")`                             | Browser navigation                   |
+| 404 / 403            | `throw new Response(..., { status: 404 })` or `throw json({...}, { status: 404 })` | `ErrorBoundary` via `useRouteError()` |
+| Unexpected exception | Unhandled throw (any `Error`)                          | `ErrorBoundary` (no `status` field)  |
+
+An `action` that returns `null` / `undefined` with no error handling is an anti-pattern: `useActionData()` is `undefined`, errors are silently swallowed, and the user sees nothing. Either throw to the boundary or return `json({ error })` and render it.
+
+## Index Route Actions
+
+Only the deepest matching action runs. When a parent layout and its index child both define an action, target the index explicitly:
+
+```tsx
+<Form action="/things?index" method="post" />
+```
+
+Without `?index`, the layout action wins.
+
+## Fetcher Actions (No Navigation)
+
+For inline edits, list-row toggles, and optimistic UI, post to a route action without a URL change via `useFetcher`:
+
+```tsx
+import { useFetcher } from "@remix-run/react";
+
+export function StarButton({ project }: { project: Project }) {
+  const fetcher = useFetcher<typeof action>();
+
+  // Predict the next state from in-flight FormData for optimistic UI.
+  const starred = fetcher.formData
+    ? fetcher.formData.get("starred") === "1"
+    : project.starred;
+
+  return (
+    <fetcher.Form method="post" action={`/projects/${project.id}/star`}>
+      <input type="hidden" name="starred" value={starred ? "0" : "1"} />
+      <button aria-pressed={starred}>{starred ? "★" : "☆"}</button>
+    </fetcher.Form>
+  );
+}
+```
+
+After the fetcher resolves, Remix automatically revalidates affected loaders.
+
+## File Uploads
+
+`request.formData()` returns a `File` for `<input type="file">` fields. For large uploads, prefer `unstable_parseMultipartFormData` with `unstable_createFileUploadHandler` or `unstable_createMemoryUploadHandler` from `@remix-run/node` — the bare `request.formData()` buffers the entire body in memory.
+
+## Don't Hit Actions With Manual `fetch()`
+
+Calling `fetch("/projects/123/star", { method: "POST" })` from a component bypasses revalidation, pending state, progressive enhancement, and CSRF affordances built into `<Form>` and `useFetcher`. Use `useFetcher().submit()` or `useFetcher().load()` instead — same UX without a URL change, and Remix wires up the lifecycle for you.
+
+## Pending State on Submit
+
+```tsx
+import { useNavigation, Form } from "@remix-run/react";
+
+export default function SaveButton() {
+  const nav = useNavigation();
+  // POST flow: idle → submitting → loading → idle. GET: idle → loading → idle.
+  // formMethod is UPPERCASE in v2.
+  const busy = nav.state !== "idle" && nav.formMethod === "POST";
+
+  return (
+    <Form method="post">
+      <button type="submit" disabled={busy}>
+        {busy ? "Saving…" : "Save"}
+      </button>
+    </Form>
+  );
+}
+```
+
+Missing pending UI is a real UX bug — users double-click and double-submit. Gate on `nav.state !== "idle"` (or `fetcher.state !== "idle"` for non-navigating mutations).
+
+## Action Anti-Pattern Recap
+
+- **No server-side validation** — client validation is bypassable; always re-validate on the server with zod / valibot and return `{ status: 400 }` on failure.
+- **`form.get("title") as string`** — `FormDataEntryValue` is `string | File`; type assertions hide injection bugs. Parse with `Object.fromEntries(form)` and a schema.
+- **Returning `null` from an action** — `useActionData()` becomes `undefined` and errors are silently swallowed. Either `throw json({ message }, { status: 500 })` to hit `ErrorBoundary` or `return json({ error })`.
+- **No redirect after success** — re-rendering the same form route on success risks accidental re-submission on refresh. Redirect via PRG unless you have a specific reason to stay.
+- **Manual `fetch()` instead of `useFetcher`** — bypasses revalidation, pending state, and progressive enhancement.
+- **Forgetting `?index`** when posting from a layout to its index action — the layout action runs instead.
+
+## Cross-Reference
+
+- Loader-side details: see [loaders.md](loaders.md) for `useLoaderData<typeof loader>()` typing, `redirect()` semantics, and sensitive-data filtering — the same rules apply to action returns.
+- Pending UI and revalidation: see [revalidation.md](revalidation.md) for `useNavigation`, `useFetcher`, `useRevalidator`, `shouldRevalidate`, and the v1 → v2 `useTransition` rename.

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/defer-await.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/defer-await.md
@@ -21,6 +21,7 @@ Defer does **not** help when:
 import { defer } from "@remix-run/node";
 
 defer(data, init?: number | ResponseInit): TypedDeferredData;
+// (numeric status shorthand was added in Remix 2.5+; pre-2.5 requires `defer(data, { status: 404 })`)
 ```
 
 `data` may contain plain values *and* unresolved promises in any field. Remix serializes the resolved values eagerly and streams the rest.
@@ -105,7 +106,7 @@ Inside the render prop, `rs` is fully typed via `SerializeFrom` — same seriali
 ## Compatibility Notes
 
 - `defer()` requires a streaming-capable runtime adapter. Node (`@remix-run/node`) and Cloudflare (`@remix-run/cloudflare`) both support it. Some older serverless adapters buffer responses and break streaming — verify your deploy target supports HTTP streaming end-to-end before depending on `defer()` for TTFB.
-- `defer()` returns a `TypedDeferredData`, not a `TypedResponse`. You cannot wrap a `defer()` result in `json()` or vice versa — pick one per loader.
+- `defer()` returns a `TypedDeferredData<T>`, not a `TypedResponse`. You cannot wrap a `defer()` result in `json()` or vice versa — pick one per loader.
 
 ## When to Use Plain `json()` Instead
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/defer-await.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/defer-await.md
@@ -1,0 +1,158 @@
+# Defer & Await — Streaming Loader Data
+
+`defer()` lets a loader return a streamed/deferred response that may contain unresolved promises. The browser receives the critical data immediately; slow data resolves over the same HTTP connection and triggers a `<Suspense>` reveal when ready.
+
+## When Streaming Helps TTFB
+
+Defer pays off when:
+
+- One query dominates the loader's wall-clock time (e.g. an aggregation, a third-party API call, a slow report) **and**
+- The rest of the page is useful on its own (header, nav, primary record).
+
+Defer does **not** help when:
+
+- All queries are fast (you just add Suspense overhead for no win).
+- The slow query *is* the critical first paint (no useful UI without it).
+- You return a deferred promise but `await` it before constructing `defer()` — that defeats streaming entirely (see anti-pattern below).
+
+## Signature
+
+```ts
+import { defer } from "@remix-run/node";
+
+defer(data, init?: number | ResponseInit): TypedDeferredData;
+```
+
+`data` may contain plain values *and* unresolved promises in any field. Remix serializes the resolved values eagerly and streams the rest.
+
+## Canonical Pattern
+
+```tsx
+// app/routes/product.$id.tsx
+import { defer, type LoaderFunctionArgs } from "@remix-run/node";
+import { Await, useLoaderData } from "@remix-run/react";
+import { Suspense } from "react";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  // Critical data is awaited so the page can't render meaningfully without it.
+  const product = await db.product.findUnique({ where: { id: params.id } });
+
+  // Slow data is NOT awaited — pass the raw promise so it can stream.
+  const reviews = db.review.findMany({ where: { productId: params.id } });
+
+  return defer({ product, reviews });
+}
+
+export default function ProductPage() {
+  const { product, reviews } = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <ProductHeader product={product} />
+
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Await resolve={reviews} errorElement={<p>Failed to load reviews</p>}>
+          {(rs) => <ProductReviews reviews={rs} />}
+        </Await>
+      </Suspense>
+    </>
+  );
+}
+```
+
+Three rules — all required:
+
+1. **Don't await the slow promise** before passing it to `defer()`. The whole point is to ship the unresolved promise.
+2. **Wrap every `<Await>` in a `<Suspense fallback={…}>`**. React throws without a fallback boundary; there's nothing to render while the promise is pending.
+3. **Provide `errorElement`** on every `<Await>` (next section).
+
+## Error Handling in `<Await>`
+
+A rejected deferred promise without an `errorElement` bubbles to the nearest route `ErrorBoundary` — which kills the whole page instead of degrading just the slow section. Always provide an inline fallback:
+
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await
+    resolve={reviews}
+    errorElement={<p role="alert">Reviews are temporarily unavailable.</p>}
+  >
+    {(rs) => <ProductReviews reviews={rs} />}
+  </Await>
+</Suspense>
+```
+
+If you want the error to reach a child `ErrorBoundary` instead of being swallowed inline, you can re-throw from a render-prop wrapper — but the default expectation is graceful, in-place degradation.
+
+## Reading the Deferred Value
+
+`useLoaderData<typeof loader>()` returns the promise field as `Promise<T>` in the component. You never `.then()` it manually — `<Await resolve={…}>` handles the unwrap and re-render. The render prop receives the resolved value:
+
+```tsx
+<Await resolve={reviews}>
+  {(rs) => <ProductReviews reviews={rs} />}
+</Await>
+```
+
+Inside the render prop, `rs` is fully typed via `SerializeFrom` — same serialization rules as a regular loader return (Dates become strings, etc.).
+
+## Anti-Patterns
+
+- **`await` before `defer`**: `const reviews = await db.review.findMany(...); return defer({ product, reviews });` makes `defer` behave exactly like `json` — nothing streams.
+- **`<Await>` without `<Suspense>`**: React throws because there's no fallback.
+- **Missing `errorElement`**: A single slow query failure tears down the whole route.
+- **Streaming everything**: If every field is deferred, the user stares at fallbacks. Resolve the critical record synchronously; only defer the long tail.
+
+## Compatibility Notes
+
+- `defer()` requires a streaming-capable runtime adapter. Node (`@remix-run/node`) and Cloudflare (`@remix-run/cloudflare`) both support it. Some older serverless adapters buffer responses and break streaming — verify your deploy target supports HTTP streaming end-to-end before depending on `defer()` for TTFB.
+- `defer()` returns a `TypedDeferredData`, not a `TypedResponse`. You cannot wrap a `defer()` result in `json()` or vice versa — pick one per loader.
+
+## When to Use Plain `json()` Instead
+
+If the slow query is fast in practice (P95 < 100ms), or if the page is meaningless without it, just `await` it inside the loader and return `json()`. Defer adds a `<Suspense>` boundary and a render flicker — only worth it when the TTFB win is real.
+
+## Multiple Deferred Fields
+
+You can stream more than one field; each `<Await>` resolves independently as its promise settles.
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = await db.product.findUnique({ where: { id: params.id } });
+  const reviews = db.review.findMany({ where: { productId: params.id } });
+  const related = db.product.findRelated(params.id!);
+  return defer({ product, reviews, related });
+}
+
+export default function ProductPage() {
+  const { product, reviews, related } = useLoaderData<typeof loader>();
+  return (
+    <>
+      <ProductHeader product={product} />
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Await resolve={reviews} errorElement={<p>Reviews unavailable.</p>}>
+          {(rs) => <ProductReviews reviews={rs} />}
+        </Await>
+      </Suspense>
+      <Suspense fallback={<RelatedSkeleton />}>
+        <Await resolve={related} errorElement={<p>Related items unavailable.</p>}>
+          {(items) => <RelatedProducts items={items} />}
+        </Await>
+      </Suspense>
+    </>
+  );
+}
+```
+
+## Interaction with Revalidation
+
+After every action, Remix re-runs loaders for matching routes — including loaders that returned `defer()`. The new deferred promises replace the old ones, and `<Await>` will re-suspend until the new ones resolve. You don't need to invalidate manually; the same `useLoaderData<typeof loader>()` call picks up the fresh promises.
+
+## Picking the Right Tool
+
+| Goal                                                | API                |
+|-----------------------------------------------------|--------------------|
+| One slow query, rest of page is useful immediately  | `defer()` + `<Await>` |
+| All queries fast, want simple data + types          | `json()`           |
+| Need explicit status / headers / typing             | `json(data, init)` |
+| Auth guard / 404 short-circuit                      | `throw redirect()` / `throw new Response(...)` |
+| Binary / streamed file body                         | Raw `new Response(stream, init)` |

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/loaders.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/loaders.md
@@ -1,0 +1,221 @@
+# Loaders
+
+Loaders are server-only data-fetch functions exported from a route module. Remix calls them during SSR and on every client navigation that lands on the route. You never call a loader directly — "Remix will call your loaders for you; in no case should you ever try to call your loader directly."
+
+## Signature
+
+```ts
+import { type LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader(
+  { request, params, context }: LoaderFunctionArgs,
+): Promise<Response> {
+  // ...
+}
+```
+
+- `request` — standard `Request`. Use `new URL(request.url)` to read search params, `request.headers` for cookies / `Authorization`.
+- `params` — route params from the file/segment definition. Values are typed `string | undefined` — always guard before passing to a DB query.
+- `context` — adapter-supplied context (Cloudflare bindings, Express locals via the Node adapter, etc.).
+
+The v2 type name is `LoaderFunctionArgs`. The v1 name `LoaderArgs` may still exist as a deprecated alias — prefer the v2 name.
+
+## Typed `useLoaderData`
+
+```tsx
+import { useLoaderData } from "@remix-run/react";
+
+export default function Invoices() {
+  const { invoices, status } = useLoaderData<typeof loader>();
+  return <InvoiceList invoices={invoices} activeStatus={status} />;
+}
+```
+
+`useLoaderData<typeof loader>()` is a **type annotation**, not a `as`-style assertion. Internally it resolves to `SerializeFrom<typeof loader>`, which models the on-the-wire transformation:
+
+- `Date` becomes `string`.
+- `Map` / `Set` collapse to empty object / array shapes.
+- `undefined` fields are stripped.
+- Class instances lose their methods (just plain data survives).
+
+If your component calls `data.createdAt.getFullYear()`, the type already says `string` — that's a real bug, not a tooling complaint.
+
+## `json()` — Status, Headers, Typing
+
+```ts
+import { json } from "@remix-run/node";
+
+return json({ invoices }, { status: 200, headers: { "Cache-Control": "private, max-age=10" } });
+return json({ errors }, { status: 400 });
+return json({ user }, 201); // numeric shorthand for status
+```
+
+`json(data, init?)` is a shortcut for an `application/json` response with the given status and headers. The return type is `TypedResponse<typeof data>` — that's what lets `useLoaderData<typeof loader>()` infer the payload through `SerializeFrom`.
+
+### When `json()` Is Optional in v2
+
+v2 did **not** change the underlying contract: loaders must return a `Response`. `json()` is the ergonomic wrapper. Returning a bare object is not the documented v2 contract — do not assume the auto-wrapping behavior of Remix 3 / React Router `dataStrategy`. Reach for `json()` whenever you need a non-200 status, custom headers, or explicit `TypedResponse<T>` inference.
+
+## `redirect()`
+
+```ts
+import { redirect } from "@remix-run/node";
+
+throw redirect("/login");
+return redirect(`/projects/${project.id}`, {
+  headers: { "Set-Cookie": await commitSession(session) },
+});
+```
+
+`redirect(url, init?)` is a shortcut for 30x responses. Default status is `302`; supports `301` / `303` / `307` and any standard `Response` init (including `Set-Cookie`).
+
+## Throwing for Short-Circuits
+
+Throwing a `Response` exits the data function immediately — useful for auth guards and 404s.
+
+```ts
+// app/utils/auth.server.ts
+export async function requireUser(request: Request) {
+  const user = await getUser(request);
+  if (!user) throw redirect("/login");
+  return user;
+}
+
+// In a loader:
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireUser(request);
+  return json({ user });
+}
+```
+
+Throw `new Response("Not Found", { status: 404 })` or `throw json({ message }, { status: 404 })` for 404s — `useRouteError()` + `isRouteErrorResponse()` will then expose `status` / `statusText` to your `ErrorBoundary`. Throwing a plain `Error` will not classify as a route response.
+
+## Filtering Sensitive Data
+
+Loaders run server-only, but their return values ship to the browser as JSON. Project to a safe DTO before returning.
+
+```ts
+// Bad — leaks passwordHash, internal flags
+const user = await db.user.findUnique({ where: { id } });
+return json({ user });
+
+// Good
+const user = await db.user.findUnique({
+  where: { id },
+  select: { id: true, email: true, name: true },
+});
+return json({ user });
+```
+
+If you must fetch the full record (to do server-side work), strip before return:
+
+```ts
+const full = await db.user.findUnique({ where: { id } });
+const { passwordHash, internalNotes, ...safe } = full!;
+return json({ user: safe });
+```
+
+## Params: Always Guard
+
+`params` values are `string | undefined`. Downstream DB lookups silently coerce or query `undefined`.
+
+```ts
+import invariant from "tiny-invariant";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  invariant(params.projectId, "projectId required");
+  const project = await db.project.findUnique({ where: { id: params.projectId } });
+  if (!project) throw new Response("Not Found", { status: 404 });
+  return json({ project });
+}
+```
+
+Or parse with zod for richer shapes:
+
+```ts
+const ParamsSchema = z.object({ projectId: z.string().uuid() });
+const { projectId } = ParamsSchema.parse(params);
+```
+
+## Reading Search Params
+
+```ts
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const status = url.searchParams.get("status") ?? "open";
+  const invoices = await db.invoice.findMany({ where: { status } });
+  return json({ invoices, status });
+}
+```
+
+## Don't Mutate in Loaders
+
+Loaders run on every GET and may be invoked speculatively by prefetch; revalidation re-runs them after every action. Any mutation inside a loader will replay. Writes belong in `action`.
+
+## Don't Re-Define Data in Child Loaders
+
+Re-loading the same query in a parent and child means two sources of truth, doubled DB load, and divergent shapes after revalidation. Load once at the highest matching route and read from children via `useMatches` / `useRouteLoaderData`.
+
+## `.server` Suffix
+
+Modules with a `.server.ts` / `.server.tsx` suffix are never bundled to the client. Import DB clients, secrets, and crypto helpers from `~/db.server`, `~/auth.server`, etc., so a stray browser-side import of a server-only utility fails fast at build time rather than leaking secrets.
+
+## Sharing Data Across Routes — `useRouteLoaderData`
+
+When a child route needs data already loaded by an ancestor, don't refetch — read the parent's loader data directly.
+
+```tsx
+// app/root.tsx
+export async function loader() {
+  return json({ user: await getCurrentUser() });
+}
+
+// app/routes/dashboard.tsx
+import { useRouteLoaderData } from "@remix-run/react";
+import type { loader as rootLoader } from "~/root";
+
+export default function Dashboard() {
+  const data = useRouteLoaderData<typeof rootLoader>("root");
+  return <h1>Welcome, {data?.user.name}</h1>;
+}
+```
+
+The string id matches the route module's id (`"root"` for `app/root.tsx`; file-based ids for nested routes). Pair with `typeof rootLoader` to keep `SerializeFrom`-aware typing.
+
+## Headers from the Leaf Loader Win
+
+Only the deepest matching `headers` export is used by default; parent caching policies are ignored unless you merge them yourself.
+
+```ts
+// app/routes/products.$id.tsx
+import type { HeadersFunction } from "@remix-run/node";
+
+export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? parentHeaders.get("Cache-Control") ?? "no-store",
+});
+```
+
+## Response Caching
+
+For per-route caching, set `Cache-Control` via the `init` argument to `json()`:
+
+```ts
+return json(
+  { product },
+  {
+    headers: {
+      "Cache-Control": "private, max-age=60, stale-while-revalidate=300",
+    },
+  },
+);
+```
+
+Choose `private` for user-specific data; `public` only when the response is identical for every viewer.
+
+## Quick Anti-Pattern Recap
+
+- **Fetching in `useEffect` what belongs in a loader** — defeats SSR, creates waterfalls, skips automatic revalidation.
+- **Mutating in a loader** — loaders run on GETs and may be prefetched; writes belong in `action`.
+- **Returning sensitive fields** — everything goes to the browser as JSON; project to a safe DTO.
+- **Reading `params.foo` without guarding** — values are `string | undefined`; use `invariant` or zod.
+- **Asserting types instead of annotating** — `useLoaderData<typeof loader>()` is an annotation that drives `SerializeFrom`; never `useLoaderData() as Foo`.

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/loaders.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/loaders.md
@@ -18,7 +18,7 @@ export async function loader(
 - `params` — route params from the file/segment definition. Values are typed `string | undefined` — always guard before passing to a DB query.
 - `context` — adapter-supplied context (Cloudflare bindings, Express locals via the Node adapter, etc.).
 
-The v2 type name is `LoaderFunctionArgs`. The v1 name `LoaderArgs` may still exist as a deprecated alias — prefer the v2 name.
+Deprecated alias still exported by `@remix-run/node` in 2.x — prefer the v2 name (`LoaderFunctionArgs` / `ActionFunctionArgs`).
 
 ## Typed `useLoaderData`
 
@@ -34,7 +34,7 @@ export default function Invoices() {
 `useLoaderData<typeof loader>()` is a **type annotation**, not a `as`-style assertion. Internally it resolves to `SerializeFrom<typeof loader>`, which models the on-the-wire transformation:
 
 - `Date` becomes `string`.
-- `Map` / `Set` collapse to empty object / array shapes.
+- `Map` and `Set` both serialize to `{}` (no own-enumerable entries).
 - `undefined` fields are stripped.
 - Class instances lose their methods (just plain data survives).
 
@@ -54,7 +54,7 @@ return json({ user }, 201); // numeric shorthand for status
 
 ### When `json()` Is Optional in v2
 
-v2 did **not** change the underlying contract: loaders must return a `Response`. `json()` is the ergonomic wrapper. Returning a bare object is not the documented v2 contract — do not assume the auto-wrapping behavior of Remix 3 / React Router `dataStrategy`. Reach for `json()` whenever you need a non-200 status, custom headers, or explicit `TypedResponse<T>` inference.
+v2 did **not** change the underlying contract: loaders must return a `Response`. `json()` is the ergonomic wrapper. Bare object returns work in v2 (Remix auto-wraps as `json()`), but `json()` is preferred for explicit status, headers, and clean `TypedResponse<T>` typing. Reach for `json()` whenever you need a non-200 status, custom headers, or explicit `TypedResponse<T>` inference.
 
 ## `redirect()`
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/revalidation.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/revalidation.md
@@ -111,7 +111,7 @@ The shape: `{ state, location, formData, formAction, formMethod }`. The `submiss
 
 ### v1 `useTransition` → v2 `useNavigation`
 
-If you see `useTransition` from `@remix-run/react` in a codebase, it's a v1 holdover and will no longer compile against v2. Replacements:
+If you see `useTransition` from `@remix-run/react`, it's a v1 holdover. In `@remix-run/react@2.x` it still exists as a deprecated forwarder to `useNavigation`, so code compiles — schedule for replacement before the next major. Replacements:
 
 | v1                                       | v2                                              |
 |------------------------------------------|-------------------------------------------------|

--- a/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/revalidation.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-data-flow/references/revalidation.md
@@ -1,0 +1,182 @@
+# Revalidation & Pending State
+
+Remix keeps the UI in sync with the server by re-running loaders automatically after every action. You almost never need to wire up cache invalidation by hand.
+
+## Automatic Revalidation
+
+The default behavior, restated from the Remix data-flow discussion:
+
+1. Route loaders provide data to the UI.
+2. Forms post data to route actions that update persistent state.
+3. **Loader data on the page is automatically revalidated** after every action.
+
+After a `<Form method="post">` submit or a `fetcher.submit()`, Remix runs the action, then re-runs every loader of every currently matched route on the page — even loaders whose params didn't change. The result: every `useLoaderData<typeof loader>()` reads fresh data without manual invalidation.
+
+## `shouldRevalidate` — Opt Out
+
+For expensive loaders that don't depend on the action, opt out via the route module's `shouldRevalidate` export.
+
+```ts
+import type { ShouldRevalidateFunction } from "@remix-run/react";
+
+export const shouldRevalidate: ShouldRevalidateFunction = ({
+  currentParams,
+  currentUrl,
+  nextParams,
+  nextUrl,
+  formMethod,
+  formAction,
+  formData,
+  actionResult,
+  defaultShouldRevalidate,
+}) => {
+  // Re-validate by default, except for parent search-param changes that
+  // don't affect this route's data.
+  if (currentUrl.pathname === nextUrl.pathname && currentParams === nextParams) {
+    return false;
+  }
+  return defaultShouldRevalidate;
+};
+```
+
+A common safe use is a root loader that returns static env config:
+
+```ts
+// app/root.tsx
+export const loader = async () =>
+  json({ env: { APP_URL: process.env.APP_URL } });
+
+export const shouldRevalidate: ShouldRevalidateFunction = () => false;
+```
+
+### Don't Return `false` Unconditionally Without Thought
+
+The docs warn: "This makes it possible for your UI to get out of sync with your server if you do it wrong, so be careful." A permanent opt-out causes stale data after the user's own mutations. Default to `defaultShouldRevalidate` and only suppress the narrow cases where you can prove the loader's inputs haven't changed.
+
+## `useRevalidator` — Manual Trigger
+
+For pull-style refresh (window focus, polling, server-sent events) use `useRevalidator`.
+
+```tsx
+import { useRevalidator } from "@remix-run/react";
+import { useEffect } from "react";
+
+export function useRevalidateOnFocus() {
+  const { revalidate, state } = useRevalidator();
+
+  useEffect(() => {
+    function onFocus() {
+      if (state === "idle") revalidate();
+    }
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [revalidate, state]);
+}
+```
+
+`useRevalidator()` returns `{ revalidate(): void; state: "idle" | "loading" }`. Always gate the call on `state === "idle"` — multiple concurrent revalidations fire overlapping loader calls.
+
+> If you find yourself using `useRevalidator` for normal CRUD operations, you're probably skipping `<Form>` / `useSubmit` / `useFetcher` and reinventing the automatic revalidation.
+
+### Polling Gotchas
+
+- Synchronized polling from many tabs / users can DDoS your origin. Add jitter.
+- Pause polling while the user is scrolling or interacting.
+- Concurrent revalidations duplicate DB queries — `state === "idle"` is a real guard.
+
+## `useNavigation` — Pending UI
+
+`useNavigation()` returns the in-flight navigation/submission state for the whole app (not scoped to one form). It is the v2 replacement for v1's `useTransition`.
+
+```tsx
+import { useNavigation, Form } from "@remix-run/react";
+
+export default function SaveButton() {
+  const nav = useNavigation();
+  // POST: idle → submitting → loading → idle.
+  // GET:  idle → loading → idle.
+  const busy = nav.state !== "idle" && nav.formMethod === "POST";
+
+  return (
+    <Form method="post">
+      <button type="submit" disabled={busy}>
+        {busy ? "Saving…" : "Save"}
+      </button>
+    </Form>
+  );
+}
+```
+
+The shape: `{ state, location, formData, formAction, formMethod }`. The `submission` object from v1 is flattened directly onto the navigation; there is no `nav.submission.formMethod` in v2.
+
+### v1 `useTransition` → v2 `useNavigation`
+
+If you see `useTransition` from `@remix-run/react` in a codebase, it's a v1 holdover and will no longer compile against v2. Replacements:
+
+| v1                                       | v2                                              |
+|------------------------------------------|-------------------------------------------------|
+| `useTransition()`                        | `useNavigation()`                               |
+| `transition.submission.formMethod`       | `nav.formMethod`                                |
+| `transition.submission.formData`         | `nav.formData`                                  |
+| `transition.state === "submitting"`      | `nav.state === "submitting"`                    |
+| `transition.type === "actionSubmission"` | `nav.state === "submitting" && nav.formMethod !== "GET"` |
+
+(Note: React 18 / React 19 also export a `useTransition` from `react` itself — that hook is unrelated and has a different API. The collision is unfortunate; the Remix one is gone, the React one stays.)
+
+### `formMethod` Is UPPERCASE in v2
+
+```ts
+nav.formMethod === "POST" // correct
+nav.formMethod === "post" // silently never matches — v1 lowercase holdover
+```
+
+`useNavigation`, `useFetcher`, and `shouldRevalidate` all return UPPERCASE methods in v2. Greping a v2 codebase for `=== "post"` (lowercase) is a fast way to surface broken pending-state checks.
+
+### `fetcher.type` Is Gone
+
+v1 code like `if (fetcher.type === "actionSubmission")` no longer compiles. Branch instead on `fetcher.state` plus presence of `fetcher.formData`:
+
+```ts
+const submitting = fetcher.state === "submitting" && fetcher.formData != null;
+```
+
+### GET Submissions Skip "submitting"
+
+A `<Form method="get">` goes `idle → loading → idle` — never enters `"submitting"`. Spinners gated only on `state === "submitting"` will silently miss GET form filtering.
+
+## Decision Sketch
+
+| Goal                                                     | API                                       |
+|----------------------------------------------------------|-------------------------------------------|
+| Refetch loaders after a write                            | Nothing — Remix does it automatically     |
+| Opt out of revalidation for an expensive parent loader   | `shouldRevalidate` returning `false`      |
+| Refetch on window focus / interval / SSE message         | `useRevalidator` (gate on `state === "idle"`) |
+| Show pending state during navigation / submission        | `useNavigation`                           |
+| Show pending state for an inline (non-nav) mutation      | `fetcher.state` + `fetcher.formData`      |
+
+## Optimistic UI from `fetcher.formData`
+
+A fetcher exposes the FormData it's currently submitting. Read it to predict the next state before the server has responded.
+
+```tsx
+import { useFetcher } from "@remix-run/react";
+
+export function StarButton({ project }: { project: Project }) {
+  const fetcher = useFetcher<typeof action>();
+  const starred = fetcher.formData
+    ? fetcher.formData.get("starred") === "1"
+    : project.starred;
+  return (
+    <fetcher.Form method="post" action={`/projects/${project.id}/star`}>
+      <input type="hidden" name="starred" value={starred ? "0" : "1"} />
+      <button aria-pressed={starred}>{starred ? "★" : "☆"}</button>
+    </fetcher.Form>
+  );
+}
+```
+
+When the fetcher resolves, automatic revalidation refreshes loader data and the component reconciles to the server's truth — no manual rollback code.
+
+## `v2_normalizeFormMethod` Future Flag
+
+In late Remix v1 (1.16+), the `v2_normalizeFormMethod` future flag opted in early to the v2 UPPERCASE-method behavior described above. In a true v2 codebase the flag is a no-op (the behavior is the default), but if you're working on a v1→v2 migration branch, enabling that flag *before* the version bump lets you fix `formMethod` comparisons incrementally.

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/SKILL.md
@@ -139,6 +139,6 @@ passes** for the batch you are about to report.
 - Reviewing thrown `Response` / `json` patterns, `handleError`, or return-vs-throw → [references/throw-response.md](references/throw-response.md)
 - Reviewing `app/root.tsx` boundary scaffolding → [references/root-boundary.md](references/root-boundary.md)
 - Detecting v1 holdovers (`CatchBoundary`, `useCatch`, `v2_errorBoundary`) → [references/v1-holdovers.md](references/v1-holdovers.md)
-- Remix v2 ErrorBoundary docs: https://v2.remix.run/docs/route/error-boundary/
-- Remix v2 error handling guide: https://v2.remix.run/docs/guides/errors/
-- Remix v2 `entry.server` / `handleError` docs: https://v2.remix.run/docs/file-conventions/entry.server/
+- Remix v2 ErrorBoundary docs: https://remix.run/docs/en/main/route/error-boundary
+- Remix v2 error handling guide: https://remix.run/docs/en/main/guides/errors
+- Remix v2 `entry.server` / `handleError` docs: https://remix.run/docs/en/main/file-conventions/entry.server

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: remix-v2-error-boundaries-review
+description: Reviews Remix v2 error-handling code for the unified ErrorBoundary, isRouteErrorResponse narrowing, throw-vs-return, root boundary scaffolding, and v1 holdovers (CatchBoundary, useCatch). Use when reviewing routes that throw or define ErrorBoundary in a Remix v2 codebase.
+---
+
+# Remix v2 Error Boundaries Code Review
+
+Targets TypeScript route modules importing from `@remix-run/*`. No sibling
+knowledge skill exists for this topic; the canonical mental model is
+summarized inline below and expanded in `references/`.
+
+## v2 Boundary Model (read first)
+
+Remix v2 unified v1's `CatchBoundary` + `ErrorBoundary` into a **single**
+`ErrorBoundary` route-module export. The framework calls it for **both**
+thrown `Response`s (e.g. `throw new Response(...)`, `throw json(...)`)
+**and** thrown runtime errors (loader/action/render exceptions). Inside
+the boundary you read the value with the `useRouteError()` hook, then
+narrow in this order:
+
+1. `isRouteErrorResponse(error)` → it was a thrown `Response`; read
+   `error.status`, `error.statusText`, `error.data`.
+2. `error instanceof Error` → real runtime error; read `error.message`.
+3. else → unknown thrown value; render a generic fallback.
+
+The boundary takes **no props**. `CatchBoundary`, `useCatch`, and the
+`future.v2_errorBoundary` flag are all gone — finding any of them is a
+v1 holdover. Errors render the *nearest* `ErrorBoundary` and bubble to
+the root if none exists; the root boundary remounts the whole document,
+so it must render `<Meta />`, `<Links />`, and `<Scripts />`. Only
+**thrown** loader/action results reach the boundary — a `return json(...)`
+with a 4xx status is a successful loader, not an error. Server-side
+runtime errors also flow through an optional `entry.server.tsx`
+`handleError` export (thrown `Response`s do *not*).
+
+## Quick Reference
+
+| Issue Type | Reference |
+|------------|-----------|
+| Missing route `ErrorBoundary`, props-on-boundary, narrowing-only `instanceof Error`, narrowing-only `isRouteErrorResponse` | [references/boundary-shape.md](references/boundary-shape.md) |
+| Return-instead-of-throw 4xx/5xx, swallowing `error.data`, throwing strings, missing `handleError` | [references/throw-response.md](references/throw-response.md) |
+| Missing root boundary, root boundary without `<Meta />`/`<Links />`/`<Scripts />`, `useLoaderData()` in root boundary | [references/root-boundary.md](references/root-boundary.md) |
+| `CatchBoundary` export, `useCatch` import, `v2_errorBoundary` future flag | [references/v1-holdovers.md](references/v1-holdovers.md) |
+
+## Review Checklist
+
+- [ ] `ErrorBoundary` declared `export function ErrorBoundary()` with **no** props
+- [ ] Error read via `useRouteError()`, not `useCatch()` and not a prop
+- [ ] Narrowing checks `isRouteErrorResponse(error)` **first**, then `error instanceof Error`, then fallback
+- [ ] `error.data` rendered defensively (typed/narrowed before going into JSX)
+- [ ] 4xx / 5xx in loaders/actions use `throw` (not `return`) for `Response` / `json`
+- [ ] Routes that can throw export their own `ErrorBoundary` (don't tear down parents for a widget failure)
+- [ ] Root `app/root.tsx` exports an `ErrorBoundary` that renders `<Meta />`, `<Links />`, and `<Scripts />`
+- [ ] Root boundary uses `useRouteLoaderData("root")` (not `useLoaderData()`) when reading root data
+- [ ] No `CatchBoundary` export anywhere; no `useCatch` import; no `future.v2_errorBoundary` in `remix.config.js`
+- [ ] `entry.server.tsx` exports `handleError` and pipes runtime errors to an error reporter
+- [ ] `handleError` does **not** assume thrown `Response`s flow through it (they don't)
+- [ ] Thrown values are `Response`/`json`/`Error` instances — never plain strings or POJOs
+
+## Valid Patterns (Do NOT Flag)
+
+These are correct Remix v2 usage and must not be reported as issues:
+
+- **Route without `ErrorBoundary` that intentionally inherits from a parent** — Boundaries cascade up. A child route may omit `ErrorBoundary` so the parent (or root) renders the fallback. Only flag if the route handles user-distinct error UX *and* a parent boundary cannot.
+- **`throw new Response(...)` or `throw json(...)` from a loader/action** — The canonical way to signal 404/401/403/etc. This is *not* "using exceptions for control flow"; it is documented v2 contract.
+- **Narrowing only with `isRouteErrorResponse(error)`** — Acceptable when the route demonstrably only throws `Response`s and has no render-time crash risk. Severity is **ADVISORY at most**; suggest adding an `instanceof Error` branch for defense-in-depth, do not flag as a bug.
+- **`ErrorBoundary` that does not call `useRouteError()`** — Valid when the boundary renders a static "Something went wrong" fallback intentionally (e.g. marketing pages that don't want to surface error detail).
+- **Root `ErrorBoundary` calling `useRouteLoaderData("root")` and getting `undefined`** — Documented defensive pattern (root loader may have thrown). Do not flag the `undefined` handling as "dead code."
+- **`handleError` returning early on `request.signal.aborted`** — Documented noise filter, not a swallowed error.
+- **`handleError` not handling thrown `Response`s** — By framework contract `handleError` only fires for runtime errors. The absence of `Response` handling is correct, not a gap.
+- **Nested `ErrorBoundary` returning a bare fragment (no `<html>` / `<body>`)** — Only the root boundary owns the document. Nested boundaries render *inside* parent layouts and must not include document tags.
+
+## Severity guidance
+
+Use these defaults unless the codebase has documented a different scale:
+
+| Pattern | Default severity |
+|---|---|
+| `CatchBoundary` export or `useCatch` import in v2 codebase | BLOCKER (build-breaking or dead code) |
+| Root `ErrorBoundary` missing `<Scripts />` | BLOCKER (dead-end error page) |
+| `ErrorBoundary` with `({ error })` v1 prop signature | WARN (silent runtime undefined) |
+| `return json(...)` for 4xx instead of `throw` | WARN (boundary never fires) |
+| Missing `instanceof Error` branch on a route with render-crash risk | WARN |
+| Missing `instanceof Error` branch on a Response-only route | ADVISORY |
+| `useLoaderData()` (vs `useRouteLoaderData`) in root boundary | WARN (latent loop) |
+| Missing `handleError` in `entry.server.tsx` | ADVISORY (observability gap, not a bug) |
+
+## Hard gates (before writing findings)
+
+Run in order. **Do not draft user-facing findings until every gate
+passes** for the batch you are about to report.
+
+1. **Location evidence** — **Pass:** Each issue lists the repo path to
+   the route module (or `app/root.tsx`, or `app/entry.server.tsx`) and
+   either a line range or a short verbatim quote from the file you read
+   (not from memory or diff-only guesswork). "The root boundary is
+   wrong" without a path to `app/root.tsx` is not reportable.
+
+2. **Exemption check** — **Pass:** For each issue, you can state in one
+   line why it is *not* covered by [Valid Patterns (Do NOT Flag)](#valid-patterns-do-not-flag).
+   In particular: confirm a missing `ErrorBoundary` is not a deliberate
+   cascade to a parent boundary; confirm an `isRouteErrorResponse`-only
+   narrowing is not on a route that demonstrably only throws Responses
+   (downgrade to ADVISORY in that case).
+
+3. **v1-vs-v2 marker check** — **Pass:** Before writing the finding,
+   grep the route module (and the repo at large for cross-cutting
+   issues) for: `CatchBoundary`, `useCatch`, `v2_errorBoundary`,
+   `ErrorBoundary({ error`, `ErrorBoundary({error`. If any of these
+   appear, the finding is a **v1 holdover** (load [references/v1-holdovers.md](references/v1-holdovers.md))
+   and must be labeled as such — *not* as a generic "missing error
+   handling" issue. If none appear, the code is v2-shape and the
+   finding is about v2 correctness.
+
+4. **Protocol** — **Pass:** You completed the Pre-Report Verification
+   Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md)
+   for this review.
+
+## Review Questions
+
+1. Does every route that can throw (loader, action, or render) have an
+   `ErrorBoundary` at the right level — local where the recovery UI
+   matters, parent/root where cascade is intentional?
+2. Does each `ErrorBoundary` call `useRouteError()` (not `useCatch()`,
+   not props) and narrow `isRouteErrorResponse` first?
+3. Are 4xx / 5xx control flows using `throw` (not `return`) so the
+   boundary actually fires?
+4. Does `app/root.tsx` export an `ErrorBoundary` with `<Meta />`,
+   `<Links />`, and `<Scripts />`, and use `useRouteLoaderData("root")`
+   defensively?
+5. Are there any v1 markers left (`CatchBoundary`, `useCatch`,
+   `v2_errorBoundary`, `({ error })` prop signature)?
+6. Is `handleError` present in `entry.server.tsx` for runtime-error
+   observability, with the correct contract (no Response handling)?
+
+## Additional Documentation
+
+- Reviewing the `ErrorBoundary` export shape, hook usage, or narrowing → [references/boundary-shape.md](references/boundary-shape.md)
+- Reviewing thrown `Response` / `json` patterns, `handleError`, or return-vs-throw → [references/throw-response.md](references/throw-response.md)
+- Reviewing `app/root.tsx` boundary scaffolding → [references/root-boundary.md](references/root-boundary.md)
+- Detecting v1 holdovers (`CatchBoundary`, `useCatch`, `v2_errorBoundary`) → [references/v1-holdovers.md](references/v1-holdovers.md)
+- Remix v2 ErrorBoundary docs: https://v2.remix.run/docs/route/error-boundary/
+- Remix v2 error handling guide: https://v2.remix.run/docs/guides/errors/
+- Remix v2 `entry.server` / `handleError` docs: https://v2.remix.run/docs/file-conventions/entry.server/

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/boundary-shape.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/boundary-shape.md
@@ -217,4 +217,4 @@ Use `useRouteLoaderData("<route-id>")` and treat the result as possibly
 - Throwing patterns (return-vs-throw, `handleError`) → [throw-response.md](throw-response.md)
 - Root boundary specifics (`<Meta />`, `<Links />`, `<Scripts />`) → [root-boundary.md](root-boundary.md)
 - v1 markers (`CatchBoundary`, `useCatch`) → [v1-holdovers.md](v1-holdovers.md)
-- Remix v2 docs: https://v2.remix.run/docs/route/error-boundary/
+- Remix v2 docs: https://remix.run/docs/en/main/route/error-boundary

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/boundary-shape.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/boundary-shape.md
@@ -1,0 +1,220 @@
+# ErrorBoundary Shape — Export, Hook, Narrowing
+
+The v2 `ErrorBoundary` is a route-module export with no props. It reads
+the thrown value through `useRouteError()` and must narrow correctly to
+distinguish thrown `Response`s from runtime `Error`s. Most boundary
+bugs are shape mistakes: props leak in from v1 examples, narrowing
+covers one case but not the other, or a route that can throw exports
+nothing at all.
+
+## Canonical shape
+
+```tsx
+// app/routes/posts.$slug.tsx
+import { isRouteErrorResponse, useRouteError } from "@remix-run/react";
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (isRouteErrorResponse(error)) {
+    return (
+      <section>
+        <h1>{error.status} {error.statusText}</h1>
+        <p>{typeof error.data === "string" ? error.data : "Request failed."}</p>
+      </section>
+    );
+  }
+  if (error instanceof Error) {
+    return (
+      <section>
+        <h1>Something went wrong</h1>
+        <p>{error.message}</p>
+      </section>
+    );
+  }
+  return <h1>Unknown error</h1>;
+}
+```
+
+Three narrowing branches in this order, no props, hook-driven.
+
+## Anti-patterns to flag
+
+### 1. Missing `ErrorBoundary` on a route that can throw
+
+**Pattern**
+
+```tsx
+// app/routes/admin.users.$userId.tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const user = await db.user.findUnique({ where: { id: params.userId } });
+  if (!user) throw new Response("Not found", { status: 404 });
+  return json({ user });
+}
+
+export default function UserDetail() {
+  const { user } = useLoaderData<typeof loader>();
+  return <UserCard user={user} />;
+}
+// No ErrorBoundary export.
+```
+
+**Why bad**
+
+The thrown 404 bubbles to the nearest ancestor with a boundary —
+usually `app/root.tsx`. A whole-document re-render replaces the admin
+chrome (nav, sidebar, breadcrumbs) for what should be an inline "user
+not found" state. If `app/root.tsx` also lacks a boundary, the user
+sees Remix's generic "Application Error" page.
+
+**Fix**
+
+Export a local `ErrorBoundary` that renders inline recovery UI inside
+the admin shell:
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error) && error.status === 404) {
+    return <p>User not found. <Link to="/admin/users">Back to list</Link></p>;
+  }
+  if (error instanceof Error) return <p>Failed to load user: {error.message}</p>;
+  return <p>Unknown error.</p>;
+}
+```
+
+**Exemption**: If the route deliberately delegates to a parent boundary
+that already renders a good fallback, do *not* flag. Verify the parent
+boundary exists and handles this route's error shape before exempting.
+
+### 2. Props on `ErrorBoundary` (v1 carryover)
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary({ error }: { error: Error }) {
+  return <div>{error.message}</div>;
+}
+```
+
+**Why bad**
+
+In v2 the boundary receives **no props**. `error` is `undefined` at
+runtime, so `error.message` throws inside the boundary — causing an
+infinite error loop. TypeScript will not catch this because the prop
+type is unconstrained.
+
+**Fix**
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  // ...narrow...
+}
+```
+
+### 3. Narrowing only with `instanceof Error`
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  if (error instanceof Error) {
+    return <p>Error: {error.message}</p>;
+  }
+  return <p>Unknown error</p>;
+}
+```
+
+**Why bad**
+
+Thrown `Response`s are unwrapped to an internal `ErrorResponse`, which
+is **not** an `Error` instance. A loader that does `throw json({ message: "Forbidden" }, { status: 403 })`
+hits the `"Unknown error"` branch and the 403 status, statusText, and
+payload are all lost. The user sees a generic message; the developer
+sees no clue what happened.
+
+**Fix**
+
+Check `isRouteErrorResponse(error)` first, then `instanceof Error`:
+
+```tsx
+if (isRouteErrorResponse(error)) {
+  return <p>{error.status}: {String(error.data)}</p>;
+}
+if (error instanceof Error) {
+  return <p>Error: {error.message}</p>;
+}
+return <p>Unknown error</p>;
+```
+
+### 4. Narrowing only with `isRouteErrorResponse`
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error)) {
+    return <p>{error.status} {error.statusText}</p>;
+  }
+  return <p>Something went wrong</p>;
+}
+```
+
+**Why bad**
+
+A real bug — null deref, failed DB call, render-time exception —
+surfaces as an `Error` instance, not an `ErrorResponse`. With no
+`instanceof Error` branch the boundary falls through to the generic
+fallback and the developer loses the message and stack at the UI
+layer.
+
+**Severity rule**
+
+- **ADVISORY** if the route demonstrably only throws `Response`s
+  (loader/action use `throw json` / `throw new Response` exclusively
+  *and* the rendered component is trivial / non-crashing).
+- **WARN** otherwise — most routes can render-crash.
+
+**Fix**
+
+Add the `instanceof Error` branch:
+
+```tsx
+if (isRouteErrorResponse(error)) return <p>{error.status} {error.statusText}</p>;
+if (error instanceof Error)      return <p>Error: {error.message}</p>;
+return <p>Something went wrong</p>;
+```
+
+### 5. Calling `useLoaderData()` inside `ErrorBoundary`
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary() {
+  const data = useLoaderData<typeof loader>();
+  return <p>Failed for {data.user.name}.</p>;
+}
+```
+
+**Why bad**
+
+The boundary may be rendering *because the loader threw* — in which
+case `useLoaderData()` itself throws, causing a second error and a
+boundary loop. Even when the boundary fires from a render-time crash
+(not a loader throw), relying on loader data inside the boundary
+couples the fallback to a code path that just proved it can fail.
+
+**Fix**
+
+Use `useRouteLoaderData("<route-id>")` and treat the result as possibly
+`undefined`, or render a fallback that does not depend on loader data.
+
+## Cross-references
+
+- Throwing patterns (return-vs-throw, `handleError`) → [throw-response.md](throw-response.md)
+- Root boundary specifics (`<Meta />`, `<Links />`, `<Scripts />`) → [root-boundary.md](root-boundary.md)
+- v1 markers (`CatchBoundary`, `useCatch`) → [v1-holdovers.md](v1-holdovers.md)
+- Remix v2 docs: https://v2.remix.run/docs/route/error-boundary/

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/root-boundary.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/root-boundary.md
@@ -209,5 +209,5 @@ with `<Meta />`, `<Links />`, and `<Scripts />`.
 
 - Boundary shape and narrowing → [boundary-shape.md](boundary-shape.md)
 - Throw vs return semantics → [throw-response.md](throw-response.md)
-- Remix root route docs: https://v2.remix.run/docs/file-conventions/root/
-- Error handling guide: https://v2.remix.run/docs/guides/errors/
+- Remix root route docs: https://remix.run/docs/en/main/file-conventions/root
+- Error handling guide: https://remix.run/docs/en/main/guides/errors

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/root-boundary.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/root-boundary.md
@@ -1,0 +1,213 @@
+# Root ErrorBoundary — Document Scaffolding
+
+The root `ErrorBoundary` in `app/root.tsx` is the last-resort boundary
+for any error that bubbles past every nested boundary (or fires before
+any nested boundary can mount). Unlike nested boundaries, it re-mounts
+the **entire document** — so it owns `<html>`, `<head>`, and `<body>`
+shells and must render the framework tags itself.
+
+Three common bugs make the root boundary worse than no boundary at
+all: missing entirely (Remix renders its generic page), present but
+without `<Meta />` / `<Links />` / `<Scripts />` (white screen of
+death after first error), or present but reading `useLoaderData()`
+(infinite error loop when the root loader is the thing that threw).
+
+## Canonical shape
+
+```tsx
+// app/root.tsx
+import {
+  isRouteErrorResponse,
+  Links,
+  Meta,
+  Scripts,
+  useRouteError,
+  useRouteLoaderData,
+} from "@remix-run/react";
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  // Defensive: root loader may have thrown.
+  const rootData = useRouteLoaderData<typeof loader>("root");
+
+  return (
+    <html lang="en">
+      <head>
+        <title>Application error</title>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <main className="error-shell">
+          {isRouteErrorResponse(error) ? (
+            <>
+              <h1>{error.status} {error.statusText}</h1>
+              <p>{typeof error.data === "string" ? error.data : "Request failed."}</p>
+            </>
+          ) : error instanceof Error ? (
+            <>
+              <h1>Something went wrong</h1>
+              <p>{error.message}</p>
+            </>
+          ) : (
+            <h1>Unknown error</h1>
+          )}
+          {rootData?.user ? <p>Signed in as {rootData.user.email}</p> : null}
+        </main>
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+```
+
+`<Meta />` and `<Links />` keep critical head tags (charset, viewport,
+CSS) in the document. `<Scripts />` boots the client runtime so the
+user can navigate away. Missing any of these turns the error page into
+a dead-end.
+
+## Anti-patterns to flag
+
+### 1. No root `ErrorBoundary` at all
+
+**Pattern**
+
+`app/root.tsx` exports `Layout` (or just a default `App`) and
+`loader`, but no `ErrorBoundary`.
+
+**Why bad**
+
+Any error that escapes every nested boundary hits Remix's built-in
+fallback — a hard-coded "Application Error" page with no branding,
+status, or recovery affordance. Production stack traces are stripped
+by default, so users see a generic message and developers see nothing
+unless `handleError` is wired. First-impression error states matter:
+this is the single most likely page a frustrated user will see.
+
+**Fix**
+
+Always export `ErrorBoundary` from `app/root.tsx` with the canonical
+shape above.
+
+### 2. Root boundary missing `<Meta />`, `<Links />`, or `<Scripts />`
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return (
+    <html>
+      <body>
+        <h1>Something went wrong</h1>
+        <p>{error instanceof Error ? error.message : "Unknown"}</p>
+      </body>
+    </html>
+  );
+}
+```
+
+**Why bad**
+
+The root boundary re-mounts the whole document. Without `<Scripts />`
+the client bundle never boots — `<Link>`, `<Form>`, navigation, even
+`window.history.back()` fall back to native browser behavior. Without
+`<Links />` all stylesheets vanish (unstyled error page). Without
+`<Meta />` the charset, viewport, and per-route meta tags are missing
+(mobile rendering breaks, SEO tags lost).
+
+The cascade is silent: dev mode with HMR will often hide it because
+HMR injects scripts; production builds expose the dead shell.
+
+**Fix**
+
+Render all three:
+
+```tsx
+<head><Meta /><Links /></head>
+<body>{ ...error UI... }<Scripts /></body>
+```
+
+If your project uses a `Layout` component that already renders these,
+the root `ErrorBoundary` can render `<Layout>...</Layout>` instead —
+but verify the Layout component does not itself crash on missing
+loader data.
+
+### 3. Root boundary calls `useLoaderData()`
+
+**Pattern**
+
+```tsx
+export async function loader() {
+  const user = await getUserOrThrow(request);          // may throw
+  return json({ user });
+}
+
+export function ErrorBoundary() {
+  const { user } = useLoaderData<typeof loader>();    // throws if loader threw
+  return <p>Sorry, {user.name}. Something broke.</p>;
+}
+```
+
+**Why bad**
+
+If the root loader is the thing that threw — and root loaders often
+include auth, feature flags, theme — `useLoaderData()` inside the
+boundary throws *again*. Remix sees a second error during boundary
+render and falls back to its built-in error page. The carefully
+designed root boundary never appears.
+
+Even when the boundary fires from a child route error (not a root
+loader error), the boundary becomes brittle: any future change that
+makes the root loader throw silently breaks the error page.
+
+**Fix**
+
+Use `useRouteLoaderData("root")` and handle `undefined`:
+
+```tsx
+const rootData = useRouteLoaderData<typeof loader>("root");
+// rootData may be undefined if root loader threw.
+{rootData?.user ? <p>Signed in as {rootData.user.email}</p> : <p>Please sign in.</p>}
+```
+
+`useRouteLoaderData` returns `undefined` rather than throwing when the
+data isn't available — making the boundary resilient to loader
+failure at any level.
+
+### 4. Root boundary without `<html>` / `<body>` wrappers
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return <div className="error">Something went wrong</div>;
+}
+```
+
+**Why bad**
+
+The root boundary owns the entire document. Returning a bare `<div>`
+means Remix renders that `<div>` *as* the document — no `<html>`, no
+`<head>`, no `<body>`. The browser tolerates this in quirks mode but
+charset declaration, language attribute, and head tags are gone. The
+page renders unstyled and accessibility tools report the document is
+malformed.
+
+Note: nested route `ErrorBoundary` exports correctly render *inside*
+the document (parent layouts still apply), so they should **not**
+include `<html>` / `<body>`. The wrapper requirement is specific to
+the root boundary.
+
+**Fix**
+
+Always wrap root-boundary output in `<html><head>...</head><body>...</body></html>`
+with `<Meta />`, `<Links />`, and `<Scripts />`.
+
+## Cross-references
+
+- Boundary shape and narrowing → [boundary-shape.md](boundary-shape.md)
+- Throw vs return semantics → [throw-response.md](throw-response.md)
+- Remix root route docs: https://v2.remix.run/docs/file-conventions/root/
+- Error handling guide: https://v2.remix.run/docs/guides/errors/

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/throw-response.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/throw-response.md
@@ -1,0 +1,232 @@
+# Throw vs Return — Responses, Errors, and `handleError`
+
+In Remix v2, only **thrown** values reach `ErrorBoundary`. A `return`
+from a loader/action is a successful result — no matter the status
+code. Choosing throw-vs-return wrong is one of the most common
+boundary bugs because the code looks correct and types check.
+
+Companion: `app/entry.server.tsx` may export `handleError` for
+server-side error reporting. Its contract has a sharp edge: it does
+**not** fire for thrown `Response`s.
+
+## Canonical patterns
+
+```tsx
+// Loader: throw for 4xx/5xx, return for success
+export async function loader({ params }: LoaderFunctionArgs) {
+  invariant(params.invoiceId, "Missing invoiceId");
+  const invoice = await db.invoice.findUnique({ where: { id: params.invoiceId } });
+  if (!invoice) {
+    throw json({ message: `Invoice ${params.invoiceId} not found` }, { status: 404 });
+  }
+  return json({ invoice });
+}
+
+// Action: throw for auth / validation hard-stops, return for field errors
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await requireUser(request);              // throws Response on 401
+  const form = await request.formData();
+  const parsed = schema.safeParse(Object.fromEntries(form));
+  if (!parsed.success) {
+    return json({ errors: parsed.error.flatten() }, { status: 400 }); // returned — rendered by route
+  }
+  await db.invoice.update({ where: { id: parsed.data.id }, data: parsed.data });
+  return redirect(`/invoices/${parsed.data.id}`);
+}
+```
+
+```tsx
+// app/entry.server.tsx
+export function handleError(
+  error: unknown,
+  { request }: DataFunctionArgs,
+) {
+  if (request.signal.aborted) return;                  // ignore client disconnects
+  if (error instanceof Error) {
+    reportToSentry(error);
+  } else {
+    console.error("Non-Error thrown server-side:", error);
+  }
+}
+```
+
+## Anti-patterns to flag
+
+### 1. Returning instead of throwing for 4xx / 5xx
+
+**Pattern**
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const post = await db.post.findUnique({ where: { slug: params.slug } });
+  if (!post) {
+    return json({ error: "Not found" }, { status: 404 }); // returned, not thrown
+  }
+  return json({ post });
+}
+
+export default function Post() {
+  const data = useLoaderData<typeof loader>();
+  if ("error" in data) return <p>{data.error}</p>;       // ad-hoc error branch
+  return <article>{data.post.title}</article>;
+}
+```
+
+**Why bad**
+
+- The 404 case does *not* reach `ErrorBoundary`. The component now
+  carries two-shape `data` and must branch on `"error" in data` —
+  defeating the v2 model.
+- The browser sees a 404 status with a successful HTML body. SEO tools
+  and crawlers get mixed signals.
+- The component types become a discriminated union of "success" and
+  "error" shapes, which leaks into every consumer.
+
+**Fix**
+
+```tsx
+if (!post) throw json({ message: "Not found" }, { status: 404 });
+return json({ post });
+```
+
+The boundary now renders the 404; the component only deals with the
+success shape.
+
+### 2. Swallowing `error.data` (rendering an object as text)
+
+**Pattern**
+
+```tsx
+export function ErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error)) {
+    return <p>{error.data}</p>;                          // error.data may be object
+  }
+  return null;
+}
+```
+
+If the loader did `throw json({ message: "Forbidden" }, { status: 403 })`,
+then `error.data` is `{ message: "Forbidden" }`. React renders this as
+`"Objects are not valid as a React child"` and the boundary itself
+crashes.
+
+**Why bad**
+
+`error.data` is typed `unknown`. The shape depends entirely on what
+the loader threw. Boundaries that assume "data is a string" work for
+some routes and fail for others.
+
+**Fix**
+
+Type-narrow before rendering:
+
+```tsx
+if (isRouteErrorResponse(error)) {
+  const msg =
+    typeof error.data === "string"
+      ? error.data
+      : typeof error.data === "object" && error.data && "message" in error.data
+      ? String((error.data as { message: unknown }).message)
+      : error.statusText;
+  return <p>{msg}</p>;
+}
+```
+
+Or define a shared `ErrorPayload` type and `throw json<ErrorPayload>(...)`.
+
+### 3. Throwing a non-`Response` / non-`Error` value
+
+**Pattern**
+
+```tsx
+if (!input.email) throw "Email required";              // string
+if (!user)       throw { code: 401, message: "Unauthorized" }; // POJO
+```
+
+**Why bad**
+
+`useRouteError()` returns the value as `unknown`. Neither
+`isRouteErrorResponse(error)` nor `error instanceof Error` matches, so
+the boundary falls through to the "Unknown error" branch. Status code
+information is lost. `handleError` receives a non-`Error` value and
+typically logs `"Non-Error thrown server-side"` with no stack.
+
+**Fix**
+
+Always throw a `Response` (for expected control flow — 4xx) or an
+`Error` (for bugs — 5xx):
+
+```tsx
+if (!input.email) throw new Response("Email required", { status: 400 });
+if (!user)        throw json({ message: "Unauthorized" }, { status: 401 });
+if (db.connection.state === "broken") throw new Error("DB connection lost");
+```
+
+### 4. Missing `handleError` in `entry.server.tsx`
+
+**Pattern**
+
+`app/entry.server.tsx` exports only `handleRequest`. No `handleError`,
+no other server logging in place.
+
+**Why bad**
+
+In production, Remix logs runtime errors to `console.error` and shows
+"Application Error" to the user. Without `handleError` the errors are
+never piped to Sentry / Datadog / your reporter — they vanish into
+stdout (or stderr depending on the host). You only learn about bugs
+when users report them.
+
+**Fix**
+
+Export `handleError`. Filter aborted requests, narrow by type, report:
+
+```tsx
+export function handleError(error: unknown, { request }: DataFunctionArgs) {
+  if (request.signal.aborted) return;
+  if (error instanceof Error) Sentry.captureException(error);
+  else console.error("Non-Error thrown:", error);
+}
+```
+
+### 5. Logging thrown `Response`s through `handleError`
+
+**Pattern**
+
+```tsx
+export function handleError(error: unknown, { request }: DataFunctionArgs) {
+  Sentry.captureException(error);                       // also for Responses?
+}
+```
+
+Then someone wraps a loader in `try { ... } catch (e) { handleError(e, ...); throw e; }`
+to "make sure 404s are tracked."
+
+**Why bad**
+
+`handleError` is **never** called for thrown `Response`s by the
+framework — Remix treats them as expected control flow. Manually
+re-routing every 404/403 through Sentry turns normal user navigation
+("user clicks expired link") into pages of error alerts and burns the
+Sentry quota.
+
+**Fix**
+
+Trust the framework contract. If you need to track specific 4xx for
+product reasons (e.g., suspicious 403 spikes), log at the **throw
+site** with structured fields — not through `handleError`:
+
+```tsx
+if (!user) {
+  metrics.increment("auth.unauthorized", { route: "/admin" });
+  throw json({ message: "Unauthorized" }, { status: 401 });
+}
+```
+
+## Cross-references
+
+- Boundary shape (narrowing, props, hook) → [boundary-shape.md](boundary-shape.md)
+- Root boundary specifics → [root-boundary.md](root-boundary.md)
+- `handleError` doc: https://v2.remix.run/docs/file-conventions/entry.server/
+- `throw` semantics: https://v2.remix.run/docs/guides/errors/

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/throw-response.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/throw-response.md
@@ -39,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
 // app/entry.server.tsx
 export function handleError(
   error: unknown,
-  { request }: DataFunctionArgs,
+  { request }: LoaderFunctionArgs | ActionFunctionArgs,
 ) {
   if (request.signal.aborted) return;                  // ignore client disconnects
   if (error instanceof Error) {
@@ -183,7 +183,7 @@ when users report them.
 Export `handleError`. Filter aborted requests, narrow by type, report:
 
 ```tsx
-export function handleError(error: unknown, { request }: DataFunctionArgs) {
+export function handleError(error: unknown, { request }: LoaderFunctionArgs | ActionFunctionArgs) {
   if (request.signal.aborted) return;
   if (error instanceof Error) Sentry.captureException(error);
   else console.error("Non-Error thrown:", error);
@@ -195,7 +195,7 @@ export function handleError(error: unknown, { request }: DataFunctionArgs) {
 **Pattern**
 
 ```tsx
-export function handleError(error: unknown, { request }: DataFunctionArgs) {
+export function handleError(error: unknown, { request }: LoaderFunctionArgs | ActionFunctionArgs) {
   Sentry.captureException(error);                       // also for Responses?
 }
 ```
@@ -228,5 +228,5 @@ if (!user) {
 
 - Boundary shape (narrowing, props, hook) → [boundary-shape.md](boundary-shape.md)
 - Root boundary specifics → [root-boundary.md](root-boundary.md)
-- `handleError` doc: https://v2.remix.run/docs/file-conventions/entry.server/
-- `throw` semantics: https://v2.remix.run/docs/guides/errors/
+- `handleError` doc: https://remix.run/docs/en/main/file-conventions/entry.server
+- `throw` semantics: https://remix.run/docs/en/main/guides/errors

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/v1-holdovers.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/v1-holdovers.md
@@ -1,0 +1,180 @@
+# v1 Holdovers — `CatchBoundary`, `useCatch`, `v2_errorBoundary`
+
+Remix v1 split error handling across two route-module exports:
+`CatchBoundary` for thrown `Response`s and `ErrorBoundary` for runtime
+errors. v2 collapsed them into a single `ErrorBoundary`. The
+transition was previewed behind the `future.v2_errorBoundary` flag in
+late v1 and the old API was **removed** in `remix@2.0.0`.
+
+In a v2 codebase, any of the three markers below is dead code at
+best, broken behavior at worst. Always flag them and label the finding
+as a **v1 holdover** (not a generic error-handling issue) so the fix
+is unambiguous: delete the v1 API and fold its logic into v2 shape.
+
+## How to detect
+
+Grep the route module — and, for `v2_errorBoundary`, the config —
+for:
+
+| Marker | Where to look | What it means |
+|---|---|---|
+| `export function CatchBoundary` / `export const CatchBoundary` | Any `app/routes/**/*.tsx` | v1 thrown-`Response` boundary. Silently ignored in v2. |
+| `useCatch` | Any `app/**/*.ts(x)` import or call site | v1 hook for reading a thrown `Response`. Does not exist in `@remix-run/react` v2. |
+| `v2_errorBoundary` | `remix.config.js`, `remix.config.ts`, `vite.config.ts` plugin options | v1 future flag, removed in v2.0.0. Triggers a startup warning. |
+| `ThrownResponse`, `CatchBoundaryComponent` types | Any `app/**/*.ts(x)` | v1 types. Gone in v2. |
+| `unstable_shouldReload` | Any `app/routes/**` | v1 revalidation API (out of scope here but commonly appears in the same files). |
+
+## Anti-patterns to flag
+
+### 1. `CatchBoundary` export
+
+**Pattern**
+
+```tsx
+// app/routes/posts.$slug.tsx
+import { useCatch } from "@remix-run/react";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const post = await db.post.findUnique({ where: { slug: params.slug } });
+  if (!post) throw new Response("Not found", { status: 404 });
+  return json({ post });
+}
+
+export function CatchBoundary() {                       // v1 export
+  const caught = useCatch();
+  return <p>{caught.status} {caught.statusText}</p>;
+}
+
+export function ErrorBoundary({ error }: { error: Error }) { // v1 prop signature
+  return <p>{error.message}</p>;
+}
+```
+
+**Why bad**
+
+- `CatchBoundary` is not a v2 route-module export. Remix silently
+  ignores it; the function is dead code.
+- `useCatch()` is not exported from `@remix-run/react` v2. The import
+  fails at build time (`'useCatch' is not exported`).
+- The thrown 404 now flows to `ErrorBoundary` (the v2 contract), but
+  the `ErrorBoundary` here uses the v1 prop signature so `error` is
+  `undefined` at runtime.
+
+The route appears to handle 404s; in production the boundary crashes
+or shows nothing.
+
+**Fix — collapse to a single v2 `ErrorBoundary`**
+
+```tsx
+import { isRouteErrorResponse, useRouteError } from "@remix-run/react";
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  if (isRouteErrorResponse(error)) {
+    return <p>{error.status} {error.statusText}</p>;
+  }
+  if (error instanceof Error) {
+    return <p>{error.message}</p>;
+  }
+  return <p>Unknown error</p>;
+}
+```
+
+Delete the `CatchBoundary` export and the `useCatch` import entirely.
+
+### 2. `useCatch` import (with or without `CatchBoundary`)
+
+**Pattern**
+
+```tsx
+import { useCatch, useLoaderData } from "@remix-run/react";
+```
+
+**Why bad**
+
+`useCatch` does not exist in `@remix-run/react@^2`. The import line
+either fails the build (strict TS / no fallback shim) or imports
+`undefined` (loose builds), leading to `TypeError: useCatch is not a
+function` at runtime.
+
+A `useCatch` import with no `CatchBoundary` export is still a v1
+holdover — usually the file was partially migrated. The author
+removed the boundary but forgot to delete the import or a stray hook
+call.
+
+**Fix**
+
+Remove the import. Replace any `useCatch()` call with `useRouteError()`
+and narrow with `isRouteErrorResponse(error)`.
+
+### 3. `v2_errorBoundary` future flag
+
+**Pattern**
+
+```js
+// remix.config.js
+module.exports = {
+  future: {
+    v2_errorBoundary: true,        // removed in 2.0.0
+    v2_routeConvention: true,
+    v2_meta: true,
+  },
+};
+```
+
+**Why bad**
+
+`future.v2_errorBoundary` was the opt-in flag for the unified boundary
+during late v1. In `remix@2.0.0` the flag — and the old
+`CatchBoundary` implementation — were both removed. Leaving the entry
+in the config produces a startup warning (`Unrecognized future flag:
+v2_errorBoundary`) but is otherwise inert. More importantly, its
+presence signals the config was migrated by a copy-paste from a v1
+upgrade guide rather than a v2-native setup; nearby flags
+(`v2_routeConvention`, `v2_meta`, `v2_normalizeFormMethod`) are likely
+also stale.
+
+**Fix**
+
+Delete the entry. Audit the rest of the `future` block — every v2
+flag from the migration era is now the default behavior and should be
+removed.
+
+### 4. `ThrownResponse` / `CatchBoundaryComponent` type imports
+
+**Pattern**
+
+```tsx
+import type { ThrownResponse, CatchBoundaryComponent } from "@remix-run/react";
+
+type NotFound = ThrownResponse<404, { message: string }>;
+```
+
+**Why bad**
+
+These types were exported from `@remix-run/react` in v1 to describe
+the shape of `useCatch()` returns and the `CatchBoundary` component.
+They are not exported in v2. Type-only imports fail in strict TS
+builds.
+
+**Fix**
+
+Replace with the v2 equivalents — there is no direct successor to
+`ThrownResponse` because `useRouteError()` returns `unknown` and is
+narrowed via `isRouteErrorResponse`. Type your thrown payload at the
+throw site instead:
+
+```tsx
+type ErrorPayload = { message: string };
+throw json<ErrorPayload>({ message: "Not found" }, { status: 404 });
+```
+
+Inside the boundary, narrow `error.data` defensively (see
+[throw-response.md](throw-response.md) anti-pattern #2).
+
+## Cross-references
+
+- v2 boundary shape (the migration target) → [boundary-shape.md](boundary-shape.md)
+- Throw / `handleError` semantics → [throw-response.md](throw-response.md)
+- Remix `remix@2.0.0` changelog (flag + `CatchBoundary` removal): https://github.com/remix-run/remix/blob/remix@2.0.0/packages/remix-react/CHANGELOG.md
+- v1 → v2 migration guide: https://v2.remix.run/docs/start/v2

--- a/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/v1-holdovers.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-error-boundaries-review/references/v1-holdovers.md
@@ -177,4 +177,4 @@ Inside the boundary, narrow `error.data` defensively (see
 - v2 boundary shape (the migration target) → [boundary-shape.md](boundary-shape.md)
 - Throw / `handleError` semantics → [throw-response.md](throw-response.md)
 - Remix `remix@2.0.0` changelog (flag + `CatchBoundary` removal): https://github.com/remix-run/remix/blob/remix@2.0.0/packages/remix-react/CHANGELOG.md
-- v1 → v2 migration guide: https://v2.remix.run/docs/start/v2
+- v1 → v2 migration guide: https://remix.run/docs/en/main/start/v2

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: remix-v2-forms-review
+description: Reviews Remix v2 form code for manual fetch() mutations, native <form> misuse, wrong useNavigation/useFetcher choice, missing pending state, unbounded uploads, and intent-pattern violations. Use when reviewing form/mutation code in a Remix v2 codebase.
+---
+
+# Remix v2 Forms Code Review
+
+See [beagle-remix-v2:remix-v2-forms](../remix-v2-forms/SKILL.md) for canonical
+patterns. This skill flags violations; the sibling skill teaches the patterns.
+
+## Quick Reference
+
+| Issue Type | Reference |
+|------------|-----------|
+| Manual `fetch()`, native `<form>`, wrong `<Form>` vs `useFetcher` choice | [references/form-vs-fetcher.md](references/form-vs-fetcher.md) |
+| `useState` loading flags, `useNavigation` for per-row, missing pending state | [references/pending-state.md](references/pending-state.md) |
+| Unbounded memory uploads, missing `encType`, unvalidated FormData, mirrored optimistic state | [references/uploads-validation.md](references/uploads-validation.md) |
+| Route sprawl instead of intent pattern, PUT/DELETE without PE fallback | [references/multi-action-routes.md](references/multi-action-routes.md) |
+
+## Review Checklist
+
+- [ ] In-app mutations use `<Form>` or `<fetcher.Form>`, never `fetch()` / `axios`
+- [ ] `<Form>` is imported from `@remix-run/react` (not native `<form>`) for POST mutations
+- [ ] `useFetcher` used when URL should NOT change (row toggle, inline edit)
+- [ ] `<Form>` + `redirect(...)` used when URL SHOULD change (create, delete-then-list)
+- [ ] Pending state derived from `useNavigation()` or `fetcher.state`, never `useState`
+- [ ] Per-row pending uses per-row `fetcher.state` (not page-global `useNavigation`)
+- [ ] `useNavigation()` calls check `navigation.formAction` to scope to expected path
+- [ ] Optimistic UI reads `fetcher.formData` / `navigation.formData` directly (not mirrored)
+- [ ] Actions returning success `redirect(...)`, returning `json()` only for errors / same-page
+- [ ] `<Form encType="multipart/form-data">` on every file-upload form
+- [ ] `unstable_createMemoryUploadHandler` always has `maxPartSize`; large files use disk/stream handler
+- [ ] `FormData` values are validated/coerced before reaching the DB (no `form.get(x) as string`)
+- [ ] Multiple mutations on one route use intent pattern, not separate routes
+- [ ] `method="put|patch|delete"` is documented as JS-only, or rewritten as POST + intent
+
+## Valid Patterns (Do NOT Flag)
+
+These are correct Remix v2 usage and should not be reported:
+
+- **`<Form>` without `action` prop** — posts to the current URL by convention; explicit `action` is optional.
+- **GET `<Form>`** — legitimate for search/filter UIs; hits the loader with form fields as URL search params and does NOT call an action. Most "hygiene" rules (intent, `redirect`, `encType`) apply only to POST forms.
+- **Multiple `useFetcher()` instances on one page** — each call returns an independent submission channel; intentional for parallel mutations to different rows.
+- **`useSubmit()` in an event handler** — correct programmatic submission for autosave, keyboard shortcuts, or `onChange` triggers.
+- **Reading `fetcher.formData` during a submission** — intended; this is the canonical optimistic source.
+- **`useActionData` data persisting after submission** — known behavior; it returns the last action result until the next navigation or action.
+- **`navigate={false}` on `<Form>`** — turns it into a fetcher form; equivalent to `<fetcher.Form>` without holding a fetcher ref.
+- **`unstable_` prefix on `parseMultipartFormData` / upload handlers** — permanent in v2; do not flag as "unstable API".
+
+## Context-Sensitive Rules
+
+Only flag these when the listed condition holds:
+
+| Issue | Flag ONLY IF |
+|-------|--------------|
+| Native `<form>` instead of `<Form>` | Method is POST and the route has an `action` — GET forms and external-URL forms are fine |
+| Missing pending state | The form is POST and there is no `useNavigation()` / `fetcher.state` read anywhere in the component |
+| Action returns `json({ ok: true })` after a create | The route is a "/new" or creation surface — same-page edit forms legitimately return JSON |
+| `method="put"` / `"patch"` / `"delete"` | Progressive enhancement is in scope for the surface (public app) — admin/JS-only tools may opt out if documented |
+| Unbounded `unstable_createMemoryUploadHandler` | The upload accepts user-controlled files (not a fixed-size internal artifact) |
+| Separate routes per mutation | The mutations operate on the same resource with compatible auth — sibling resources with different rules are fine |
+| `useNavigation()` without `formAction` filter | The component contains other navigation surfaces (sidebar `<Link>`, sibling forms) that would trigger false positives |
+| Mirroring `fetcher.formData` into state | The shadowed value drives a user-visible element (button label, count, toggle) — a local "is-editing" flag is unrelated |
+
+## Hard gates (before writing findings)
+
+Run these in order. **Do not draft user-facing findings until every gate passes** for the batch you are about to report.
+
+1. **Location evidence** — **Pass:** Each issue lists a repo path and either a line range or a short verbatim quote from the file you read (not from memory or diff-only guesswork). Name the route module, the component, and the `action` if one exists.
+
+2. **Exemption check** — **Pass:** For each issue, you can state in one line why it is *not* covered by [Valid Patterns (Do NOT Flag)](#valid-patterns-do-not-flag) and any matching row in [Context-Sensitive Rules](#context-sensitive-rules).
+
+3. **Form-method check** — **Pass:** Before flagging missing intent, missing `encType`, missing `redirect`, or missing pending state, you have confirmed the form is `method="post"` (or `put|patch|delete`). GET forms are legitimate for search/filter and trigger loaders, not actions — applying POST-form rules to them is a false positive.
+
+4. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../review-verification-protocol/SKILL.md) for this review.
+
+## Additional Documentation
+
+- **Form vs fetcher misuse** — manual `fetch()`, native `<form>`, wrong primitive: [references/form-vs-fetcher.md](references/form-vs-fetcher.md)
+- **Pending state anti-patterns** — `useState` flags, page-global vs per-row, missing entirely: [references/pending-state.md](references/pending-state.md)
+- **Uploads & FormData validation** — unbounded handlers, missing `encType`, unvalidated keys, mirrored optimistic state: [references/uploads-validation.md](references/uploads-validation.md)
+- **Multi-action routes** — intent-pattern violations, PUT/DELETE without PE fallback, missing submit button: [references/multi-action-routes.md](references/multi-action-routes.md)
+- **Canonical patterns** — see sibling [beagle-remix-v2:remix-v2-forms](../remix-v2-forms/SKILL.md)
+
+## When to Load References
+
+- Reviewing forms that call `fetch()` / `axios` / native `<form>`, or choose between `<Form>` and `useFetcher` → [form-vs-fetcher.md](references/form-vs-fetcher.md)
+- Reviewing loading flags, spinners, disabled-button logic, per-row pending → [pending-state.md](references/pending-state.md)
+- Reviewing file uploads, `unstable_*` handlers, FormData parsing, optimistic UI → [uploads-validation.md](references/uploads-validation.md)
+- Reviewing routes with multiple mutations, intent fields, PUT/DELETE methods → [multi-action-routes.md](references/multi-action-routes.md)
+
+## Review Questions
+
+1. Does every in-app mutation flow through a route `action` (no manual `fetch()`)?
+2. Is the `<Form>` vs `useFetcher` choice driven by whether the URL should change?
+3. Is pending state derived from `useNavigation()` / `fetcher.state` (never `useState`)?
+4. Are per-row spinners wired to per-row `fetcher.state` (not page-global `useNavigation`)?
+5. Do file-upload forms set `encType="multipart/form-data"` and use bounded handlers?
+6. Are FormData values validated before reaching the DB?
+7. Do multiple mutations on one resource use the intent pattern, not separate routes?
+8. Do POST forms have at least one real submit button for progressive enhancement?
+
+## False-Positive Notes
+
+- A `<Form>` rendering inside a non-route component is still tied to the
+  nearest route's `action` — read the route file before flagging
+  "missing action".
+- `useActionData()` returning data after a successful submission is
+  expected behavior; the data persists until the next navigation. Only
+  flag if a success banner is rendered unconditionally without a
+  dismiss path.
+- Code that imports `Form` aliased (e.g. `import { Form as RemixForm }`)
+  is still the Remix component — match on import source, not local name.
+
+## Before Submitting Findings
+
+Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 4), then report only issues that still pass the [review-verification-protocol](../review-verification-protocol/SKILL.md) pre-report checks.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/SKILL.md
@@ -33,6 +33,7 @@ patterns. This skill flags violations; the sibling skill teaches the patterns.
 - [ ] `FormData` values are validated/coerced before reaching the DB (no `form.get(x) as string`)
 - [ ] Multiple mutations on one route use intent pattern, not separate routes
 - [ ] `method="put|patch|delete"` is documented as JS-only, or rewritten as POST + intent
+- [ ] `nav.formMethod` / `fetcher.formMethod` compared against UPPERCASE strings (`"POST"`, `"GET"`); v2's `v2_normalizeFormMethod` default returns UPPERCASE — `=== "post"` silently never matches.
 
 ## Valid Patterns (Do NOT Flag)
 
@@ -72,7 +73,7 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 
 3. **Form-method check** — **Pass:** Before flagging missing intent, missing `encType`, missing `redirect`, or missing pending state, you have confirmed the form is `method="post"` (or `put|patch|delete`). GET forms are legitimate for search/filter and trigger loaders, not actions — applying POST-form rules to them is a false positive.
 
-4. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../review-verification-protocol/SKILL.md) for this review.
+4. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
 
 ## Additional Documentation
 
@@ -114,4 +115,4 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 
 ## Before Submitting Findings
 
-Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 4), then report only issues that still pass the [review-verification-protocol](../review-verification-protocol/SKILL.md) pre-report checks.
+Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 4), then report only issues that still pass the [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) pre-report checks.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/form-vs-fetcher.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/form-vs-fetcher.md
@@ -1,0 +1,183 @@
+# Form vs Fetcher Misuse
+
+Flag code that bypasses Remix's mutation lifecycle or picks the wrong
+primitive for the job. See
+[beagle-remix-v2:remix-v2-forms](../../remix-v2-forms/SKILL.md) for the
+decision gates and canonical patterns.
+
+## Anti-pattern 1 — Manual `fetch()` for in-app mutations
+
+```tsx
+// BAD
+function CreatePost() {
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        await fetch("/api/posts", { method: "POST", body: fd });
+      }}
+    >
+      <input name="title" />
+      <button>Create</button>
+    </form>
+  );
+}
+```
+
+**Why bad:** Bypasses the route `action` entirely. Loaders do not
+revalidate, so the UI shows stale data until a hard reload. Progressive
+enhancement is broken (the form does nothing without JS). There is no
+`useNavigation`/`useFetcher` pending state hook. Race-safe out-of-order
+submission handling is gone.
+
+**Fix:** Replace with `<Form method="post" action="/posts">` (URL
+changes) or `<fetcher.Form method="post" action="/posts">` (stays in
+place). Move the network call into that route's `action`.
+
+**Exemptions — do NOT flag:**
+
+- `fetch()` to a third-party URL (Stripe, Mapbox, an unrelated API).
+- `fetch()` inside an `action` or `loader` on the server.
+- `fetch()` in a webhook handler or background worker.
+
+## Anti-pattern 2 — Native `<form>` for POST mutations
+
+```tsx
+// BAD
+import { useActionData } from "@remix-run/react";
+export default function Signup() {
+  return (
+    <form method="post">  {/* lowercase — native, not Remix */}
+      <input name="email" />
+      <button>Sign up</button>
+    </form>
+  );
+}
+```
+
+**Why bad:** It works — Remix `action`s accept native form posts — but a
+hard navigation happens on submit, scroll position resets, and there is
+no way to read pending state, no `useNavigation.formData`, no
+optimistic UI surface. The user loses every benefit of client
+enhancement.
+
+**Fix:** Import `Form` from `@remix-run/react`. Native `<form>` is fine
+ONLY for forms that intentionally target external URLs or expect a full
+document reload (rare; document the reason).
+
+**Exemptions — do NOT flag:**
+
+- `<form action="https://external.example.com/...">` — external target.
+- `<form method="get">` — GET forms work identically as native or
+  `<Form>`; the Remix component still has benefits (no scroll reset)
+  but the native version is not a bug.
+- `<form>` rendered inside a markdown/CMS-rendered body.
+
+## Anti-pattern 3 — `useFetcher` when the URL should change
+
+```tsx
+// BAD — "create" flow with no redirect
+function NewItem() {
+  const fetcher = useFetcher();
+  return (
+    <fetcher.Form method="post" action="/items">
+      <input name="title" />
+      <button>Create</button>
+    </fetcher.Form>
+  );
+}
+```
+
+**Why bad:** No history entry, no scroll reset, no shareable URL for
+the new record, and the user's back button now skips the just-completed
+flow. Usually a sign the developer worked around `<Form>` because the
+pending-state ergonomics felt clumsy.
+
+**Fix:** Use `<Form>` and `redirect(\`/items/\${created.id}\`)` from
+the action. Derive pending state from `useNavigation()` with a
+`formAction` check.
+
+**Exemptions — do NOT flag:**
+
+- A "quick-add" widget where the user stays on the dashboard.
+- Inline create-in-place rows in a table.
+- Drafts/autosave where the URL deliberately stays put.
+
+## Anti-pattern 4 — `<Form>` when each row needs independent pending state
+
+```tsx
+// BAD — every row flickers on any submission
+function TaskList({ tasks }: { tasks: Task[] }) {
+  const nav = useNavigation();
+  return tasks.map((t) => (
+    <Form key={t.id} method="post" action={`/tasks/${t.id}/toggle`}>
+      <button disabled={nav.state !== "idle"}>
+        {nav.state !== "idle" ? "..." : "Toggle"}
+      </button>
+    </Form>
+  ));
+}
+```
+
+**Why bad:** `useNavigation` is page-global. The moment any row
+submits, every other row's button disables. Also: a `<Form>` submission
+navigates, so clicking row 5 changes the URL to `/tasks/5/toggle`.
+
+**Fix:** Use `useFetcher()` per row and key pending state off that
+fetcher's `fetcher.state`. Each `useFetcher()` call returns an
+independent submission channel.
+
+```tsx
+function TaskRow({ task }: { task: Task }) {
+  const fetcher = useFetcher();
+  return (
+    <fetcher.Form method="post" action={`/tasks/${task.id}/toggle`}>
+      <button disabled={fetcher.state !== "idle"}>Toggle</button>
+    </fetcher.Form>
+  );
+}
+```
+
+## Anti-pattern 5 — Action returning JSON on a create surface
+
+```tsx
+// BAD
+export async function action({ request }: ActionFunctionArgs) {
+  const fd = await request.formData();
+  const created = await createItem(fd);
+  return json({ ok: true, id: created.id });
+}
+```
+
+**Why bad:** The user is stranded on the `/new` URL after success.
+Refreshing prompts the browser to resubmit the POST. The back button
+revisits the form. Reset logic has to be wired manually.
+
+**Fix:** `return redirect(\`/items/\${created.id}\`)`. Only return
+`json()` from a create surface for validation errors or when the user
+must stay on the same page.
+
+## Verification before reporting
+
+1. Confirm the form's `method` is POST (or PUT/PATCH/DELETE). GET forms
+   are exempt from these rules.
+2. Confirm there is a real route `action` (or that one is expected).
+   `fetch()` against a deliberately non-Remix endpoint may be correct.
+3. Confirm `<form>` is the lowercase native element, not the imported
+   `Form` from `@remix-run/react`. A grep for `from "@remix-run/react"`
+   in the file usually settles it.
+4. For row-pending issues, confirm the surrounding list actually
+   renders multiple instances — a one-row "list" is not a bug.
+5. For "should redirect" findings, confirm the route's path segment
+   implies creation (e.g. `/items/new`, `/posts/create`). A nested
+   form on a dashboard or detail page may legitimately stay put.
+
+## Severity guidance
+
+- **High** — Manual `fetch()` for any POST in-app mutation; missing
+  `encType` on a file upload; trusting `formData.get()` as DB input.
+- **Medium** — Native `<form>` for POST; `useFetcher` where `<Form>` +
+  `redirect` is correct; action returning `json` on a `/new` route.
+- **Low** — `<Form>` where `useFetcher` would be lighter (rarely worth
+  flagging unless the surface lists multiple rows).

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/multi-action-routes.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/multi-action-routes.md
@@ -1,0 +1,159 @@
+# Multi-action Routes & Method Choice
+
+Flag route file sprawl that the intent pattern would collapse, missing
+submit buttons that break progressive enhancement, and `method="put"` /
+`"patch"` / `"delete"` without a JS-only acknowledgement. See
+[beagle-remix-v2:remix-v2-forms](../../remix-v2-forms/SKILL.md) for the
+canonical intent pattern.
+
+## Anti-pattern 1 — Separate routes for sibling mutations
+
+```text
+// BAD — file tree
+app/routes/
+  tweets.$id.like.tsx
+  tweets.$id.unlike.tsx
+  tweets.$id.retweet.tsx
+  tweets.$id.delete.tsx
+```
+
+```tsx
+// Each route has a tiny action and no default export
+export async function action({ params }: ActionFunctionArgs) {
+  await likeTweet(params.id!);
+  return json({ ok: true });
+}
+```
+
+**Why bad:** Four route files for one logical resource. Each duplicates
+parsing, auth checks, and revalidation scope. The component now juggles
+four `useFetcher()` instances or four `<Form action>` targets when one
+would do. Adds friction for new operations (every new mutation needs a
+new file).
+
+**Fix:** Single route `app/routes/tweets.$id.tsx` with one `action`
+that switches on `formData.get("intent")`. Each operation is a `<button
+name="intent" value="...">` inside one `<fetcher.Form>`.
+
+```tsx
+export async function action({ request, params }: ActionFunctionArgs) {
+  const fd = await request.formData();
+  switch (fd.get("intent")) {
+    case "like":    return json(await likeTweet(params.id!));
+    case "retweet": return json(await retweetTweet(params.id!));
+    case "delete":  return json(await deleteTweet(params.id!));
+    default: throw new Response("Unknown intent", { status: 400 });
+  }
+}
+
+export default function Tweet() {
+  const fetcher = useFetcher();
+  const pendingIntent = fetcher.formData?.get("intent");
+  return (
+    <fetcher.Form method="post">
+      <button name="intent" value="like" disabled={pendingIntent === "like"}>Like</button>
+      <button name="intent" value="retweet" disabled={pendingIntent === "retweet"}>RT</button>
+      <button name="intent" value="delete">Delete</button>
+    </fetcher.Form>
+  );
+}
+```
+
+**Exemptions — do NOT flag:**
+
+- The mutations live on genuinely different resources (`/posts/:id/like`
+  vs `/users/:id/follow`).
+- Each route owns substantively different auth, validation, or
+  revalidation requirements.
+- One mutation is a webhook target and not a UI submission.
+
+## Anti-pattern 2 — Action chooses intent from non-button source
+
+```tsx
+// BAD — intent inferred from field presence
+export async function action({ request }: ActionFunctionArgs) {
+  const fd = await request.formData();
+  if (fd.has("like")) return like();
+  if (fd.has("retweet")) return retweet();
+}
+```
+
+**Why bad:** Only the clicked submit button's `name=value` lands in the
+body. Inferring intent from field presence couples the action to a
+specific render order and breaks under refactor. Pressing Enter in a
+text input submits the FIRST button in DOM order, so the inferred
+intent may not match user expectation.
+
+**Fix:** Use `<button name="intent" value="...">` and read
+`formData.get("intent")`. Order buttons so the first is the correct
+Enter-key default.
+
+## Anti-pattern 3 — `method="put"` / `"patch"` / `"delete"` without fallback
+
+```tsx
+// BAD — works only with JS
+<Form method="delete" action={`/posts/${id}`}>
+  <button>Delete</button>
+</Form>
+```
+
+**Why bad:** Native HTML forms only support `GET` and `POST`. Without
+JS, the browser degrades `method="delete"` to GET, which usually hits
+the loader (or 405s the action) — the delete silently never happens.
+Progressive enhancement is silently broken.
+
+**Fix:** If progressive enhancement matters for this surface, use
+`method="post"` and dispatch via an `intent` field:
+
+```tsx
+<Form method="post" action={`/posts/${id}`}>
+  <input type="hidden" name="intent" value="delete" />
+  <button>Delete</button>
+</Form>
+```
+
+If the surface is admin-only or JS-required, document the constraint
+near the form and move on. Flag missing acknowledgement, not the
+choice itself.
+
+**Exemptions — do NOT flag:**
+
+- The route is explicitly an internal admin tool with a JS requirement
+  documented in `CLAUDE.md`, README, or a comment.
+- The form is `method="get"` — GET is the only other HTML-native verb
+  and works fine without JS.
+
+## Anti-pattern 4 — `<button type="button">` as the only submit
+
+```tsx
+// BAD — no native submit path
+<Form method="post">
+  <input name="title" />
+  <button type="button" onClick={() => submit(formRef.current!)}>Save</button>
+</Form>
+```
+
+**Why bad:** Without JS, pressing Enter or clicking "Save" does
+nothing — the action never runs. Progressive enhancement is gone.
+
+**Fix:** Keep at least one `<button>` (default `type="submit"`) inside
+the `<Form>` body so the native submit path works. Use `useSubmit()`
+only for genuinely programmatic submission (autosave, keyboard
+shortcuts) and pair it with a real submit button as fallback.
+
+**Exemptions — do NOT flag:** JS-only admin tool with documented
+constraint; controlled wizard step where the parent owns submit.
+
+## Verification before reporting
+
+1. For separate-routes findings, read all sibling route files and
+   confirm the mutations are genuinely on the same resource with
+   compatible auth and validation. False positives are common when the
+   routes look similar but encapsulate different domains.
+2. For PUT/PATCH/DELETE findings, check whether the project has a
+   declared no-JS-fallback stance (`CLAUDE.md`, repo README, or
+   per-file comments). If so, downgrade to a low-severity note.
+3. For intent-inference findings, confirm there is at least one
+   `<button name="intent">` somewhere — many codebases mix patterns
+   inconsistently.
+4. For missing-submit-button findings, confirm no `<button>` (without `type="button"`) and no `<input type="submit">` exists inside the `<Form>`.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/multi-action-routes.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/multi-action-routes.md
@@ -88,6 +88,8 @@ intent may not match user expectation.
 `formData.get("intent")`. Order buttons so the first is the correct
 Enter-key default.
 
+Older codebases may use `_action` instead of `intent` — treat as equivalent; do not flag the spelling difference unless the action handler hardcodes one name.
+
 ## Anti-pattern 3 — `method="put"` / `"patch"` / `"delete"` without fallback
 
 ```tsx

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/pending-state.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/pending-state.md
@@ -1,0 +1,187 @@
+# Pending State Anti-patterns
+
+Flag code that re-implements pending state Remix already owns, or wires
+the wrong observer to the wrong submission. See
+[beagle-remix-v2:remix-v2-forms](../../remix-v2-forms/SKILL.md) for the
+`useNavigation` vs `fetcher.state` decision gates.
+
+## Anti-pattern 1 — `useState` loading flag alongside `<Form>` / `useFetcher`
+
+```tsx
+// BAD
+function Signup() {
+  const [isLoading, setIsLoading] = useState(false);
+  return (
+    <Form
+      method="post"
+      onSubmit={() => setIsLoading(true)}
+    >
+      <input name="email" />
+      <button disabled={isLoading}>
+        {isLoading ? "Signing up..." : "Sign Up"}
+      </button>
+    </Form>
+  );
+}
+```
+
+**Why bad:** Duplicates state Remix already owns. The flag diverges
+from `navigation.state` on:
+
+- Server-side errors (state never flips back if you forget the
+  `useActionData` effect).
+- `redirect()` responses (the new route mounts a fresh component, so
+  the flag is stuck `true` until cleanup runs).
+- Double-submits and rapid clicks (no race-safe handoff).
+- No JS — the button is enabled, the form posts, the flag never sets,
+  so any reliance on it breaks progressive enhancement.
+
+**Fix:** Derive busy state from `useNavigation()` for `<Form>` or
+`fetcher.state` for `useFetcher`.
+
+```tsx
+const nav = useNavigation();
+const busy = nav.state !== "idle" && nav.formAction === "/signup";
+```
+
+Filter by `formAction` whenever the surface might see other navigations
+(sidebar links, sibling forms) — otherwise unrelated nav lights up your
+spinner.
+
+## Anti-pattern 2 — `useNavigation` driving a per-row spinner
+
+```tsx
+// BAD
+function FavoriteList({ items }: { items: Item[] }) {
+  const nav = useNavigation();
+  return items.map((i) => (
+    <fetcher.Form key={i.id} method="post" action={`/items/${i.id}/fav`}>
+      <button disabled={nav.state !== "idle"}>Favorite</button>
+    </fetcher.Form>
+  ));
+}
+```
+
+**Why bad:** `useNavigation` does **not** observe fetcher activity. If
+each row submits via its own `useFetcher`, the page-level
+`navigation.state` stays `"idle"` and the spinner never lights up.
+
+Even if rows used `<Form>` instead, every row would disable on every
+submission because `navigation.state` is page-global.
+
+**Fix:** Use one `useFetcher()` per row and key pending state off that
+fetcher's state. To express a true "anything in flight" indicator, use
+`useFetchers()` at the page level.
+
+```tsx
+function Row({ item }: { item: Item }) {
+  const fetcher = useFetcher();
+  const pending = fetcher.state !== "idle";
+  return (
+    <fetcher.Form method="post" action={`/items/${item.id}/fav`}>
+      <button disabled={pending} aria-busy={pending}>Favorite</button>
+    </fetcher.Form>
+  );
+}
+```
+
+## Anti-pattern 3 — Missing pending state entirely
+
+```tsx
+// BAD — user gets no feedback during a 2s mutation
+export default function Comment() {
+  return (
+    <Form method="post">
+      <textarea name="body" />
+      <button>Post</button>
+    </Form>
+  );
+}
+```
+
+**Why bad:** The user double-clicks, submits twice, and waits with no
+indication anything happened. On a slow connection, the form looks
+broken.
+
+**Fix:** Read `useNavigation()` (for `<Form>`) or `fetcher.state` (for
+`useFetcher`) and disable the submit button or surface a spinner.
+Filter on `formAction` so an unrelated nav (sidebar link) does not
+disable your form.
+
+**Exemptions — do NOT flag:**
+
+- The button is non-interactive after submit (e.g. unmounted by a
+  conditional render that depends on `useActionData`).
+- The surface is read-only / no real mutation.
+- A wrapping layout already renders a top-level pending indicator
+  (root-level `useNavigation` bar).
+
+## Anti-pattern 4 — `useNavigation()` without a `formAction` filter
+
+```tsx
+// BAD — sidebar Link navigations also disable this button
+const nav = useNavigation();
+const busy = nav.state !== "idle";
+```
+
+**Why bad:** `navigation.state` flips for ANY navigation in the route
+tree. Clicking a sidebar `<Link>` will disable an unrelated submit
+button and surface a spinner that has nothing to do with the form.
+
+**Fix:** Compare `navigation.formAction` to the form's action path:
+
+```tsx
+const nav = useNavigation();
+const busy = nav.state !== "idle" && nav.formAction === "/signup";
+```
+
+For forms posting to the current route, capture the route's path from
+`useLocation()` or hardcode the literal — both are correct.
+
+**Exemptions — do NOT flag:**
+
+- The button is in `root.tsx` and intentionally reflects ALL nav.
+- The surface is a single-form route where no other navigation is
+  reachable (rare; usually still safer to filter).
+
+## Anti-pattern 5 — Reading `fetcher.state` from the wrong fetcher
+
+```tsx
+// BAD — two fetchers, one observed
+function Row({ item }: { item: Item }) {
+  const likeFetcher = useFetcher();
+  const deleteFetcher = useFetcher();
+  const busy = likeFetcher.state !== "idle";  // ignores delete
+  return (
+    <>
+      <likeFetcher.Form method="post" action={`/items/${item.id}/like`}>
+        <button disabled={busy}>Like</button>
+      </likeFetcher.Form>
+      <deleteFetcher.Form method="post" action={`/items/${item.id}/delete`}>
+        <button disabled={busy}>Delete</button>
+      </deleteFetcher.Form>
+    </>
+  );
+}
+```
+
+**Why bad:** Pending state of "like" is wired to the delete button.
+Visual feedback is inverted.
+
+**Fix:** Either observe both (`busy = like.state !== "idle" ||
+delete.state !== "idle"`) or — better — use the intent pattern on a
+single fetcher so only the clicked button is "in flight". See
+[multi-action-routes.md](multi-action-routes.md).
+
+## Verification before reporting
+
+1. Grep the file for `useState`, `useNavigation`, `useFetcher`,
+   `fetcher.state`. A real loading flag often shadows what is really
+   happening.
+2. Confirm `<Form method>` is POST (or non-GET). GET forms only ever
+   produce `"loading"`, never `"submitting"`, so some patterns look
+   different on GET.
+3. Confirm the per-row vs page-global axis by reading the surrounding
+   `.map()` — page-global checks are correct on a single-form route.
+4. Confirm `nav.formAction` checks the right path; an outdated literal
+   is worth flagging as a soft warning, not a critical bug.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/pending-state.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/pending-state.md
@@ -178,9 +178,10 @@ single fetcher so only the clicked button is "in flight". See
 1. Grep the file for `useState`, `useNavigation`, `useFetcher`,
    `fetcher.state`. A real loading flag often shadows what is really
    happening.
-2. Confirm `<Form method>` is POST (or non-GET). GET forms only ever
-   produce `"loading"`, never `"submitting"`, so some patterns look
-   different on GET.
+2. Confirm `<Form method>` is POST (or non-GET). GET forms driven by
+   `useNavigation` only ever produce `"loading"`, never `"submitting"`,
+   so some patterns look different on GET. (`<fetcher.Form method='get'>`
+   driven by `fetcher.state` DOES produce `"submitting"`.)
 3. Confirm the per-row vs page-global axis by reading the surrounding
    `.map()` — page-global checks are correct on a single-form route.
 4. Confirm `nav.formAction` checks the right path; an outdated literal

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/uploads-validation.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/uploads-validation.md
@@ -36,7 +36,7 @@ upload directly to object storage for anything larger than ~1 MB.
 ```tsx
 const handler = unstable_createMemoryUploadHandler({
   maxPartSize: 500_000,           // 500 KB cap; reject larger uploads
-  filter: ({ contentType }) => contentType?.startsWith("image/"),
+  filter: ({ contentType }) => contentType.startsWith("image/"),
 });
 ```
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/uploads-validation.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms-review/references/uploads-validation.md
@@ -1,0 +1,191 @@
+# Uploads, FormData Validation & Optimistic State
+
+Flag upload handlers that can be weaponized for DoS, file inputs that
+silently strip their contents, FormData consumed without validation,
+and optimistic UI that drifts from `fetcher.formData`. See
+[beagle-remix-v2:remix-v2-forms](../../remix-v2-forms/SKILL.md) for the
+canonical upload and optimistic patterns.
+
+## Anti-pattern 1 — Unbounded `unstable_createMemoryUploadHandler`
+
+```tsx
+// BAD — no maxPartSize, user input
+import {
+  unstable_createMemoryUploadHandler,
+  unstable_parseMultipartFormData,
+} from "@remix-run/node";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const handler = unstable_createMemoryUploadHandler({});  // no cap
+  const fd = await unstable_parseMultipartFormData(request, handler);
+  await storeAvatar(fd.get("avatar"));
+  return redirect("/account");
+}
+```
+
+**Why bad:** The memory upload handler buffers entire uploads into RAM.
+Without `maxPartSize`, a single malicious POST with a multi-gigabyte
+body can OOM the server. This is a denial-of-service surface, not a
+theoretical concern — it is exploitable from the public internet by
+anyone who can submit the form.
+
+**Fix:** Always pass `maxPartSize`, and prefer
+`unstable_createFileUploadHandler` (disk-backed) or a streaming
+upload directly to object storage for anything larger than ~1 MB.
+
+```tsx
+const handler = unstable_createMemoryUploadHandler({
+  maxPartSize: 500_000,           // 500 KB cap; reject larger uploads
+  filter: ({ contentType }) => contentType?.startsWith("image/"),
+});
+```
+
+**Exemptions — do NOT flag:**
+
+- Internal admin-only routes behind authentication where input size is
+  bounded by upstream constraints (still better to set a cap).
+- A fixed-size internal artifact uploaded by a trusted job runner.
+
+## Anti-pattern 2 — Missing `encType="multipart/form-data"` on file upload
+
+```tsx
+// BAD — file data is silently stripped
+export default function AvatarRoute() {
+  return (
+    <Form method="post">
+      <input type="file" name="avatar" />
+      <button>Upload</button>
+    </Form>
+  );
+}
+```
+
+**Why bad:** Without `encType="multipart/form-data"`, the browser
+encodes the form as `application/x-www-form-urlencoded`.
+`request.formData()` then yields the filename string for `avatar`, not
+a `File` instance. The upload silently fails — the action runs, sees a
+string where it expected a file, and either errors out or stores
+garbage.
+
+**Fix:** Set `encType="multipart/form-data"` on the `<Form>` and parse
+in the action via `unstable_parseMultipartFormData` with a bounded
+upload handler.
+
+```tsx
+<Form method="post" encType="multipart/form-data">
+  <input type="file" name="avatar" accept="image/*" />
+  <button>Upload</button>
+</Form>
+```
+
+## Anti-pattern 3 — `request.formData()` values trusted as-is
+
+```tsx
+// BAD
+export async function action({ request }: ActionFunctionArgs) {
+  const fd = await request.formData();
+  await db.user.update({
+    where: { id: fd.get("id") as string },
+    data: {
+      email: fd.get("email") as string,
+      age: Number(fd.get("age")),
+    },
+  });
+  return redirect("/account");
+}
+```
+
+**Why bad:** `FormData.get()` returns `FormDataEntryValue | null` — a
+string, a `File`, or `null`. `as string` lies to the type system. An
+empty form field, a repeated key, a file upload masquerading as a
+text input, or a missing key all flow straight into the DB. `Number()`
+on `null` is `0`; on an empty string is also `0`. Coercion silently
+corrupts data.
+
+**Fix:** Validate every field. Cast explicitly with
+`String(fd.get("x") ?? "")`, then run a schema validator (Zod,
+Valibot, or hand-rolled checks) before any DB call.
+
+```tsx
+const id = String(fd.get("id") ?? "");
+const email = String(fd.get("email") ?? "");
+const age = Number(fd.get("age") ?? "");
+
+if (!id) return json({ error: "missing id" }, { status: 400 });
+if (!email.includes("@")) return json({ errors: { email: "invalid" } }, { status: 400 });
+if (!Number.isFinite(age) || age < 0) return json({ errors: { age: "invalid" } }, { status: 400 });
+```
+
+**Exemptions — do NOT flag:**
+
+- A wrapper helper (e.g. `parseForm(request, schema)`) is in use and
+  delegates validation. Flag only the call sites that bypass it.
+- The action is server-internal (e.g. called only by another action via
+  `fetch` on the server) where input shape is provably bounded.
+
+## Anti-pattern 4 — Mirroring `fetcher.formData` into local state
+
+```tsx
+// BAD
+function FavoriteButton({ favorited }: { favorited: boolean }) {
+  const fetcher = useFetcher();
+  const [optimistic, setOptimistic] = useState(favorited);
+  return (
+    <fetcher.Form
+      method="post"
+      onSubmit={() => setOptimistic((v) => !v)}
+    >
+      <input type="hidden" name="favorited" value={String(!optimistic)} />
+      <button aria-pressed={optimistic}>Favorite</button>
+    </fetcher.Form>
+  );
+}
+```
+
+**Why bad:** Two sources of truth. On an action error, `fetcher.data`
+returns the failure but local state still shows the optimistic flipped
+value. The button is now lying about the server's state. The user
+clicks again, the state mismatches further, debugging gets ugly.
+
+**Fix:** Read directly from `fetcher.formData` each render. It is
+populated synchronously on submit and cleared automatically when
+`fetcher.state === "idle"`.
+
+```tsx
+function FavoriteButton({ id, favorited }: { id: string; favorited: boolean }) {
+  const fetcher = useFetcher();
+  const pendingFavorited = fetcher.formData
+    ? fetcher.formData.get("favorited") === "true"
+    : favorited;
+  return (
+    <fetcher.Form method="post" action={`/items/${id}/favorite`}>
+      <input type="hidden" name="favorited" value={String(!pendingFavorited)} />
+      <button aria-pressed={pendingFavorited}>Favorite</button>
+    </fetcher.Form>
+  );
+}
+```
+
+The same rule applies to `navigation.formData` for `<Form>` submissions.
+
+**Exemptions — do NOT flag:**
+
+- A genuine local UI state that does not represent the in-flight
+  submission (e.g. a modal-open flag).
+- A debounced text input where local state is the controlled value and
+  only the submitted version flows through `fetcher.formData`.
+
+## Verification before reporting
+
+1. For an unbounded-upload finding, confirm the `unstable_create*`
+   handler is invoked without `maxPartSize` (or with a suspiciously
+   high cap) on a route reachable by unauthenticated users.
+2. For a missing `encType` finding, confirm at least one
+   `<input type="file">` is rendered inside the same `<Form>` and the
+   method is POST.
+3. For a FormData-validation finding, confirm there is no wrapper /
+   schema helper called before the DB write. Grep for Zod / Valibot /
+   `parseForm` first.
+4. For a mirrored-optimistic-state finding, confirm the local state
+   actually shadows what `fetcher.formData` already exposes — a local
+   "is-editing" flag is not the same bug.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/SKILL.md
@@ -49,9 +49,11 @@ export default function Signup() {
 | Name | Purpose |
 |---|---|
 | `<Form>` from `@remix-run/react` | Navigating, progressively-enhanced form that posts to a route `action` and triggers full-page revalidation |
+| `<Form navigate={false}>` | Shorthand for "post via fetcher; do not navigate." Equivalent to `<fetcher.Form>` without holding a fetcher ref — useful when you only need pending state, not a programmatic handle |
 | `useFetcher()` | Non-navigating submission channel for inline mutations, list rows, popovers — same revalidation, no URL change |
+| `useFetchers()` | **Read-only** array of all in-flight fetcher states across the app. Use for global pending indicators (top-bar loader) without prop drilling. No `Form`/`submit`/`load` methods on the returned items — just `formData`, `state`, etc. |
 | `useNavigation()` | Observes page-level navigation; the source of truth for `<Form>` pending state |
-| `useSubmit()` | Programmatic submission (onChange autosave, keyboard shortcuts) |
+| `useSubmit()` | Programmatic submission (onChange autosave, keyboard shortcuts). Accepts `HTMLFormElement`, `FormData`, plain object (form-encoded), or plain object encoded as JSON via `{ encType: "application/json" }` |
 | `useActionData<typeof action>()` | Read the most recent action result for the current route |
 
 State transitions:

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: remix-v2-forms
+description: Remix v2 form submissions and mutations. Use when implementing forms, optimistic UI, file uploads, or multi-action routes. Triggers on <Form>, useFetcher, useSubmit, useNavigation for pending state, unstable_parseMultipartFormData, fetcher.formData, intent-based actions, encType multipart.
+---
+
+# Remix v2 Forms & Mutations
+
+Canonical mutation primitives for the `@remix-run/react@^2` route-module
+framework. A correct Remix v2 mutation is: a `<Form method="post">` (or
+`<fetcher.Form>`), an `action` that parses `request.formData()` and returns
+either `redirect(...)` or `json(...)`, and UI that reads `useActionData()`
+(or `fetcher.data`) for errors plus `useNavigation()` (or `fetcher.state`)
+for pending state. Anything that bypasses this loop — `fetch()`, raw
+`<form>`, `e.preventDefault()` + client state — silently sacrifices
+revalidation, progressive enhancement, and race-safe transitions.
+
+## Quick Reference
+
+**`<Form>` + action**:
+
+```tsx
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { Form, useActionData, useNavigation } from "@remix-run/react";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "");
+  if (!email.includes("@")) return json({ errors: { email: "Invalid" } }, { status: 400 });
+  await createUser({ email });
+  return redirect("/dashboard");
+}
+
+export default function Signup() {
+  const actionData = useActionData<typeof action>();
+  const nav = useNavigation();
+  const busy = nav.state !== "idle" && nav.formAction === "/signup";
+  return (
+    <Form method="post" replace>
+      <input name="email" type="email" />
+      {actionData?.errors?.email ? <em>{actionData.errors.email}</em> : null}
+      <button disabled={busy}>{busy ? "Signing up..." : "Sign Up"}</button>
+    </Form>
+  );
+}
+```
+
+## Primitives
+
+| Name | Purpose |
+|---|---|
+| `<Form>` from `@remix-run/react` | Navigating, progressively-enhanced form that posts to a route `action` and triggers full-page revalidation |
+| `useFetcher()` | Non-navigating submission channel for inline mutations, list rows, popovers — same revalidation, no URL change |
+| `useNavigation()` | Observes page-level navigation; the source of truth for `<Form>` pending state |
+| `useSubmit()` | Programmatic submission (onChange autosave, keyboard shortcuts) |
+| `useActionData<typeof action>()` | Read the most recent action result for the current route |
+
+State transitions:
+
+- `useNavigation().state`: `idle → submitting → loading → idle` for non-GET
+  form submissions; `idle → loading → idle` for GET navigation.
+- `useFetcher().state`: `idle → submitting → loading → idle` (submitting
+  only present for non-GET).
+
+## Key Patterns
+
+### `<Form>` for navigation, `useFetcher` for in-place
+
+`<Form>` changes the URL, adds history, and revalidates all loaders.
+`useFetcher` does the same revalidation but stays on the current URL.
+Each `useFetcher()` call returns an independent submission channel, so
+two rows submitting at once do not share pending state.
+
+### Intent pattern for multiple actions on one route
+
+One `action`, switch on `formData.get("intent")`, distinct
+`<button name="intent" value="...">` per operation. Only the clicked
+submit button's `name=value` lands in the body. See
+[references/intent-actions.md](references/intent-actions.md).
+
+### Optimistic UI from `formData`
+
+`fetcher.formData` and `navigation.formData` are populated synchronously
+on submit and cleared at `idle`. Read directly each render; never mirror
+into local React state. See
+[references/optimistic-ui.md](references/optimistic-ui.md).
+
+### File uploads need `encType="multipart/form-data"`
+
+Without it, `request.formData()` strips file data and you get the
+filename string instead of a `File`. Parse with
+`unstable_parseMultipartFormData` and a bounded upload handler. The
+`unstable_` prefix is permanent in v2. See
+[references/uploads.md](references/uploads.md).
+
+## Gates (decision sequencing)
+
+Answer **in order**. **Pass** means the condition is true; pick the API
+on the same line and **stop**.
+
+### `<Form>` vs `useFetcher`
+
+1. **Does the URL need to change after the mutation** (creating a record
+   and routing to `/records/:id`, deleting and going back to a list,
+   multi-step flow)?
+   - **Pass →** `<Form method="post">` + `redirect(...)` from the action. **Stop.**
+   - **Fail →** Step 2.
+2. **Is this a mutation against a row, cell, toggle, or sub-section while
+   the user stays on the same page** (favorite, like, increment quantity,
+   inline edit)?
+   - **Pass →** `useFetcher()` with `<fetcher.Form>`. **Stop.**
+   - **Fail →** Step 3.
+3. **Is this loading data outside of normal navigation** (popover content,
+   combobox results, prefetch)?
+   - **Pass →** `fetcher.load(href)`. **Stop.**
+   - **Fail →** Default to `<Form>`. Navigation is the conservative
+     choice — revalidation and history work out of the box.
+
+Hard rule: never reach for `fetch()` or `axios` for in-app mutations
+against your own Remix routes. That bypasses the action lifecycle and
+skips loader revalidation.
+
+### `useNavigation` vs `useFetcher.state` for pending state
+
+1. **Is the pending indicator global** (page spinner in root, top-bar
+   loading bar)?
+   - **Pass →** `useNavigation()` in `root.tsx`
+     (`navigation.state !== "idle"`). **Stop.**
+   - **Fail →** Step 2.
+2. **Was the mutation made with `useFetcher`?**
+   - **Pass →** Use that fetcher's `fetcher.state`. `useNavigation()`
+     will NOT reflect fetcher activity. **Stop.**
+   - **Fail →** Step 3.
+3. **Is the indicator scoped to one row/button inside a list where each
+   row has its own fetcher?**
+   - **Pass →** Use the per-row `fetcher.state` (or look up by key via
+     `useFetchers()`) so other rows do not flicker. **Stop.**
+   - **Fail →** Step 4.
+4. **Is the indicator scoped to the form just submitted via `<Form>`?**
+   - **Pass →** `useNavigation()` AND check
+     `navigation.formAction === "/expected-path"` so unrelated navigations
+     don't trigger your local spinner. **Stop.**
+   - **Fail →** Step 5.
+5. **Need to render an optimistic value?**
+   - **Pass →** Read `navigation.formData?.get("field")` (page form) or
+     `fetcher.formData?.get("field")` (fetcher) — both are populated
+     while `state !== "idle"`. **Stop.**
+
+## Additional Documentation
+
+- **`<Form>` component**: See [references/form.md](references/form.md) for
+  `<Form>` vs native `<form>` vs `fetch()`, progressive enhancement,
+  redirect-after-success, and validation error display via `useActionData`.
+- **`useFetcher`**: See [references/fetcher.md](references/fetcher.md) for
+  inline mutations, list operations, popovers, `fetcher.state`,
+  `fetcher.data`, `fetcher.Form`, `fetcher.submit`, `fetcher.load`.
+- **Optimistic UI**: See
+  [references/optimistic-ui.md](references/optimistic-ui.md) for
+  `fetcher.formData` and `useNavigation.formData`, when to apply, and
+  reverting on failure.
+- **File uploads**: See [references/uploads.md](references/uploads.md)
+  for `unstable_parseMultipartFormData`,
+  `unstable_createMemoryUploadHandler`,
+  `unstable_createFileUploadHandler`, and bounded handlers.
+- **Intent-based actions**: See
+  [references/intent-actions.md](references/intent-actions.md) for
+  multiple actions on one route via the FormData `intent` field.
+
+## Comparison
+
+| Concern | `<Form>` | `useFetcher` | Native `<form>` | `fetch()` |
+|---|---|---|---|---|
+| URL change / history entry | Yes | No | Yes (hard nav) | No |
+| Works without JS | Yes | Yes (via degraded `<Form>`) | Yes | No |
+| Revalidates loaders | Yes | Yes | Yes (hard reload) | No |
+| Pending state hook | `useNavigation()` | `fetcher.state` | None | Manual |
+| Optimistic input source | `navigation.formData` | `fetcher.formData` | None | Manual |
+| In-app mutation use case | Create / delete / multi-step | Inline / row / toggle | External targets only | Never for own routes |

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/SKILL.md
@@ -58,8 +58,9 @@ State transitions:
 
 - `useNavigation().state`: `idle → submitting → loading → idle` for non-GET
   form submissions; `idle → loading → idle` for GET navigation.
-- `useFetcher().state`: `idle → submitting → loading → idle` (submitting
-  only present for non-GET).
+- `useFetcher().state`: `idle → submitting → loading → idle`.
+
+**Asymmetry:** `useNavigation` skips `submitting` for GET navigations; `useFetcher` does NOT — only `fetcher.load()` skips it. `<fetcher.Form method='get'>` and `fetcher.submit(..., {method:'get'})` both transition through `submitting`.
 
 ## Key Patterns
 
@@ -170,7 +171,7 @@ skips loader revalidation.
 | Concern | `<Form>` | `useFetcher` | Native `<form>` | `fetch()` |
 |---|---|---|---|---|
 | URL change / history entry | Yes | No | Yes (hard nav) | No |
-| Works without JS | Yes | Yes (via degraded `<Form>`) | Yes | No |
+| Works without JS | Yes | Yes | Yes | No |
 | Revalidates loaders | Yes | Yes | Yes (hard reload) | No |
 | Pending state hook | `useNavigation()` | `fetcher.state` | None | Manual |
 | Optimistic input source | `navigation.formData` | `fetcher.formData` | None | Manual |

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/fetcher.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/fetcher.md
@@ -23,8 +23,9 @@ fetcher.formAction    // target action URL while in flight
 fetcher.formMethod    // method while in flight
 ```
 
-State transitions: `idle → submitting → loading → idle` (submitting only
-present for non-GET).
+State transitions: `idle → submitting → loading → idle`.
+
+**Asymmetry:** `useNavigation` skips `submitting` for GET navigations; `useFetcher` does NOT — only `fetcher.load()` skips it. `<fetcher.Form method='get'>` and `fetcher.submit(..., {method:'get'})` both transition through `submitting`.
 
 ## When to Reach for `useFetcher`
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/fetcher.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/fetcher.md
@@ -1,0 +1,190 @@
+# `useFetcher`
+
+A non-navigating submission channel. `useFetcher` posts to a route
+`action` (or loads from a route `loader`) and triggers the same loader
+revalidation as `<Form>` — but it does not change the URL, does not add
+a history entry, and does not reset scroll. Each `useFetcher()` call
+returns an independent fetcher, so concurrent submissions in different
+components do not share pending state.
+
+## Signature
+
+```tsx
+const fetcher = useFetcher<TLoaderOrAction>({ key? });
+
+// Returned API
+fetcher.Form          // <fetcher.Form method="post"> — like <Form>, no nav
+fetcher.submit(data, options?)  // programmatic submit
+fetcher.load(href)    // GET-load data from a route's loader
+fetcher.state         // "idle" | "submitting" | "loading"
+fetcher.data          // last loader/action response (typed via generic)
+fetcher.formData      // FormData in flight (populated while state !== "idle")
+fetcher.formAction    // target action URL while in flight
+fetcher.formMethod    // method while in flight
+```
+
+State transitions: `idle → submitting → loading → idle` (submitting only
+present for non-GET).
+
+## When to Reach for `useFetcher`
+
+- Inline edit on a list row (favorite, like, increment, status toggle).
+- Mutation from a popover/modal that should leave the underlying page
+  intact.
+- Combobox results, popover content, prefetch — `fetcher.load()`.
+- Any mutation where a URL change would be wrong (no shareable URL, no
+  new screen).
+
+Use `<Form>` instead whenever the URL should change after the mutation
+(create a record, delete and go back to list, multi-step flow).
+
+## Inline Mutation (No URL Change)
+
+```tsx
+// app/components/favorite-button.tsx
+import { useFetcher } from "@remix-run/react";
+
+export function FavoriteButton({ id, favorited }: { id: string; favorited: boolean }) {
+  const fetcher = useFetcher();
+  // Optimistic: trust the in-flight intent if present.
+  const pendingFavorited = fetcher.formData
+    ? fetcher.formData.get("favorited") === "true"
+    : favorited;
+  return (
+    <fetcher.Form method="post" action={`/items/${id}/favorite`}>
+      <input type="hidden" name="favorited" value={String(!pendingFavorited)} />
+      <button aria-pressed={pendingFavorited}>
+        {pendingFavorited ? "Unfavorite" : "Favorite"}
+      </button>
+    </fetcher.Form>
+  );
+}
+```
+
+Each row gets its own `useFetcher`, so two rows submitting at once do not
+share a pending state. The optimistic `pendingFavorited` reads directly
+from `fetcher.formData` each render — no local state to drift on error.
+
+## List Operations
+
+For a list where each row can mutate, each row owns its own fetcher.
+Page-global `useNavigation()` will NOT observe fetcher activity. If you
+want a "something is loading anywhere" indicator, use `useFetchers()` to
+enumerate all in-flight fetchers.
+
+```tsx
+import { useFetchers } from "@remix-run/react";
+
+function GlobalSpinner() {
+  const fetchers = useFetchers();
+  const anyBusy = fetchers.some((f) => f.state !== "idle");
+  return anyBusy ? <Spinner /> : null;
+}
+```
+
+## Popovers and `fetcher.load`
+
+`fetcher.load(href)` fetches a route's loader without navigating. Useful
+for hover cards, comboboxes, and prefetch.
+
+```tsx
+import { useEffect } from "react";
+import { useFetcher } from "@remix-run/react";
+
+export function UserHoverCard({ id }: { id: string }) {
+  const fetcher = useFetcher<typeof loader>();
+  useEffect(() => {
+    if (fetcher.state === "idle" && !fetcher.data) {
+      fetcher.load(`/users/${id}`);
+    }
+  }, [id, fetcher]);
+  if (fetcher.state === "loading") return <p>Loading...</p>;
+  if (!fetcher.data) return null;
+  return <UserCard user={fetcher.data} />;
+}
+```
+
+## Programmatic Submission with `fetcher.submit`
+
+```tsx
+const fetcher = useFetcher();
+
+// Submit raw FormData
+const fd = new FormData();
+fd.set("intent", "delete");
+fetcher.submit(fd, { method: "post", action: `/items/${id}` });
+
+// Submit a plain object (encoded as FormData)
+fetcher.submit({ intent: "archive" }, { method: "post" });
+
+// Post JSON instead of FormData
+fetcher.submit({ ids: [1, 2, 3] }, {
+  method: "post",
+  encType: "application/json",
+});
+```
+
+When you submit with `encType: "application/json"`, in the action use
+`await request.json()` — `request.formData()` will throw.
+
+## Reading `fetcher.data`
+
+`fetcher.data` is the typed response of the last action or loader call
+through this fetcher. Use the generic `useFetcher<typeof action>()` to
+get the serialized action return type, including validation errors.
+
+```tsx
+const fetcher = useFetcher<typeof action>();
+const error = fetcher.data?.errors?.title;
+```
+
+`fetcher.data` persists until the fetcher next submits, similar to
+`useActionData`.
+
+## Shared Fetchers via `fetcherKey`
+
+A `useFetcher({ key })` and a `<Form navigate={false} fetcherKey={key}>`
+with the same key share submission state. Useful when a submission
+should remain observable while the user navigates to a different
+component — e.g. a sidebar that watches an in-flight upload started on
+another route. Surprising when reused accidentally.
+
+```tsx
+// Sidebar — observe whether a known fetcher is in flight
+import { useFetchers } from "@remix-run/react";
+
+function UploadStatus() {
+  const fetchers = useFetchers();
+  const upload = fetchers.find((f) => f.key === "avatar-upload");
+  return upload?.state !== "idle" ? <p>Uploading...</p> : null;
+}
+```
+
+## Anti-Patterns
+
+- **`useFetcher` when the URL should change** — no history entry, no
+  scroll reset, no shareable URL, back button skips the just-completed
+  flow. Use `<Form>` + `redirect()`.
+- **`useNavigation()` to drive a per-row spinner inside a list where
+  each row uses `useFetcher`** — `useNavigation` does not observe
+  fetcher activity, so the spinner never lights up. Use the per-row
+  `fetcher.state`.
+- **Single `useFetcher` shared across a list** — submissions from
+  different rows clobber each other's `formData` and `state`. Each row
+  needs its own fetcher.
+- **Mirroring `fetcher.formData.get("field")` into local React state**
+  for optimistic rendering — two sources of truth. On error,
+  `fetcher.data` returns the failure but local state still shows the
+  optimistic value. Read from `fetcher.formData` each render.
+
+## Gotchas
+
+- `useNavigation` **does not observe fetchers**. Use `useFetchers()` for
+  a page-wide "anything in flight" view.
+- `fetcher.formData` is cleared when state returns to `idle`. After
+  success, render against the refreshed loader data; after error,
+  derive UI from `fetcher.data?.errors`.
+- `fetcher.Form` with `method="get"` calls the matched route's loader,
+  not its action — same as `<Form method="get">`.
+- Two fetchers with the same explicit `key` share state. Without a key,
+  each `useFetcher()` call is independent even in the same component.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/form.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/form.md
@@ -1,0 +1,217 @@
+# `<Form>` from `@remix-run/react`
+
+The navigating, progressively-enhanced form component. It posts to a route
+`action`, then triggers full-page revalidation of every loader in the
+matched route tree.
+
+## Signature
+
+```tsx
+<Form
+  method="get | post | put | patch | delete"
+  action?={string}
+  encType?="application/x-www-form-urlencoded" | "multipart/form-data" | "application/json" | "text/plain"
+  replace?={boolean}
+  reloadDocument?={boolean}
+  navigate?={boolean}          // false → behaves like <fetcher.Form>
+  fetcherKey?={string}         // observed via useFetchers()
+  preventScrollReset?={boolean}
+  viewTransition?={boolean}
+/>
+```
+
+## `<Form>` vs native `<form>` vs `fetch()`
+
+| Aspect | `<Form>` from `@remix-run/react` | Native `<form>` | `fetch()` in `onSubmit` |
+|---|---|---|---|
+| Submits to route `action` | Yes | Yes (hard navigation) | Yes (if URL matches) |
+| Loaders revalidate | Yes (client-side) | Yes (full reload) | **No** |
+| Works without JS | Yes | Yes | **No** |
+| `useNavigation()` pending state | Yes | No (full reload) | **No** |
+| `useNavigation().formData` for optimistic UI | Yes | No | **No** |
+| Scroll position preserved | Yes (configurable) | No | N/A |
+
+Use `<Form>` from `@remix-run/react` for in-app mutations. Native `<form>`
+is fine only for forms that intentionally target external URLs or want a
+full document reload. Never use `fetch()` for in-app mutations — it
+bypasses the entire Remix action lifecycle, leaves loaders stale, and
+breaks progressive enhancement.
+
+## Progressive Enhancement
+
+`<Form method="post">` works before client JS hydrates. The browser
+performs a native POST, the server runs the action, returns a redirect or
+re-renders, and the page works. When JS is available, Remix intercepts the
+submission, runs the action, and revalidates loaders without a full page
+reload.
+
+This is why `useState`/`setIsLoading(true)` is wrong for tracking
+submission: it does not exist before hydration, and it duplicates state
+Remix already owns. Always derive busy state from `useNavigation()`.
+
+PE caveats:
+
+- Native HTML forms only support `method="get"` and `method="post"`.
+  Without JS, `put` / `patch` / `delete` degrade to `get`, which usually
+  hits the loader instead of the action and 405s. If PE matters, use
+  `method="post"` and dispatch via an `intent` field.
+- `GET <Form>` does not call the action — it triggers a navigation with
+  form fields as URL search params, hitting the loader. Useful for
+  search/filter UIs; confusing if you expected the action to run.
+
+## Redirect After Success
+
+Always `redirect(...)` on success. Returning `json({ ok: true })` from a
+mutation that should redirect strands the user on the form URL:
+refreshing re-submits via the browser's POST-resubmit prompt, and the
+back button revisits the form.
+
+```tsx
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const title = String(form.get("title") ?? "");
+  if (!title) return json({ errors: { title: "Required" } }, { status: 400 });
+  const created = await createItem({ title });
+  return redirect(`/items/${created.id}`);
+}
+```
+
+Return `json(...)` only for validation errors or when the user must stay
+on the same page after the mutation.
+
+## Validation Errors via `useActionData`
+
+`useActionData<typeof action>()` returns the most recent action result
+for the current route. It persists across renders until the user
+navigates away or another action runs — so success banners derived from
+`actionData` will linger until next nav.
+
+```tsx
+import { json, redirect, type ActionFunctionArgs } from "@remix-run/node";
+import { Form, useActionData, useNavigation } from "@remix-run/react";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "");
+  const password = String(form.get("password") ?? "");
+
+  const errors: Record<string, string> = {};
+  if (!email.includes("@")) errors.email = "Invalid email";
+  if (password.length < 12) errors.password = "Min 12 characters";
+  if (Object.keys(errors).length) return json({ errors }, { status: 400 });
+
+  await createUser({ email, password });
+  return redirect("/dashboard");
+}
+
+export default function Signup() {
+  const actionData = useActionData<typeof action>();
+  const nav = useNavigation();
+  const busy = nav.state !== "idle" && nav.formAction === "/signup";
+  return (
+    <Form method="post" replace>
+      <input name="email" type="email" />
+      {actionData?.errors?.email ? <em>{actionData.errors.email}</em> : null}
+      <input name="password" type="password" />
+      {actionData?.errors?.password ? <em>{actionData.errors.password}</em> : null}
+      <button disabled={busy}>{busy ? "Signing up..." : "Sign Up"}</button>
+    </Form>
+  );
+}
+```
+
+`redirect()` on success clears `useActionData` and resets the form
+naturally on the new route. `json({ errors }, { status: 400 })`
+re-renders the same route with the errors visible.
+
+## Validate Input — `FormData.get()` is `string | File | null`
+
+`FormData.get()` returns `FormDataEntryValue | null`. Implicit coercion
+silently lets attackers submit empty strings, repeated keys, or files
+where strings are expected. Cast with `String(form.get("x") ?? "")` and
+run a schema validator (Zod, Valibot) before any DB call.
+
+## Programmatic Submission with `useSubmit`
+
+```tsx
+import { Form, useSubmit } from "@remix-run/react";
+
+export default function SearchBar() {
+  const submit = useSubmit();
+  return (
+    <Form
+      method="get"
+      action="/search"
+      onChange={(event) => submit(event.currentTarget, { replace: true })}
+    >
+      <input type="search" name="q" />
+    </Form>
+  );
+}
+```
+
+`replace: true` keeps the back button useful — one history entry instead
+of one per keystroke.
+
+`useSubmit` also accepts `FormData`, `URLSearchParams`, or a plain
+object. With `{ encType: "application/json" }` it posts JSON, not
+FormData — in the action use `await request.json()` because
+`request.formData()` will throw.
+
+## Reset Uncontrolled Form on Success
+
+React does not unmount uncontrolled inputs across a same-route mutation,
+so the DOM keeps the old value until you call `form.reset()`.
+
+```tsx
+import { useEffect, useRef } from "react";
+import { Form, useActionData, useNavigation } from "@remix-run/react";
+
+export default function CommentForm() {
+  const formRef = useRef<HTMLFormElement>(null);
+  const nav = useNavigation();
+  const actionData = useActionData<typeof action>();
+  useEffect(() => {
+    if (nav.state === "idle" && actionData?.ok) formRef.current?.reset();
+  }, [nav.state, actionData]);
+  return (
+    <Form ref={formRef} method="post">
+      <input name="body" />
+      <button>Post</button>
+    </Form>
+  );
+}
+```
+
+For fetchers, swap `nav` for `fetcher` and key the effect on
+`fetcher.state` / `fetcher.data`.
+
+## Anti-Patterns
+
+- **`onSubmit={(e) => { e.preventDefault(); fetch(...) }}`** — bypasses
+  the action lifecycle, leaves loaders stale, breaks PE. Replace with
+  `<Form method="post" action="/...">` and move logic to the action.
+- **Native `<form method="post">`** for in-app mutations — works but loses
+  client-side enhancement and gives no `useNavigation` hook. Import
+  `Form` from `@remix-run/react`.
+- **`useState`/`setIsLoading(true)` for submission state** — diverges
+  from `navigation.state` on errors and double-submits; stops working
+  without JS. Derive from `useNavigation()`.
+- **Returning `json({ ok: true })` when you should redirect** — strands
+  the user on a stale URL. `return redirect("/items/" + created.id)`.
+
+## Gotchas
+
+- `useActionData` is **per-route, not per-intent**. To distinguish which
+  intent ran, include the intent in the response or use a separate
+  `useFetcher` per intent.
+- `<Form method="post">` revalidates **all** loaders in the matched route
+  tree. For high-frequency mutations, use `useFetcher` for granular
+  control or `shouldRevalidate` per route to opt out.
+- `replace` and `preventScrollReset` are independent. Setting one does
+  not imply the other.
+- `navigate={false}` on `<Form>` turns it into a fetcher form —
+  equivalent to `<fetcher.Form>` but without holding the fetcher
+  reference. Use `fetcherKey` to observe it via `useFetchers()`.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/form.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/form.md
@@ -8,7 +8,7 @@ matched route tree.
 
 ```tsx
 <Form
-  method="get | post | put | patch | delete"
+  method="get | post | put | patch | delete"  // Remix accepts lowercase JSX method and normalizes; v2 docs document them as uppercase. formMethod on useNavigation/fetcher always returns UPPERCASE.
   action?={string}
   encType?="application/x-www-form-urlencoded" | "multipart/form-data" | "application/json" | "text/plain"
   replace?={boolean}

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/intent-actions.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/intent-actions.md
@@ -1,0 +1,126 @@
+# Multiple Actions on One Route (the `intent` Pattern)
+
+A Remix route has exactly one `action` export. To handle multiple
+operations (like, retweet, delete) without sprawling into separate route
+files, encode the operation in a FormData field named `intent` and
+switch on it inside the single action.
+
+## The Pattern
+
+```tsx
+// app/routes/tweets.$id.tsx
+import { json, type ActionFunctionArgs } from "@remix-run/node";
+import { useFetcher } from "@remix-run/react";
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const form = await request.formData();
+  const intent = form.get("intent");
+  switch (intent) {
+    case "like":
+      return json(await likeTweet(params.id!));
+    case "retweet":
+      return json(await retweetTweet(params.id!));
+    case "delete":
+      return json(await deleteTweet(params.id!));
+    default:
+      throw new Response("Unknown intent", { status: 400 });
+  }
+}
+
+export default function Tweet() {
+  const fetcher = useFetcher();
+  const pendingIntent = fetcher.formData?.get("intent");
+  return (
+    <fetcher.Form method="post">
+      <button name="intent" value="like" disabled={pendingIntent === "like"}>
+        Like
+      </button>
+      <button name="intent" value="retweet" disabled={pendingIntent === "retweet"}>
+        RT
+      </button>
+      <button name="intent" value="delete">
+        Delete
+      </button>
+    </fetcher.Form>
+  );
+}
+```
+
+## Why It Works
+
+Only the clicked submit button's `name=value` lands in the form body. So
+when the user clicks "Like", `formData.get("intent")` is `"like"`; the
+other two buttons contribute nothing. This is HTML-standard form behavior
+and works without JS.
+
+Per-button pending state comes from `fetcher.formData?.get("intent")` —
+populated synchronously on submit, cleared at `idle`.
+
+## When to Use It
+
+- A row in a list has multiple related actions (like, retweet, delete).
+- A form has a primary submit and a "Save as draft" variant.
+- A modal handles a small group of related mutations.
+
+When **not** to use it:
+
+- Mutations operate on different resources (different URLs are clearer).
+- Operations belong on a different route conceptually (e.g. user vs.
+  admin actions on the same record — split them).
+- The intents have wildly different request shapes (validation gets
+  ugly fast).
+
+## Pattern: Page Form Variant
+
+The same pattern works with page-level `<Form>`:
+
+```tsx
+import { Form, useNavigation } from "@remix-run/react";
+
+export default function PostForm() {
+  const nav = useNavigation();
+  const pending = nav.formData?.get("intent");
+  return (
+    <Form method="post">
+      <input name="body" />
+      <button name="intent" value="draft" disabled={pending === "draft"}>
+        Save Draft
+      </button>
+      <button name="intent" value="publish" disabled={pending === "publish"}>
+        Publish
+      </button>
+    </Form>
+  );
+}
+```
+
+Filter on `nav.formAction` too if the route can be the target of multiple
+unrelated forms.
+
+## Anti-Patterns
+
+- **Multiple `<form>` elements each posting to a different route** just
+  to disambiguate operations. Forces route file sprawl, duplicates
+  parsing, and breaks revalidation scope. Use one action with intents.
+- **Reading `useActionData()` to detect which intent ran**, without
+  including the intent in the response. `useActionData` is per-route,
+  not per-intent — the component can't tell whether the "like" or the
+  "delete" returned. Either include the intent in the response
+  (`json({ intent: "like", ok: true })`) or use a separate
+  `useFetcher` per intent.
+- **Defaulting to a "happy" intent in the action** when `intent` is
+  missing. Better to throw `400` so a bug in the UI doesn't silently
+  mutate the wrong way.
+
+## Gotchas
+
+- **Pressing Enter in a text input submits the first button in DOM
+  order.** Order your `<button>` elements so the safe / common operation
+  comes first. If you have a destructive action ("Delete"), put it
+  last and consider requiring a confirmation step.
+- `formData.get("intent")` returns `FormDataEntryValue | null`. Compare
+  against string literals; do not pass it directly to a discriminated
+  union without narrowing.
+- The `intent` field is just a convention — any name works as long as
+  the action and UI agree. `intent` is the conventional choice and
+  matches the broader Remix ecosystem.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/optimistic-ui.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/optimistic-ui.md
@@ -1,0 +1,180 @@
+# Optimistic UI
+
+Remix v2 exposes the in-flight submission as `FormData` while the
+mutation is pending. Reading that `FormData` synchronously each render
+is the canonical way to show optimistic values — no local state, no
+mirroring, no drift.
+
+## The Two Sources
+
+- `useNavigation().formData` — the `FormData` of the active page-level
+  `<Form>` submission. Populated when `navigation.state !== "idle"` for a
+  non-GET form submission. Cleared at `idle`.
+- `useFetcher().formData` — the `FormData` of the active fetcher
+  submission. Populated when `fetcher.state !== "idle"`. Cleared at
+  `idle`.
+
+Both are the **canonical** optimistic source: populated synchronously on
+submit, automatically reverted when the action completes and loaders
+revalidate.
+
+## Why Not Local State
+
+```tsx
+// Anti-pattern — do not do this
+const [optimisticCount, setOptimisticCount] = useState(count);
+
+function onSubmit() {
+  setOptimisticCount((c) => c + 1);
+  fetcher.submit(...);
+}
+```
+
+Two sources of truth. On error, `fetcher.data` returns the failure but
+`optimisticCount` still shows the incremented value. On reload, local
+state resets but the server may have completed the mutation. The user
+sees flicker, ghost values, and stale UI.
+
+Instead, derive optimistic state from `fetcher.formData` directly.
+
+## Pattern: Counter / Quantity
+
+```tsx
+import { useFetcher } from "@remix-run/react";
+
+export function CartCount({ count }: { count: number }) {
+  const fetcher = useFetcher({ key: "add-to-bag" });
+  const inFlight = Number(fetcher.formData?.get("quantity") ?? 0);
+  const optimistic = count + inFlight;
+  return <span aria-live="polite">{optimistic}</span>;
+}
+```
+
+While the submission is in flight, `fetcher.formData.get("quantity")`
+holds the value the user submitted. When `fetcher.state` returns to
+`idle`, loaders have revalidated, `count` reflects the new server value,
+and `inFlight` is `0` again. No code path needs to "revert on failure":
+on failure, `fetcher.formData` clears and you fall back to the
+unchanged server `count`.
+
+## Pattern: Toggle (Favorite / Like)
+
+```tsx
+import { useFetcher } from "@remix-run/react";
+
+export function FavoriteButton({ id, favorited }: { id: string; favorited: boolean }) {
+  const fetcher = useFetcher();
+  const pendingFavorited = fetcher.formData
+    ? fetcher.formData.get("favorited") === "true"
+    : favorited;
+  return (
+    <fetcher.Form method="post" action={`/items/${id}/favorite`}>
+      <input type="hidden" name="favorited" value={String(!pendingFavorited)} />
+      <button aria-pressed={pendingFavorited}>
+        {pendingFavorited ? "Unfavorite" : "Favorite"}
+      </button>
+    </fetcher.Form>
+  );
+}
+```
+
+The hidden input encodes the new target state. `pendingFavorited` is the
+single source of truth for what the UI should display — drawn from the
+in-flight `FormData` when present, otherwise from the server prop.
+
+## Pattern: Optimistic via `useNavigation` (Page Form)
+
+For a `<Form>` submission (not a fetcher), read `useNavigation().formData`:
+
+```tsx
+import { Form, useNavigation } from "@remix-run/react";
+
+export default function EditTitle({ title }: { title: string }) {
+  const nav = useNavigation();
+  const optimisticTitle =
+    nav.formAction === "/title" && nav.formData
+      ? String(nav.formData.get("title") ?? title)
+      : title;
+  return (
+    <>
+      <h1>{optimisticTitle}</h1>
+      <Form method="post" action="/title">
+        <input name="title" defaultValue={title} />
+        <button>Save</button>
+      </Form>
+    </>
+  );
+}
+```
+
+Filter on `nav.formAction` so unrelated navigations don't trigger this
+component's optimistic render.
+
+## When to Apply Optimistic UI
+
+Apply it when:
+
+- The mutation almost always succeeds (favorites, likes, increments,
+  toggles, quantity changes).
+- The user's intent is unambiguous and easily reverted.
+- A round-trip delay is perceptible (>~100ms) and would feel sluggish.
+
+Skip it when:
+
+- The mutation has meaningful failure modes (payment, account changes,
+  destructive deletes) — the user expects to see the actual result.
+- The new value depends on server-computed data (auto-generated IDs,
+  derived fields, slugs).
+- The optimistic render would mislead the user about real state
+  (insufficient funds, permission denied, conflict).
+
+## Reverting on Failure
+
+You don't have to. When the action returns an error response, the
+fetcher transitions through `loading` to `idle`. `fetcher.formData`
+clears. Your render falls back to the server value. The UI "reverts"
+automatically.
+
+What you should do on failure: read `fetcher.data` for the error and
+surface it.
+
+```tsx
+const fetcher = useFetcher<typeof action>();
+const pendingFavorited = fetcher.formData
+  ? fetcher.formData.get("favorited") === "true"
+  : favorited;
+const error = fetcher.state === "idle" ? fetcher.data?.error : null;
+return (
+  <>
+    <fetcher.Form method="post" action={`/items/${id}/favorite`}>
+      <input type="hidden" name="favorited" value={String(!pendingFavorited)} />
+      <button aria-pressed={pendingFavorited}>...</button>
+    </fetcher.Form>
+    {error ? <p role="alert">{error}</p> : null}
+  </>
+);
+```
+
+## Anti-Patterns
+
+- **Mirroring `fetcher.formData.get("field")` into `useState`.** Two
+  sources of truth; ghost values on error.
+- **Setting optimistic state inside `onSubmit`.** Stops working without
+  JS; diverges from `fetcher.state` on double-submit.
+- **Applying optimistic UI to destructive actions** (delete account,
+  irreversible payment) — the user needs to see the real outcome.
+- **Optimistic IDs / slugs.** Server-generated values cannot be guessed
+  client-side. Wait for `fetcher.data` or revalidation.
+
+## Gotchas
+
+- `formData.get(key)` returns `FormDataEntryValue | null` (string or
+  File). Cast or compare explicitly:
+  `formData.get("favorited") === "true"`.
+- `useNavigation().formData` is page-global. Filter on `formAction` to
+  avoid one form's submission lighting up another form's optimistic UI.
+- After a successful action, the optimistic value should match the
+  server value — but loader revalidation is async. There is a brief
+  window where `fetcher.formData` has cleared and the loader has not yet
+  returned. Display the new server value as soon as it's available; the
+  gap is normally a single tick.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/uploads.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/uploads.md
@@ -75,7 +75,7 @@ export async function action({ request }: ActionFunctionArgs) {
     directory: "/tmp/uploads",
     maxPartSize: 10_000_000,    // 10 MB
     file: ({ filename }) => filename,
-    filter: ({ contentType }) => contentType.startsWith("image/"),
+    filter: ({ contentType }) => contentType.startsWith("image/"), // callbacks also receive `name`
   });
   const formData = await unstable_parseMultipartFormData(request, uploadHandler);
   const upload = formData.get("attachment");
@@ -91,10 +91,7 @@ permanent store, then clean up.
 
 ## Bound Every Handler
 
-**Always pass `maxPartSize`.** Without it,
-`unstable_createMemoryUploadHandler` will buffer entire uploads into RAM.
-A single malicious upload can OOM the server. The disk handler will fill
-the disk. Treat unbounded handlers as a security bug.
+**`unstable_createMemoryUploadHandler`** has no default cap — without `maxPartSize`, it buffers the entire upload into RAM. **`unstable_createFileUploadHandler`** defaults `maxPartSize` to 3MB, which is usually still too generous for untrusted user input. Always set an explicit `maxPartSize` matched to the upload's purpose.
 
 `filter` is the second line of defense: reject parts whose `contentType`
 or `name` doesn't match what you accept.

--- a/plugins/beagle-remix-v2/skills/remix-v2-forms/references/uploads.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-forms/references/uploads.md
@@ -1,0 +1,139 @@
+# File Uploads
+
+Remix v2 ships file-upload helpers under permanent `unstable_` prefixes.
+The API was renamed without the prefix in React Router v7 — in v2 you
+keep the prefix. Code that migrates needs to update imports.
+
+## The Three Helpers
+
+| Import | Purpose |
+|---|---|
+| `unstable_parseMultipartFormData(request, uploadHandler)` | Parse a `multipart/form-data` request body in an action. Returns `Promise<FormData>`. |
+| `unstable_createMemoryUploadHandler({ maxPartSize?, filter? })` | In-memory upload handler. Returns a `File`. For small files only. |
+| `unstable_createFileUploadHandler({ directory?, maxPartSize?, filter?, file? })` | Disk-backed upload handler. Streams to a directory. For larger files. |
+
+All three live in `@remix-run/node` (or `@remix-run/cloudflare` for the
+Cloudflare adapter). The `unstable_` prefix is **permanent in v2** — do
+not strip it expecting it to work.
+
+## `encType="multipart/form-data"` Is Mandatory
+
+Without it, `request.formData()` strips file data. `formData.get("avatar")`
+returns the filename **string**, not a `File`. The upload silently
+fails. Set `encType="multipart/form-data"` on the `<Form>` AND parse via
+`unstable_parseMultipartFormData` in the action.
+
+## Pattern: In-Memory Upload (Small Files)
+
+```tsx
+// app/routes/avatar.tsx
+import {
+  json,
+  redirect,
+  unstable_createMemoryUploadHandler,
+  unstable_parseMultipartFormData,
+  type ActionFunctionArgs,
+} from "@remix-run/node";
+import { Form } from "@remix-run/react";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const uploadHandler = unstable_createMemoryUploadHandler({
+    maxPartSize: 500_000, // 500 KB cap; reject larger uploads
+  });
+  const formData = await unstable_parseMultipartFormData(request, uploadHandler);
+  const file = formData.get("avatar");
+  if (!(file instanceof File)) return json({ error: "No file" }, { status: 400 });
+  await storeAvatar(file);
+  return redirect("/account");
+}
+
+export default function AvatarRoute() {
+  return (
+    <Form method="post" encType="multipart/form-data">
+      <input type="file" name="avatar" accept="image/*" />
+      <button>Upload</button>
+    </Form>
+  );
+}
+```
+
+Memory handler is fine for avatars and small attachments (a few hundred
+KB). For anything larger, use `unstable_createFileUploadHandler` or
+stream directly to object storage.
+
+## Pattern: Disk-Backed Upload
+
+```tsx
+import {
+  unstable_createFileUploadHandler,
+  unstable_parseMultipartFormData,
+  type ActionFunctionArgs,
+} from "@remix-run/node";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const uploadHandler = unstable_createFileUploadHandler({
+    directory: "/tmp/uploads",
+    maxPartSize: 10_000_000,    // 10 MB
+    file: ({ filename }) => filename,
+    filter: ({ contentType }) => contentType.startsWith("image/"),
+  });
+  const formData = await unstable_parseMultipartFormData(request, uploadHandler);
+  const upload = formData.get("attachment");
+  // upload is a NodeOnDiskFile — has .name, .size, .type, and .getFilePath()
+  // Move it to permanent storage, then delete the temp file.
+  return json({ ok: true });
+}
+```
+
+`unstable_createFileUploadHandler` streams the part to disk. The returned
+file object exposes the temp path; move or stream from there to your
+permanent store, then clean up.
+
+## Bound Every Handler
+
+**Always pass `maxPartSize`.** Without it,
+`unstable_createMemoryUploadHandler` will buffer entire uploads into RAM.
+A single malicious upload can OOM the server. The disk handler will fill
+the disk. Treat unbounded handlers as a security bug.
+
+`filter` is the second line of defense: reject parts whose `contentType`
+or `name` doesn't match what you accept.
+
+```ts
+const uploadHandler = unstable_createMemoryUploadHandler({
+  maxPartSize: 500_000,
+  filter: ({ contentType, name }) =>
+    name === "avatar" && contentType.startsWith("image/"),
+});
+```
+
+## Anti-Patterns
+
+- **`<Form method="post">` with `<input type="file">` but no `encType`.**
+  The file silently isn't sent; `formData.get("avatar")` returns the
+  filename string. Set `encType="multipart/form-data"`.
+- **`unstable_createMemoryUploadHandler()` with no `maxPartSize`.**
+  Unbounded RAM buffering — OOM risk. Always bound.
+- **Stripping the `unstable_` prefix in v2.** The prefix is permanent in
+  Remix v2; only React Router v7 renamed these without it.
+- **Using the memory handler for user-uploaded photos / documents.**
+  Anything over ~1 MB should stream to disk or object storage.
+- **Trusting `file.name` or `file.type` as security boundaries.** Both
+  are user-controlled. Validate magic bytes, scan content, or run
+  uploads through a trusted processor.
+
+## Gotchas
+
+- `unstable_parseMultipartFormData` returns the parsed `FormData`. Use
+  `formData.get(name) instanceof File` to discriminate text fields from
+  uploads — `get` can return string, File, or null.
+- Mixed forms (text fields + file inputs) work fine: text fields pass
+  through `formData` as strings; only file inputs invoke the upload
+  handler.
+- The Cloudflare adapter (`@remix-run/cloudflare`) re-exports these
+  helpers with the same `unstable_` names. Node and Cloudflare imports
+  are interchangeable at the type level but pick one matching your
+  runtime.
+- Upload handlers run on the server. The `request` object cannot be
+  consumed twice — call `unstable_parseMultipartFormData(request, ...)`
+  exactly once per action.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remix-v2-meta-sessions-review
 description: Reviews Remix v2 code for v1-shape meta exports (BREAKING in v2), cookie security gaps (httpOnly, secure, secrets rotation), auth gates in wrong layer, and missing CSRF. Use when reviewing meta/SEO, session, auth, or form-mutation code in a Remix v2 codebase.
+user-invocable: false
 ---
 
 # Remix v2 Meta, Sessions, Auth, and CSRF Code Review

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: remix-v2-meta-sessions-review
+description: Reviews Remix v2 code for v1-shape meta exports (BREAKING in v2), cookie security gaps (httpOnly, secure, secrets rotation), auth gates in wrong layer, and missing CSRF. Use when reviewing meta/SEO, session, auth, or form-mutation code in a Remix v2 codebase.
+---
+
+# Remix v2 Meta, Sessions, Auth, and CSRF Code Review
+
+Reviews Remix v2 meta/SEO, session, auth-gate, and CSRF code paths. Loaded
+by the umbrella `review-remix-v2` reviewer when a diff touches any of:
+`meta`/`links` exports, `root.tsx`, `*.server.ts` session/cookie modules,
+loaders/actions reading or writing `session`, or `<Form>`/`useFetcher`
+mutations.
+
+See [beagle-remix-v2:remix-v2-meta-sessions](../remix-v2-meta-sessions/SKILL.md) for canonical patterns.
+
+## Quick Reference
+
+| Issue Type | Reference |
+|------------|-----------|
+| **`meta` returning v1 object shape (BREAKING)**, OG shorthand, `document.title` in effect, missing `<Meta />`/`<Links />`, parent merge | [references/meta-v2-shape.md](references/meta-v2-shape.md) |
+| Missing `httpOnly`/`secure`, hardcoded secrets, single-string `secrets`, replace-not-prepend rotation | [references/cookie-security.md](references/cookie-security.md) |
+| Auth check in component, logout in loader, missing `commitSession`, `flash` without commit | [references/auth-gates.md](references/auth-gates.md) |
+| Manual `fetch` POST bypassing CSRF, token in session cookie, no CSRF protection, shared secrets | [references/csrf.md](references/csrf.md) |
+
+**Highest-stakes detection — call out first:** v1 `meta` object shape (`return { title, description }`) in a v2 codebase. It typechecks, but the runtime ignores it and the page renders with **no title and no meta tags**. Grep every `export const meta` and confirm the return value starts with `[`, not `{`.
+
+## Review Checklist
+
+- [ ] `meta` returns `MetaDescriptor[]` (array starts with `[`), NOT the v1 object shape
+- [ ] OG / Twitter tags use `{ property, content }`, NOT v1 shorthand `{ "og:title": "..." }`
+- [ ] No `document.title = "..."` or `useEffect(() => { document.title = ... })` — meta is set via the `meta` export
+- [ ] `root.tsx` includes `<Meta />` and `<Links />` inside `<head>`
+- [ ] Child `meta` that wants parent values uses `matches.flatMap((m) => m.meta ?? [])`
+- [ ] `meta` null-guards `data` (loader may not have run / returned `undefined` on 404)
+- [ ] Cookie config sets `httpOnly: true` and `secure: process.env.NODE_ENV === "production"`
+- [ ] `secrets` is read from `process.env` (no hardcoded strings, no committed `.env.example` values)
+- [ ] `secrets` is an array supporting rotation (prepend new, keep old) — not a single value
+- [ ] Every `session.set`/`session.unset`/`session.flash` is followed by a response with `"Set-Cookie": await commitSession(session)`
+- [ ] Auth gate is in `loader` (or `action`) via `requireUserId(request)` — NOT a component-level redirect
+- [ ] Logout is an `action` (POST), not a `loader` (GET)
+- [ ] Mutating actions call `csrf.validate(request)` when CSRF protection is in use
+- [ ] CSRF token uses a dedicated `createCookie("csrf", ...)`, NOT the session cookie
+- [ ] Mutations use `<Form>` / `useFetcher` so `AuthenticityTokenInput` attaches the token (no manual `fetch` POST)
+
+## Valid Patterns (Do NOT Flag)
+
+These are correct usage — do not report as issues:
+
+- **`sameSite: "lax"`** — acceptable default. Not every app needs `"strict"`; flag only when threat model warrants stricter (e.g. CSRF protection is otherwise absent).
+- **`meta` returning `[]`** — legitimate when the route intentionally emits no meta (inherits root tags or relies on a sibling).
+- **`links` returning `[]`** — legitimate when the route has no route-specific stylesheets or preloads.
+- **`session.flash(...)` followed on the next line by `commitSession(session)`** — the standard 2-line flash pattern. The separation is correct; do not flag it as "missing commit".
+- **Auth check in `action` (not `loader`)** — correct for POST-only routes (e.g. logout, delete). Loaders gate GETs; actions gate mutations.
+- **`charset` and `viewport` as plain JSX `<meta>`** in `root.tsx`'s `<head>` — preferred over the `meta` export to avoid duplicate-tag warnings under v2's no-merge behavior.
+- **`secrets: [process.env.X!, process.env.X_OLD!]`** — `!` non-null assertion is acceptable when a fail-fast guard above (`if (!process.env.X) throw`) is present.
+- **`throw redirect(...)`** inside a loader/action — canonical Remix pattern; the thrown response is intentional.
+- **`commitSession` called in a loader (not just an action)** — required when a loader reads a flash message and must clear it.
+
+## Context-Sensitive Rules
+
+Only flag these issues when the specific context applies:
+
+| Issue | Flag ONLY IF |
+|-------|--------------|
+| Missing CSRF validation in action | App declares `remix-utils/csrf` as its protection mechanism, OR the action is public-facing (not internal/VPN-gated) AND no `Origin` check is present |
+| `sameSite: "lax"` | App has no library-based CSRF protection AND no `Origin` check — `"lax"` then becomes the only defense and is insufficient |
+| Missing `secure` flag | Cookie config is the production session/CSRF cookie (not a test fixture or commented example) |
+| `meta` returning `[]` | The route is documented as needing route-specific tags (e.g. a public landing page) — empty is usually intentional inheritance, do not flag by default |
+| Auth check in `action` not `loader` | Route is GET-renderable (has a `loader`) — for POST-only routes, `action` is the correct gate |
+| Logout in `action` AND `<Form method="post">` | Never flag — that is the canonical pattern |
+| Manual `fetch` POST | The target is an internal Remix action AND no CSRF token is attached via headers |
+| `secrets: [singleValue]` | App is in production OR has been deployed for long enough to need rotation — flag as recommendation, not CRITICAL |
+
+## Hard gates (before writing findings)
+
+Run these in order. **Do not draft user-facing findings until every gate passes** for the batch you are about to report.
+
+1. **Location evidence** — **Pass:** Each issue lists a repo path and either a line range or a short verbatim quote from the file you read. Diff-only or memory-based claims do not pass. For meta/links/session issues, the cited file is a `.ts`/`.tsx` route module, `root.tsx`, or `*.server.ts` — not a generic config file.
+
+2. **Exemption check** — **Pass:** For each issue, you can state in one line why it is *not* covered by [Valid Patterns (Do NOT Flag)](#valid-patterns-do-not-flag). In particular: `sameSite: "lax"`, empty `meta`/`links` arrays, and the standard `flash` + `commitSession` two-line pattern must be explicitly cleared.
+
+3. **Meta-shape check** — **Pass:** Before flagging *anything* about `meta`, you read the actual function body and confirmed what it returns. TypeScript may have masked the shape (a v1 object can satisfy a poorly-typed `MetaFunction` alias). The check is: the return expression starts with `[` and every element is a descriptor object. If it starts with `{`, that is the v1 shape — flag as CRITICAL. If it is `[]`, that is valid (do not flag).
+
+4. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
+
+## When to Load References
+
+- Reviewing any `export const meta` or `export const links`, or `root.tsx` → [meta-v2-shape.md](references/meta-v2-shape.md)
+- Reviewing `createCookieSessionStorage`, `createCookie`, or any `*.server.ts` that configures cookies → [cookie-security.md](references/cookie-security.md)
+- Reviewing loaders/actions that read or write `session`, or any auth helper → [auth-gates.md](references/auth-gates.md)
+- Reviewing forms, fetchers, or any mutating route → [csrf.md](references/csrf.md)
+
+## Review Questions
+
+1. Does every `meta` export return an array, and is every OG/Twitter tag `{ property, content }`?
+2. Does `root.tsx` include `<Meta />` and `<Links />` inside `<head>`?
+3. Are cookies `httpOnly` + `secure: NODE_ENV === 'production'` with `secrets` from env in an array (rotation-ready)?
+4. Is every session mutation followed by a `Set-Cookie: await commitSession(session)` header?
+5. Is auth gated in the loader/action via a throwing helper, never in a component?
+6. Is logout an `action` (POST), and do mutating actions validate CSRF (or document the threat model)?
+
+## Additional Documentation
+
+- [references/meta-v2-shape.md](references/meta-v2-shape.md) — v1 object shape in v2 codebases (BREAKING), OG shorthand, `document.title` antipatterns, root scaffolding, parent merging
+- [references/cookie-security.md](references/cookie-security.md) — `httpOnly`/`secure`/`sameSite`, hardcoded secrets, rotation hygiene
+- [references/auth-gates.md](references/auth-gates.md) — loader-level gates, logout-must-be-action, commit pairing, flash patterns
+- [references/csrf.md](references/csrf.md) — `remix-utils/csrf` wiring, manual-fetch bypass, dedicated cookie, shared-secret hygiene
+
+## Before Submitting Findings
+
+Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 3 — meta-shape check), then report only issues that still pass the [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) pre-report checks.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/auth-gates.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/auth-gates.md
@@ -1,0 +1,224 @@
+# Auth Gates — Anti-Patterns
+
+Remix has no built-in auth. The convention is a `requireUserId(request)`
+helper that **throws** `redirect()` from inside loaders and actions, paired
+with `commitSession`/`destroySession` on every mutation. The common failure
+modes are gating in the wrong layer (component instead of loader), missing
+`commitSession`, and logout-as-GET (CSRF-able).
+
+See [beagle-remix-v2:remix-v2-meta-sessions](../../remix-v2-meta-sessions/SKILL.md)
+for the canonical pattern.
+
+## 1. Auth check in a React component (instead of loader)
+
+**Anti-pattern:**
+
+```tsx
+// BAD — SSRs protected HTML and ships loader data to unauthenticated users
+export default function Dashboard() {
+  const user = useUser();
+  if (!user) return <Navigate to="/login" />;
+  return <PrivateContent />;
+}
+```
+
+**Why bad:** Remix renders the entire route tree on the server. The
+loader runs, fetches private data, and ships it down in the HTML payload.
+By the time the React component decides "no user, redirect," the secret
+data is already on the wire. The client then double-renders: a brief
+flash of `<PrivateContent />` (or nothing if the loader threw), then the
+redirect.
+
+This pattern also creates a race: the protected component renders against
+loader data that may be `null` or partial, often causing runtime errors
+before the redirect fires.
+
+**Fix:** Gate in the loader. Throw the redirect — Remix short-circuits
+the request and never invokes the component.
+
+```ts
+// app/auth.server.ts
+import { redirect } from "@remix-run/node";
+import { getSession } from "./session.server";
+
+export async function requireUserId(request: Request): Promise<string> {
+  const session = await getSession(request.headers.get("Cookie"));
+  const userId = session.get("userId");
+  if (!userId) {
+    const url = new URL(request.url);
+    const redirectTo = `${url.pathname}${url.search}`;
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+  }
+  return userId;
+}
+
+// app/routes/dashboard.tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await requireUserId(request);
+  // ...fetch only data this user is allowed to see
+  return json({ userId });
+}
+```
+
+**Detection:** Search for `<Navigate to=` and `useNavigate()` calls in
+route components that also have a `loader` export. Any auth check at the
+component level is suspect.
+
+## 2. Logout implemented in a `loader`
+
+**Anti-pattern:**
+
+```tsx
+// app/routes/logout.tsx — BAD
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  return redirect("/", {
+    headers: { "Set-Cookie": await destroySession(session) },
+  });
+}
+
+// Used as: <Link to="/logout">Log out</Link>
+```
+
+**Why bad:** Loaders run on GET requests. Any third-party page can
+trigger logout by including `<img src="https://yoursite.com/logout">`,
+or by linking from a malicious page. This is a classic CSRF vector — the
+Remix sessions docs explicitly call it out.
+
+Beyond CSRF, GET requests should be idempotent and safe per HTTP
+semantics. Logout mutates server state (destroys the session); it must
+be a POST.
+
+**Fix:** Move to an `action` and use `<Form method="post">`.
+
+```tsx
+// app/routes/logout.tsx — GOOD
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  return redirect("/", {
+    headers: { "Set-Cookie": await destroySession(session) },
+  });
+}
+
+// Used as:
+<Form method="post" action="/logout">
+  <button type="submit">Log out</button>
+</Form>
+```
+
+**Detection:** Any route module named `logout.*` with a `loader` export
+is almost always wrong. Also flag any `<Link to="/logout">` regardless of
+the route's implementation — if the route correctly uses an `action`,
+`<Link>` will hit the loader and 404 or do nothing.
+
+## 3. Session mutation without `commitSession`
+
+**Anti-pattern:**
+
+```ts
+// BAD — session.set runs, but no Set-Cookie header; mutation is lost
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  session.set("userId", user.id);
+  return json({ ok: true }); // no headers
+}
+```
+
+**Why bad:** Remix does NOT auto-commit sessions. `session.set` mutates
+the in-memory session object; without `commitSession`, the response has
+no `Set-Cookie` header and the browser keeps the old cookie. The login
+"succeeds" but the user is not actually logged in.
+
+This bug is silent: typecheck passes, the action returns 200, the form
+reports success — but the next request has no session.
+
+**Fix:** Every mutation that writes to `session` (including
+`session.set`, `session.unset`, `session.flash`) must produce a response
+with `"Set-Cookie": await commitSession(session)`.
+
+```ts
+session.set("userId", user.id);
+return redirect("/dashboard", {
+  headers: { "Set-Cookie": await commitSession(session) },
+});
+```
+
+**Detection grep:** Find `session.set(`, `session.unset(`, `session.flash(`.
+For each, read forward to the next `return` and confirm the response
+includes `commitSession`. If the function calls `redirect()` or `json()`
+without a `headers.Set-Cookie`, that is the bug.
+
+## 4. `session.flash` without `commitSession` on the reading side
+
+**Anti-pattern:**
+
+```ts
+// app/routes/login.tsx loader — BAD
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const error = session.get("error"); // reads flash
+  return json({ error }); // no commit — flash persists forever
+}
+```
+
+**Why bad:** Flash messages are read-once: Remix clears them when the
+session is **committed** after the read. Returning the loader response
+without `commitSession` leaves the flash in the cookie. On the next
+request the user sees the same error again. Worse, depending on read
+order across loaders, the flash may appear to clear on some requests and
+not others.
+
+**Fix:** After reading a flash, commit the session and attach the
+header. This is the standard 2-line pattern — `session.flash` and
+`commitSession` on consecutive lines is correct; do not confuse it with
+anti-pattern #3.
+
+```ts
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const error = session.get("error");
+  return json(
+    { error },
+    { headers: { "Set-Cookie": await commitSession(session) } },
+  );
+}
+```
+
+**Note for reviewers:** A loader that calls `session.get(key)` for a
+non-flash key (e.g. `userId`) does NOT need to commit — `get` does not
+mutate. Only flash reads trigger the auto-clear-on-commit behavior.
+
+## Patterns NOT to flag
+
+- **Auth check in an `action` (not loader)** — correct for POST-only
+  routes. Logout, delete, settings updates all gate via `requireUserId`
+  inside `action`, not `loader`.
+- **`throw redirect(...)`** — canonical pattern; the throw is intentional
+  and short-circuits the loader.
+- **`commitSession` in a loader** — required when reading a flash (#4
+  above). Do not flag as "session shouldn't be mutated in a loader."
+- **`flash` immediately followed by `commitSession` on the next line** —
+  the standard pattern.
+- **`requireUserId` returning early via throw** — no top-level `return`
+  is needed in the loader; the thrown response is the exit.
+
+## Detection notes for reviewers
+
+- Open every route module under `app/routes/`. For each `loader` and
+  `action`, ask: does this require auth? If yes, is `requireUserId`
+  called? If the answer is "auth is checked in the component," that is
+  the bug.
+- Grep `<Link to="/logout"` and `<Link to={routes.logout}` — almost
+  always wrong.
+- Grep `session.set(`, `session.unset(`, `session.flash(`. Verify each
+  is followed by a response with `commitSession` in the headers.
+- For loaders that read user-facing errors: confirm `commitSession` on
+  the response if the data came from `session.get` of a key written via
+  `session.flash`.
+
+## Hard gates reminder
+
+Before flagging an auth issue, confirm the route is actually intended
+to be protected (read the route's purpose). Public routes do not need
+`requireUserId`, and flagging a missing auth gate on a public route is
+a false positive.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/cookie-security.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/cookie-security.md
@@ -1,0 +1,229 @@
+# Cookie Security — Anti-Patterns
+
+Remix sets **no** secure defaults on cookies. Every flag is caller
+responsibility. The common failure mode is a `createCookieSessionStorage`
+config that ships to production missing `httpOnly`, `secure`, or rotation
+support.
+
+See [beagle-remix-v2:remix-v2-meta-sessions](../../remix-v2-meta-sessions/SKILL.md)
+for the canonical setup.
+
+## 1. Missing `httpOnly`
+
+**Anti-pattern:**
+
+```ts
+// BAD — no httpOnly; cookie is readable from JavaScript
+export const { getSession, commitSession } = createCookieSessionStorage({
+  cookie: {
+    name: "__session",
+    secure: true,
+    sameSite: "lax",
+    secrets: [process.env.SESSION_SECRET!],
+  },
+});
+```
+
+**Why bad:** Without `httpOnly: true`, any XSS payload that lands on the
+page can read the session cookie via `document.cookie` and exfiltrate it.
+Defense-in-depth: even if your CSP catches one XSS vector, `httpOnly` makes
+the cookie inert.
+
+**Fix:** Add `httpOnly: true`. There is no legitimate reason to read a
+session cookie from client JS — anything the page needs should come from
+loader data.
+
+```ts
+cookie: {
+  name: "__session",
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax",
+  secrets: [process.env.SESSION_SECRET!],
+},
+```
+
+## 2. Missing or hardcoded `secure`
+
+**Anti-pattern A — missing:**
+
+```ts
+// BAD — no secure flag; cookie sent over HTTP
+cookie: {
+  name: "__session",
+  httpOnly: true,
+  sameSite: "lax",
+  secrets: [process.env.SESSION_SECRET!],
+},
+```
+
+**Anti-pattern B — hardcoded `true`:**
+
+```ts
+// BAD — breaks local development; cookie never set on http://localhost
+cookie: {
+  name: "__session",
+  httpOnly: true,
+  secure: true,
+  sameSite: "lax",
+  secrets: [process.env.SESSION_SECRET!],
+},
+```
+
+**Why bad:** Missing `secure` allows the cookie to be sent over plain
+HTTP — any network-level adversary can sniff it. Hardcoding `secure: true`
+blocks the cookie from being set at all on `http://localhost`, so
+developers see "login does nothing" and either disable security entirely
+or invent workarounds.
+
+**Fix:** Tie `secure` to `NODE_ENV` so it is `true` in production and
+`false` in development:
+
+```ts
+secure: process.env.NODE_ENV === "production",
+```
+
+## 3. Hardcoded session secrets in source
+
+**Anti-pattern:**
+
+```ts
+// BAD — secret is now in git history forever
+cookie: {
+  name: "__session",
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax",
+  secrets: ["dev-secret-please-change"],
+},
+```
+
+**Also bad:** A committed `.env.example` with a realistic-looking secret.
+Junior devs copy it to `.env` and never rotate.
+
+**Why bad:** Anyone with read access to the repo (current contributors,
+former contributors, anyone who saw a leaked archive) can forge session
+cookies and impersonate any user. The blast radius scales with the user
+base.
+
+**Fix:** Read from environment with a fail-fast guard. Never commit real
+values. Use `.env.example` only for keys, not values — or use clearly fake
+placeholders like `__set_a_strong_secret__`.
+
+```ts
+const SESSION_SECRET = process.env.SESSION_SECRET;
+if (!SESSION_SECRET) throw new Error("SESSION_SECRET is required");
+
+export const { getSession, commitSession, destroySession } =
+  createCookieSessionStorage({
+    cookie: {
+      name: "__session",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      secrets: [SESSION_SECRET],
+    },
+  });
+```
+
+## 4. Single-string `secrets` with no rotation plan
+
+**Anti-pattern A — string, not array:**
+
+```ts
+// BAD — type-coerces in some Remix versions, but blocks rotation
+secrets: process.env.SESSION_SECRET!, // string, not string[]
+```
+
+**Anti-pattern B — array with only one entry, no rotation slot:**
+
+```ts
+// BAD — works, but no migration path when you need to rotate
+secrets: [process.env.SESSION_SECRET!],
+```
+
+Anti-pattern B is **not a CRITICAL** finding on its own — it works
+correctly. Flag it as a recommendation when reviewing a session config
+that has been in production long enough to need rotation, or when adjacent
+code suggests the team is unaware rotation is supported.
+
+**Why it matters:** `secrets` is an array because Remix signs new cookies
+with `secrets[0]` and accepts any entry for verification. That is the
+mechanism for rotating without invalidating existing sessions.
+
+**Fix:** Always declare as an array; add an `_OLD` env slot for rotation.
+
+```ts
+secrets: [
+  SESSION_SECRET,
+  ...(process.env.SESSION_SECRET_OLD ? [process.env.SESSION_SECRET_OLD] : []),
+],
+```
+
+## 5. Replace-not-prepend secret rotation
+
+**Anti-pattern:** Operator deploys with `SESSION_SECRET` changed to a new
+value and no `SESSION_SECRET_OLD`:
+
+```bash
+# BAD — instant logout for every user
+SESSION_SECRET=new-strong-secret
+```
+
+**Why bad:** Remix signs with `secrets[0]` and verifies with any array
+entry. If you replace the only entry, every existing cookie fails
+verification and every user is logged out. Worse, users may interpret the
+mass logout as a security incident.
+
+**Fix:** Prepend the new secret. Keep the old one in `secrets` for at
+least `maxAge` (so existing sessions remain valid until they expire
+naturally), then remove it.
+
+```bash
+SESSION_SECRET=new-strong-secret
+SESSION_SECRET_OLD=previous-strong-secret  # remove after maxAge elapses
+```
+
+Detection: a PR that changes `SESSION_SECRET` in deployment config
+without adding/keeping `SESSION_SECRET_OLD` is a smell — flag with a
+note about the rotation pattern.
+
+## 6. Cookie-specific edge cases
+
+**`sameSite` choice:**
+
+- `"lax"` — acceptable default. Cookies sent on top-level navigations
+  (including form GETs) but not on cross-origin sub-requests. Do NOT flag
+  `"lax"` unless the app relies on the session cookie alone for CSRF
+  protection (no `remix-utils/csrf` and no `Origin` checks).
+- `"strict"` — required if you're using session cookie alone for CSRF
+  defense.
+- `"none"` — REQUIRES `secure: true`. Flag any `"none"` without `secure`,
+  and flag any `"none"` without a documented cross-site use case (e.g.
+  iframe embeds, OAuth callbacks).
+
+**Missing `path`:** Defaults to the path of the request that set the
+cookie. Most apps want `path: "/"` so the cookie covers all routes;
+omitting it is rarely intentional. Flag as a minor issue.
+
+**Missing `maxAge`/`expires`:** Cookie becomes a session cookie (cleared
+on browser close). May be intentional for short-lived auth; ask the
+author rather than flagging blindly.
+
+## Detection notes for reviewers
+
+- Search every `createCookieSessionStorage(` and `createCookie(` call.
+  Open each and verify: `httpOnly`, `secure`, `sameSite`, `secrets`.
+- Search for `secrets: [` followed by a string literal — that is the
+  hardcoded-secret pattern.
+- Search `.env.example` and any committed env files for realistic-looking
+  values.
+- `git log -p -- .env*` to confirm no real secret was ever committed.
+  If one was, secret rotation is required regardless of current state.
+
+## Hard gates reminder
+
+Before flagging cookie config, confirm the file is actually wiring the
+production session — not a test fixture, demo, or commented-out example.
+Read the surrounding module to verify the exported `commitSession` is
+imported by route modules.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/csrf.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/csrf.md
@@ -1,0 +1,212 @@
+# CSRF — Anti-Patterns
+
+Remix has **no built-in CSRF protection**. The community convention is
+`remix-utils/csrf` with a dedicated signed cookie, an
+`AuthenticityTokenProvider` in `root.tsx`, and `csrf.validate(request)` in
+every mutating action. The common failure modes are no protection at all,
+shared session/CSRF cookies, manual `fetch` POSTs that bypass token
+injection, and shared secrets.
+
+See [beagle-remix-v2:remix-v2-meta-sessions](../../remix-v2-meta-sessions/SKILL.md)
+for the canonical wiring.
+
+## 1. No CSRF protection at all
+
+**Anti-pattern:** App ships without any token validation, relying on
+"Remix is safe by default."
+
+**Why bad:** Remix is **not** safe by default. The only protection
+against cross-origin POSTs is whatever `SameSite` value the session
+cookie carries. `SameSite=Lax` leaves gaps:
+
+- HTML form POSTs from a top-level cross-origin navigation are exempt
+  from `Lax` in some older browsers.
+- Subdomain takeovers: an attacker controlling `evil.example.com` can
+  forge POSTs to `app.example.com` since `SameSite` treats sibling
+  subdomains as same-site.
+- Apps that use `SameSite=None` for legitimate cross-site needs (OAuth
+  popups, iframe embeds) have no cookie-level CSRF protection at all.
+
+**Fix:** Add `remix-utils/csrf`. Wire the provider in `root.tsx`, the
+input in every `<Form>`, and `csrf.validate(request)` at the top of
+every mutating action.
+
+```ts
+// app/utils/csrf.server.ts
+import { createCookie } from "@remix-run/node";
+import { CSRF } from "remix-utils/csrf/server";
+
+export const csrfCookie = createCookie("csrf", {
+  path: "/",
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax",
+  secrets: [process.env.CSRF_SECRET!],
+});
+
+export const csrf = new CSRF({
+  cookie: csrfCookie,
+  secret: process.env.CSRF_SECRET!,
+});
+```
+
+**Acceptable alternative:** If `remix-utils/csrf` is not in use, the app
+must (a) set `sameSite: "strict"` on the session cookie AND (b) verify
+the `Origin` header in every action. Document the threat model in the
+repo. Flag any app that does neither.
+
+## 2. CSRF token stored in the session cookie
+
+**Anti-pattern:**
+
+```ts
+// BAD — reuses the session cookie for CSRF; types don't match
+export const csrf = new CSRF({
+  cookie: sessionCookie, // same cookie used for session storage
+  secret: process.env.SESSION_SECRET!,
+});
+```
+
+**Why bad:** The session cookie value is a serialized object (the
+session data). The CSRF cookie value is a signed string (the token).
+`remix-utils/csrf` writes its own value to the configured cookie; if
+that cookie is also being used for session storage, every commit clobbers
+the other.
+
+At runtime: `csrf.validate(request)` throws on every request because the
+serialized session object does not match the signed-token format.
+Alternatively, session reads return `undefined` because CSRF overwrote
+the value.
+
+**Fix:** Use a dedicated `createCookie("csrf", ...)` with its own name
+and its own secret env var. The CSRF cookie and the session cookie are
+two separate cookies, each with their own `Set-Cookie` header on
+responses that mutate them.
+
+## 3. Manual `fetch` POST bypassing the token
+
+**Anti-pattern:**
+
+```tsx
+// BAD — skips AuthenticityTokenInput; csrf.validate throws on the server
+async function deletePost(id: string) {
+  await fetch(`/posts/${id}`, { method: "POST" });
+}
+```
+
+**Why bad:** Two failure modes:
+
+1. **If the action validates CSRF:** every manual POST returns 403 because
+   no token was attached. The feature is broken.
+2. **If the action does NOT validate CSRF:** this is the exact entry
+   point an attacker uses. Cross-origin pages can submit the same POST
+   and the server processes it.
+
+Either way, the manual `fetch` route is wrong.
+
+**Fix:** Use `<Form>` or `useFetcher().submit(...)` so
+`AuthenticityTokenInput` (rendered inside the form) or
+`useAuthenticityToken` (read inside `submit`) attaches the token.
+
+```tsx
+import { Form } from "@remix-run/react";
+import { AuthenticityTokenInput } from "remix-utils/csrf/react";
+
+export default function DeletePostForm({ id }: { id: string }) {
+  return (
+    <Form method="post" action={`/posts/${id}/delete`}>
+      <AuthenticityTokenInput />
+      <button type="submit">Delete</button>
+    </Form>
+  );
+}
+```
+
+For programmatic submission, use `useFetcher`:
+
+```tsx
+const fetcher = useFetcher();
+const token = useAuthenticityToken();
+
+function deletePost(id: string) {
+  const formData = new FormData();
+  formData.set("csrf", token);
+  fetcher.submit(formData, { method: "post", action: `/posts/${id}/delete` });
+}
+```
+
+**Detection:** Grep `fetch("/`, `fetch(`/`, and `fetch(` followed by
+`method: "POST"` (or PUT, PATCH, DELETE). Each call site is suspect —
+verify whether the target action validates CSRF, and whether the call
+attaches a token via headers.
+
+## 4. Shared secrets across session cookie and CSRF
+
+**Anti-pattern:**
+
+```ts
+// BAD — one env var feeds both session and CSRF
+const SECRET = process.env.APP_SECRET!;
+
+export const sessionStorage = createCookieSessionStorage({
+  cookie: { name: "__session", secrets: [SECRET], /* ... */ },
+});
+
+export const csrf = new CSRF({
+  cookie: csrfCookie, // separate cookie (good)
+  secret: SECRET,     // same secret (bad)
+});
+```
+
+**Why bad:** A compromise of one secret compromises both subsystems
+simultaneously. Rotation of one forces rotation of the other, so teams
+either rotate neither or accept higher blast radius. The two concerns
+have different threat models and lifetimes; they should have independent
+secrets.
+
+This is also bad rotation hygiene: prepending a new `SESSION_SECRET`
+while keeping `CSRF_SECRET` static means tokens issued before rotation
+still validate against post-rotation session cookies — which is fine but
+defeats the point of separate secrets.
+
+**Fix:** Two env vars, two independent rotation schedules.
+
+```ts
+const SESSION_SECRET = process.env.SESSION_SECRET!;
+const CSRF_SECRET = process.env.CSRF_SECRET!;
+```
+
+## Patterns NOT to flag
+
+- **`<Form method="post">` without explicit CSRF input** — only flag if
+  the app declares `remix-utils/csrf` as the protection mechanism and
+  the form is missing `<AuthenticityTokenInput />`. If the app uses
+  another approach (Origin check, `SameSite=Strict`), absence of
+  `AuthenticityTokenInput` is correct.
+- **`csrf.validate(request)` thrown without try/catch** — letting
+  `CSRFError` propagate to the route error boundary is acceptable. Only
+  flag if the error boundary doesn't return a 403 status.
+- **`sameSite: "lax"` with CSRF library** — `remix-utils/csrf` is the
+  primary defense; `"lax"` on the session cookie is fine.
+
+## Detection notes for reviewers
+
+- Search `node_modules/.package-lock.json` or `package.json` for
+  `remix-utils`. If absent, the app has no library-based CSRF.
+- Search every `action` export. For each, confirm either
+  `csrf.validate(request)` is called or an `Origin` header check is
+  present, or the action is documented as intentionally unprotected
+  (e.g. a public webhook with its own auth).
+- Grep `fetch(` inside `app/` for any string that looks like an
+  internal route path. Each one is a candidate for the manual-POST
+  bypass.
+- Compare `secrets: [` in session config with the `secret:` argument in
+  `new CSRF({ ... })`. Same env var? Flag it.
+
+## Hard gates reminder
+
+Before flagging CSRF gaps, confirm the threat model. Internal admin
+tools behind a VPN with no public exposure may legitimately skip CSRF.
+Public-facing apps must have one of: library-based tokens,
+`SameSite=Strict` + `Origin` checks, or documented compensating
+controls.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/csrf.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/csrf.md
@@ -17,10 +17,13 @@ for the canonical wiring.
 
 **Why bad:** Remix is **not** safe by default. The only protection
 against cross-origin POSTs is whatever `SameSite` value the session
-cookie carries. `SameSite=Lax` leaves gaps:
+cookie carries. `SameSite=Lax` blocks cookies on cross-site POST
+navigations in all current browsers. (Chrome briefly had a 2-minute
+"Lax+POST" window in 2020 — removed in 2021.) The real `Lax`-vs-`Strict`
+tradeoff is subdomain takeover: with `Lax`, a compromised subdomain can
+initiate top-level GET nav with credentials; with `Strict`, deep-link
+navigations from external sites lose session. Additional gaps:
 
-- HTML form POSTs from a top-level cross-origin navigation are exempt
-  from `Lax` in some older browsers.
 - Subdomain takeovers: an attacker controlling `evil.example.com` can
   forge POSTs to `app.example.com` since `SameSite` treats sibling
   subdomains as same-site.
@@ -90,7 +93,7 @@ responses that mutate them.
 ```tsx
 // BAD — skips AuthenticityTokenInput; csrf.validate throws on the server
 async function deletePost(id: string) {
-  await fetch(`/posts/${id}`, { method: "POST" });
+  await fetch(`/posts/${id}/delete`, { method: "POST" });
 }
 ```
 
@@ -188,6 +191,14 @@ const CSRF_SECRET = process.env.CSRF_SECRET!;
   flag if the error boundary doesn't return a 403 status.
 - **`sameSite: "lax"` with CSRF library** — `remix-utils/csrf` is the
   primary defense; `"lax"` on the session cookie is fine.
+
+## Reviewer note: `csrf.commitToken` return shape
+
+`csrf.commitToken(request)` returns `[token, cookieHeader | undefined]`.
+The cookie header may be undefined when the existing CSRF cookie is still
+valid. Reviewers should look for the `cookieHeader ? { ... } : {}`
+conditional in `root.tsx` and not flag the empty-headers branch as dead
+code.
 
 ## Detection notes for reviewers
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/meta-v2-shape.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions-review/references/meta-v2-shape.md
@@ -1,0 +1,236 @@
+# Meta v2 Shape — Anti-Patterns
+
+The v1 → v2 `meta` migration is the single highest-stakes detection in this
+skill. v2 returns `MetaDescriptor[]` (an array). The v1 object shape still
+typechecks in stale codebases and via loose `MetaFunction` aliases, but the
+runtime ignores it: the route renders with **no title and no meta tags**.
+
+See [beagle-remix-v2:remix-v2-meta-sessions](../../remix-v2-meta-sessions/SKILL.md)
+for canonical descriptor reference.
+
+## 1. v1 object shape used in a v2 codebase (BREAKING — flag as CRITICAL)
+
+**Severity:** CRITICAL. Silent SEO and social-preview regression in
+production.
+
+**Anti-pattern:**
+
+```tsx
+// BAD — v1 shape; v2 ignores this at runtime
+export const meta = () => ({
+  title: "My Page",
+  description: "A page on my site",
+});
+```
+
+**Why bad:** v2 expects an array of descriptors. An object literal does not
+match the runtime contract; Remix discards it and emits nothing. The page
+ships with the default browser-tab title (often `localhost` or the URL) and
+no OG/Twitter tags. Typecheck passes if `@remix-run/*` is stale, or if the
+return is typed loosely, or if the function lacks an annotation.
+
+**Fix:**
+
+```tsx
+import type { MetaFunction } from "@remix-run/node";
+
+export const meta: MetaFunction = () => [
+  { title: "My Page" },
+  { name: "description", content: "A page on my site" },
+];
+```
+
+**Detection grep:** `export const meta` followed by `=>` and `{` (or
+`return {`) inside the function body — not `[`. Read the full return
+expression; an inline conditional like `return cond ? { ... } : [ ... ]`
+needs both branches inspected.
+
+## 2. v1 OG / Twitter shorthand keys
+
+**Anti-pattern:**
+
+```tsx
+// BAD — v1 shorthand; key is dropped silently in v2
+export const meta: MetaFunction = () => [
+  { "og:title": "My Page" },
+  { "twitter:card": "summary_large_image" },
+];
+```
+
+**Why bad:** v2 has no shorthand for Open Graph or Twitter Cards. The keys
+do not match any descriptor shape (`title`, `name`+`content`,
+`property`+`content`, `tagName`, `script:ld+json`, `charset`,
+`httpEquiv`+`content`). They render as nothing.
+
+**Fix:**
+
+```tsx
+export const meta: MetaFunction = () => [
+  { property: "og:title", content: "My Page" },
+  { name: "twitter:card", content: "summary_large_image" },
+];
+```
+
+Note: Open Graph uses `property=`; Twitter Cards use `name=`. They look
+similar but are not interchangeable.
+
+## 3. `document.title` set in `useEffect` (or during render)
+
+**Anti-pattern:**
+
+```tsx
+// BAD — bypasses SSR; bots and previews see the default title
+export default function Page() {
+  useEffect(() => {
+    document.title = "My Page";
+  }, []);
+  return <h1>...</h1>;
+}
+```
+
+**Why bad:** The server renders the document `<head>` with whatever
+`<Meta />` aggregates from route exports. Setting `document.title` on the
+client only fires after hydration — search bots and social-preview scrapers
+that do not execute JavaScript see the parent or default title. Users see a
+visible flash from "Untitled" to "My Page".
+
+`document.title` inside render (not in an effect) is worse: it causes a
+hydration mismatch and runs on every render.
+
+**Fix:** Move to the `meta` export. If the title depends on loader data,
+type the export with `MetaFunction<typeof loader>` and read from `data`.
+
+```tsx
+export const meta: MetaFunction<typeof loader> = ({ data }) =>
+  [{ title: data?.title ?? "Loading..." }];
+```
+
+## 4. `root.tsx` missing `<Meta />` or `<Links />`
+
+**Anti-pattern:**
+
+```tsx
+// BAD — no <Meta /> or <Links /> aggregators in <head>
+export default function App() {
+  return (
+    <html>
+      <head>
+        <title>My Site</title>
+      </head>
+      <body>
+        <Outlet />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+```
+
+**Why bad:** Every route `meta` and `links` export silently does nothing.
+The symptom is "css is broken in production" or "meta tags are missing" —
+no compile error, no runtime warning.
+
+**Fix:** Both aggregators must live inside `<head>`. `<ScrollRestoration />`
+and `<Scripts />` go at the end of `<body>`.
+
+```tsx
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration }
+  from "@remix-run/react";
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+```
+
+## 5. Missing parent `meta` merge (no `matches.flatMap`)
+
+**Anti-pattern:**
+
+```tsx
+// BAD — leaf returns only its own title; root title/OG tags disappear
+export const meta: MetaFunction = () => [{ title: "Dashboard" }];
+```
+
+**Why bad:** v2 picks the **last matching route's** meta array — it does
+**not** merge across the hierarchy. A leaf route with no parent merge ships
+without site-wide tags (default OG image, canonical site name, etc.).
+
+This trips up reviewers familiar with v1, where parent + child meta merged
+automatically with last-write-wins per key.
+
+**Fix:** Use `matches` to pull parent descriptors, optionally filtering to
+override specific keys (e.g. title):
+
+```tsx
+export const meta: MetaFunction = ({ matches }) => {
+  const parentMeta = matches
+    .flatMap((m) => m.meta ?? [])
+    .filter((tag) => !("title" in tag)); // child overrides title only
+  return [...parentMeta, { title: "Dashboard" }];
+};
+```
+
+Alternative: put truly site-wide tags as plain JSX in `root.tsx`'s `<head>`
+so they live outside the `<Meta />` aggregator and cannot be displaced.
+
+## 6. `meta` reading `data` without null-guard
+
+**Anti-pattern:**
+
+```tsx
+// BAD — crashes on 404 / parent loader returning null
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  { title: data.post.title },
+];
+```
+
+**Why bad:** `meta` runs on every render path including error boundaries
+and 404s. If the loader threw a Response (e.g. `notFound()`), `data` is
+`undefined`. Accessing `data.post.title` throws during render, the
+document fails to render, and the user sees a generic error page instead
+of the proper 404.
+
+**Fix:** Guard at the top of the function:
+
+```tsx
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data?.post) return [{ title: "Not Found" }];
+  return [{ title: data.post.title }];
+};
+```
+
+## Detection notes for reviewers
+
+- **Grep first, read second.** Run `rg "export const meta" app/` and read
+  every match — the v1 shape is easy to miss in PR diffs because most
+  reviewers skim past `meta` exports.
+- **Check the import.** `MetaFunction` must come from `@remix-run/node`
+  (or `@remix-run/cloudflare`). An import from `@remix-run/react` or a
+  custom alias may have a loose return type that masks v1 shape.
+- **Check `tsconfig.json` strictness.** A v2 codebase with
+  `"strict": false` or no `MetaFunction` annotation can ship v1 shape
+  without any typecheck failure.
+- **Look for stale `v2_meta` future flag references.** A `remix.config.js`
+  still mentioning `v2_meta` suggests a partial migration — confirm every
+  `meta` export was updated.
+
+## Hard gates reminder
+
+Before flagging any `meta` issue, confirm the **Meta-shape check** in the
+parent SKILL's Hard gates: you read the actual return expression and it
+starts with `[` (array) or `{` (object). Diff-only inspection is insufficient.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/SKILL.md
@@ -136,9 +136,15 @@ and ships HTML/loader data to unauthenticated users. See
 ## CSRF
 
 **Remix has no built-in CSRF protection.** Same-origin `<Form>` posts rely
-entirely on whatever `SameSite` value you set on the session cookie. Subdomain
-takeovers, older browsers, and `<form>` POST exceptions to `SameSite=Lax` leave
-gaps. Recommend `remix-utils/csrf` with a **dedicated** signed cookie — never
+entirely on whatever `SameSite` value you set on the session cookie.
+`SameSite=Lax` blocks cookies on cross-site POST navigations in all current
+browsers. (Chrome briefly had a 2-minute "Lax+POST" window in 2020 — removed
+in 2021.) The real `Lax`-vs-`Strict` tradeoff is subdomain takeover: with
+`Lax`, a compromised subdomain can initiate top-level GET nav with
+credentials; with `Strict`, deep-link navigations from external sites lose
+session. Apps that use `SameSite=None` for legitimate cross-site needs
+(OAuth popups, iframe embeds) have no cookie-level CSRF protection at all.
+Recommend `remix-utils/csrf` with a **dedicated** signed cookie — never
 reuse the session cookie. Manual `fetch("/api/x", { method: "POST" })`
 bypasses `AuthenticityTokenInput`, so any action that does not call
 `csrf.validate(request)` is an attacker entry point.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: remix-v2-meta-sessions
+description: Remix v2 meta/SEO, sessions, auth, and CSRF. Use when working with document head, cookie sessions, auth gates, or CSRF protection. Triggers on meta export (v2 array shape), links export, createCookieSessionStorage, commitSession, destroySession, requireUserId, remix-utils/csrf, remix-auth.
+---
+
+# Remix v2 Meta, Sessions, Auth, and CSRF
+
+## Quick Reference
+
+**v2 `meta` returns an array of descriptor objects** — NOT the v1 object shape.
+A v1-style object literal still typechecks in stale codebases but renders no
+tags at runtime.
+
+```tsx
+// app/routes/posts.$slug.tsx
+import type { MetaFunction } from "@remix-run/node";
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+  if (!data?.post) return [{ title: "Not Found" }];
+  return [
+    { title: `${data.post.title} | My Blog` },
+    { name: "description", content: data.post.excerpt },
+    { property: "og:title", content: data.post.title },
+    { tagName: "link", rel: "canonical", href: data.post.url },
+  ];
+};
+```
+
+**Cookie session storage with secure defaults and secret rotation**:
+
+```ts
+// app/session.server.ts
+import { createCookieSessionStorage } from "@remix-run/node";
+
+type SessionData = { userId: string };
+type SessionFlashData = { error: string };
+
+const SESSION_SECRET = process.env.SESSION_SECRET;
+if (!SESSION_SECRET) throw new Error("SESSION_SECRET is required");
+
+export const { getSession, commitSession, destroySession } =
+  createCookieSessionStorage<SessionData, SessionFlashData>({
+    cookie: {
+      name: "__session",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30,
+      secrets: [
+        SESSION_SECRET,
+        ...(process.env.SESSION_SECRET_OLD ? [process.env.SESSION_SECRET_OLD] : []),
+      ],
+    },
+  });
+```
+
+## Document Head: `meta` and `links`
+
+`<Meta />` and `<Links />` must live inside `<head>` in `root.tsx`;
+`<ScrollRestoration />`, `<Scripts />`, and `<LiveReload />` go at the end of
+`<body>`. Missing either of these aggregators produces "css doesn't load" or
+"meta tags missing" with no compile error.
+
+```tsx
+// app/root.tsx
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+```
+
+v2 does NOT auto-merge meta across the route hierarchy — Remix picks the last
+matching route's meta array only. To inherit from parents, flatMap `matches`
+explicitly. See [references/meta-v2.md](references/meta-v2.md).
+
+## Sessions
+
+`commitSession` must be attached as a `Set-Cookie` header on every mutating
+response. Remix does NOT auto-commit; calling `session.set(...)` and returning
+plain `json(data)` silently drops the change.
+
+```ts
+return redirect("/dashboard", {
+  headers: { "Set-Cookie": await commitSession(session) },
+});
+```
+
+`session.flash(key, value)` is read-once; the consuming loader must still call
+`commitSession` after reading to clear the flash. See
+[references/sessions.md](references/sessions.md).
+
+## Auth: throw `redirect` from loaders
+
+The canonical pattern is a `requireUserId(request)` helper that **throws**
+`redirect()` for unauthenticated requests. The thrown response short-circuits
+the loader; no top-level `return` is needed.
+
+```ts
+// app/auth.server.ts
+import { redirect } from "@remix-run/node";
+import { getSession } from "./session.server";
+
+export async function requireUserId(request: Request): Promise<string> {
+  const session = await getSession(request.headers.get("Cookie"));
+  const userId = session.get("userId");
+  if (!userId) {
+    const url = new URL(request.url);
+    const redirectTo = `${url.pathname}${url.search}`;
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+  }
+  return userId;
+}
+```
+
+Never gate routes inside React components — the protected component still SSRs
+and ships HTML/loader data to unauthenticated users. See
+[references/auth-csrf.md](references/auth-csrf.md).
+
+## CSRF
+
+**Remix has no built-in CSRF protection.** Same-origin `<Form>` posts rely
+entirely on whatever `SameSite` value you set on the session cookie. Subdomain
+takeovers, older browsers, and `<form>` POST exceptions to `SameSite=Lax` leave
+gaps. Recommend `remix-utils/csrf` with a **dedicated** signed cookie — never
+reuse the session cookie. Manual `fetch("/api/x", { method: "POST" })`
+bypasses `AuthenticityTokenInput`, so any action that does not call
+`csrf.validate(request)` is an attacker entry point.
+
+## Gates (decision sequencing)
+
+Answer **in order**. **Pass** means the condition is true; pick the API on the
+same line and **stop**.
+
+### Where does this `meta` tag live?
+
+1. **Is it site-wide (charset, viewport, default OG image)?**
+   - **Pass →** Plain JSX inside `<head>` in `root.tsx`. Avoids the v2
+     no-merge surprise and prevents duplicate tags. **Stop.**
+   - **Fail →** Step 2.
+2. **Is it route-specific (title, description, canonical, JSON-LD)?**
+   - **Pass →** `export const meta` in the leaf route file; if you need
+     parent values, `matches.flatMap((m) => m.meta ?? [])`. **Stop.**
+
+### Auth check: `loader`, `action`, or helper?
+
+1. **Is this a GET (page render) that must be protected?**
+   - **Pass →** Call `await requireUserId(request)` at the top of the
+     `loader`. **Stop.**
+2. **Is this a POST/PUT/DELETE mutation that must be protected?**
+   - **Pass →** Call `await requireUserId(request)` at the top of the
+     `action`, AND call `await csrf.validate(request)`. **Stop.**
+3. **Logout?**
+   - **Pass →** `action` only, never `loader`. A `<Link to="/logout">`
+     pointing at a loader is CSRF-able via `<img src="/logout">`. Use
+     `<Form method="post" action="/logout">`. **Stop.**
+
+### Where does the CSRF token live?
+
+1. **Are you using `remix-utils/csrf`?**
+   - **Pass →** A dedicated `createCookie("csrf", { ... })` cookie, separate
+     from the session cookie. The CSRF value is a signed string; the
+     session value is a serialized object — reusing one cookie throws on
+     validate. **Stop.**
+   - **Fail →** Step 2.
+2. **No CSRF library?**
+   - **Pass →** Document the threat model; require `sameSite: "strict"` on
+     the session cookie and verify the `Origin` header in every action.
+     Prefer adding `remix-utils/csrf` instead.
+
+## Additional Documentation
+
+- **Meta v2**: See [references/meta-v2.md](references/meta-v2.md) for
+  descriptor types, parent merging via `matches`, JSON-LD, and v1→v2 migration
+  pitfalls.
+- **Links**: See [references/links.md](references/links.md) for stylesheet,
+  preload, dns-prefetch, and the parent-aggregation behavior of `<Links />`.
+- **Sessions**: See [references/sessions.md](references/sessions.md) for
+  `createCookieSessionStorage` config, `commitSession`/`destroySession`
+  patterns, flash messages, and database-backed sessions.
+- **Auth and CSRF**: See [references/auth-csrf.md](references/auth-csrf.md)
+  for `requireUserId` helpers, login/logout actions, `remix-auth`, and
+  `remix-utils/csrf` wiring.
+
+## v1 vs v2 Quick Comparison
+
+| Concern | v1 | v2 |
+|---|---|---|
+| `meta` return shape | Object `{ title, description }` | Array `[{ title }, { name, content }]` |
+| Parent meta merge | Auto-merged (last-write-wins per key) | No merge; last matching route only |
+| `meta` argument for parent data | `parentsData` | `matches` (flatMap manually) |
+| OG tags | `{ "og:title": "..." }` shorthand | `{ property: "og:title", content: "..." }` |
+| Migration flag | `v2_meta: true` future flag | N/A (v2 default) |

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/SKILL.md
@@ -86,9 +86,33 @@ export default function App() {
 }
 ```
 
-v2 does NOT auto-merge meta across the route hierarchy — Remix picks the last
-matching route's meta array only. To inherit from parents, flatMap `matches`
-explicitly. See [references/meta-v2.md](references/meta-v2.md).
+**`<Meta />` and `<Links />` aggregate differently.** `<Links />` walks the
+entire route match chain and renders **every** matched route's `links` export
+— a stylesheet declared in a leaf route is rendered automatically and
+unloaded on navigation away. `<Meta />` does **NOT** aggregate; Remix picks
+the last matching route's `meta` array only. To inherit from parents in
+`meta`, flatMap `matches` explicitly:
+
+```tsx
+import type { MetaFunction } from "@remix-run/node";
+import type { loader as projectLoader } from "./project.$pid";
+
+export const meta: MetaFunction<
+  typeof loader,
+  { "routes/project.$pid": typeof projectLoader }
+> = ({ data, matches }) => {
+  const parentMeta = matches.flatMap((m) => m.meta ?? []);
+  const project = matches.find((m) => m.id === "routes/project.$pid")?.data;
+  return [
+    ...parentMeta,
+    { title: `${data?.task.name} | ${project?.name}` },
+  ];
+};
+```
+
+The second generic on `MetaFunction` (keyed by route id) types
+`matches.find(...).data` for parent routes. See
+[references/meta-v2.md](references/meta-v2.md).
 
 ## Sessions
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/auth-csrf.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/auth-csrf.md
@@ -1,0 +1,305 @@
+# Auth and CSRF Reference
+
+Remix v2 ships **no** built-in auth and **no** built-in CSRF protection. The
+conventional patterns are a `requireUserId(request)` helper that throws
+`redirect()` from loaders and actions, optionally paired with `remix-auth`
+for strategy-based flows, plus `remix-utils/csrf` for token-based CSRF.
+
+## The `requireUserId` Helper
+
+The canonical Remix auth pattern is a helper that loads the session,
+returns the `userId` if present, and **throws** `redirect(...)` otherwise.
+Thrown responses short-circuit the loader; there's no top-level `return`
+needed at the call site.
+
+```ts
+// app/auth.server.ts
+import { redirect } from "@remix-run/node";
+import { getSession } from "./session.server";
+
+export async function requireUserId(request: Request): Promise<string> {
+  const session = await getSession(request.headers.get("Cookie"));
+  const userId = session.get("userId");
+  if (!userId) {
+    const url = new URL(request.url);
+    const redirectTo = `${url.pathname}${url.search}`;
+    throw redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+  }
+  return userId;
+}
+
+// Optional "may be logged out" variant.
+export async function getUserId(request: Request): Promise<string | null> {
+  const session = await getSession(request.headers.get("Cookie"));
+  return session.get("userId") ?? null;
+}
+```
+
+Usage in a protected loader:
+
+```ts
+// app/routes/dashboard.tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { requireUserId } from "~/auth.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const userId = await requireUserId(request);
+  const data = await getDashboardData(userId);
+  return json({ data });
+}
+```
+
+Same pattern works in actions — call `requireUserId` first, then run the
+mutation. Treating auth as the first line of every protected loader and
+action is the SSR-correct approach: unauthenticated users never see the
+protected component's HTML, never receive its loader data, and never get
+a flash of protected content.
+
+## Auth Checks in React Components Are Wrong
+
+```tsx
+// DO NOT DO THIS
+function Dashboard() {
+  const user = useUser();
+  if (!user) return <Navigate to="/login" />;
+  return <ProtectedContent />;
+}
+```
+
+The component still SSRs and ships its HTML to unauthenticated users. The
+loader's data is already in the document. The `<Navigate>` redirect fires
+after hydration — a visible flash of protected content. Always gate at the
+loader.
+
+## Login Action
+
+```ts
+// app/routes/login.tsx
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { getSession, commitSession } from "~/session.server";
+import { verifyLogin } from "~/models/user.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const form = await request.formData();
+  const email = String(form.get("email") ?? "");
+  const password = String(form.get("password") ?? "");
+
+  const user = await verifyLogin(email, password);
+
+  if (!user) {
+    session.flash("error", "Invalid email or password");
+    return redirect("/login", {
+      headers: { "Set-Cookie": await commitSession(session) },
+    });
+  }
+
+  session.set("userId", user.id);
+  return redirect("/dashboard", {
+    headers: { "Set-Cookie": await commitSession(session) },
+  });
+}
+```
+
+Failed-login response uses `session.flash` so the message survives the
+redirect and clears on the next read. Successful login sets `userId` and
+redirects; both paths attach `commitSession` as `Set-Cookie`.
+
+## Logout Action
+
+Logout MUST live in an `action`, never a `loader`. A `<Link to="/logout">`
+pointing at a loader is CSRF-able via `<img src="/logout">` — any
+third-party page can force-logout your users.
+
+```ts
+// app/routes/logout.tsx
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import { getSession, destroySession } from "~/session.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  return redirect("/login", {
+    headers: { "Set-Cookie": await destroySession(session) },
+  });
+}
+```
+
+In the UI:
+
+```tsx
+<Form method="post" action="/logout">
+  <button type="submit">Log out</button>
+</Form>
+```
+
+## `remix-auth` Brief Overview
+
+For multi-strategy auth (OAuth, magic links, multiple providers),
+`remix-auth` provides an `Authenticator<User>` that wraps your session
+storage and runs strategy classes.
+
+```ts
+// app/auth.server.ts
+import { Authenticator } from "remix-auth";
+import { FormStrategy } from "remix-auth-form";
+import { sessionStorage } from "~/session.server";
+
+export const authenticator = new Authenticator<User>(sessionStorage);
+
+authenticator.use(
+  new FormStrategy(async ({ form }) => {
+    const email = String(form.get("email"));
+    const password = String(form.get("password"));
+    const user = await verifyLogin(email, password);
+    if (!user) throw new Error("Invalid credentials");
+    return user;
+  }),
+  "user-pass",
+);
+```
+
+In an action:
+
+```ts
+return authenticator.authenticate("user-pass", request, {
+  successRedirect: "/dashboard",
+  failureRedirect: "/login",
+});
+```
+
+`remix-auth` requires session storage and writes the user into the session
+itself. If you already have a working `requireUserId` helper, adding
+`remix-auth` only makes sense once you have multiple strategies to manage.
+
+## CSRF: Remix Has None
+
+Remix ships no CSRF tooling. Same-origin `<Form>` posts rely entirely on
+the `SameSite` value of the session cookie. `SameSite=Lax` blocks most
+cross-origin POSTs but allows top-level GET navigations and has a known
+exception for `<form method="post">` POSTs in some browsers. Subdomain
+takeovers and older browsers leave further gaps.
+
+The community answer is `remix-utils/csrf` — a separate signed cookie that
+issues per-session tokens, validated in every mutating action.
+
+## CSRF Setup with `remix-utils`
+
+The CSRF token lives in its OWN cookie, never the session cookie. The
+session cookie holds a serialized object; the CSRF cookie holds a signed
+string. Reusing one cookie for both throws on validate.
+
+```ts
+// app/utils/csrf.server.ts
+import { createCookie } from "@remix-run/node";
+import { CSRF } from "remix-utils/csrf/server";
+
+export const csrfCookie = createCookie("csrf", {
+  path: "/",
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax",
+  secrets: [process.env.CSRF_SECRET!],
+});
+
+export const csrf = new CSRF({
+  cookie: csrfCookie,
+  secret: process.env.CSRF_SECRET!,
+});
+```
+
+Issue the token in `root.tsx`'s loader and provide it to the component
+tree:
+
+```tsx
+// app/root.tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
+import { AuthenticityTokenProvider } from "remix-utils/csrf/react";
+import { csrf } from "~/utils/csrf.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const [token, cookieHeader] = await csrf.commitToken(request);
+  return json(
+    { csrf: token },
+    { headers: cookieHeader ? { "Set-Cookie": cookieHeader } : {} },
+  );
+}
+
+export default function App() {
+  const { csrf: token } = useLoaderData<typeof loader>();
+  return (
+    <html lang="en">
+      {/* head ... */}
+      <body>
+        <AuthenticityTokenProvider token={token}>
+          <Outlet />
+        </AuthenticityTokenProvider>
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+```
+
+Attach the token to every mutating form:
+
+```tsx
+import { Form } from "@remix-run/react";
+import { AuthenticityTokenInput } from "remix-utils/csrf/react";
+
+export default function CommentForm() {
+  return (
+    <Form method="post">
+      <AuthenticityTokenInput />
+      <textarea name="body" />
+      <button type="submit">Post</button>
+    </Form>
+  );
+}
+```
+
+For `useFetcher().submit(...)` calls, use `useAuthenticityToken()` to read
+the token and include it in the submission payload manually.
+
+## Validating in Actions
+
+Every mutating action must call `csrf.validate(request)`. Skip it and the
+action becomes the entry point an attacker uses.
+
+```ts
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { CSRFError } from "remix-utils/csrf/server";
+import { csrf } from "~/utils/csrf.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  try {
+    await csrf.validate(request);
+  } catch (err) {
+    if (err instanceof CSRFError) {
+      throw new Response("Bad CSRF", { status: 403 });
+    }
+    throw err;
+  }
+  // ...continue with mutation
+}
+```
+
+`CSRFError` exposes codes (`missing_token_in_cookie`, `invalid_token_in_cookie`,
+`tampered_token_in_cookie`, `missing_token_in_body`, `mismatched_token`) for
+finer-grained handling if needed.
+
+## The Manual `fetch` POST Bypass
+
+Hand-rolled `fetch("/api/x", { method: "POST" })` skips
+`AuthenticityTokenInput` entirely, so `csrf.validate(request)` throws. The
+fix is to use `<Form>` or `useFetcher().submit(...)`, which round-trip
+through the form-data submission path the token wiring expects. If you
+genuinely need a JSON `fetch`, manually attach the token in the body or
+header — and audit every mutating action to confirm `csrf.validate` is the
+first thing it does. An action without validation, reachable via plain
+`fetch`, is an open CSRF hole regardless of any other defense.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/auth-csrf.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/auth-csrf.md
@@ -147,6 +147,7 @@ import { Authenticator } from "remix-auth";
 import { FormStrategy } from "remix-auth-form";
 import { sessionStorage } from "~/session.server";
 
+// Snippet targets remix-auth@^2; v3 dropped the sessionStorage argument from the constructor.
 export const authenticator = new Authenticator<User>(sessionStorage);
 
 authenticator.use(

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/links.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/links.md
@@ -13,12 +13,15 @@ import type { LinksFunction } from "@remix-run/node";
 
 A `LinkDescriptor` is one of two unions:
 
-- `HtmlLinkDescriptor` — fields mirror the `<link>` element:
-  `rel` (`stylesheet` | `preload` | `prefetch` | `dns-prefetch` |
-  `preconnect` | `icon` | `canonical` | `alternate`), `href`, `as`,
-  `type`, `media`, `crossOrigin`, `imagesrcset`, `imagesizes`,
-  `integrity`, `disabled`.
-- `PageLinkDescriptor` — `{ page: string }`. Tells Remix to preload the
+- `HtmlLinkDescriptor` — fields mirror the `<link>` element. Per Remix v2
+  the `rel` type is `LiteralUnion<"alternate" | "dns-prefetch" | "icon" |
+  "manifest" | "modulepreload" | "next" | "pingback" | "preconnect" |
+  "prefetch" | "preload" | "prerender" | "search" | "stylesheet", string>`
+  — any string is accepted at compile time; common non-literal values
+  include `canonical` and `apple-touch-icon`. Other fields: `href`, `as`,
+  `type`, `media`, `crossOrigin`, `imageSrcSet`, `imageSizes`,
+  `integrity`, `disabled`, `hrefLang`.
+- `PrefetchPageDescriptor` — `{ page: string }`. Tells Remix to preload the
   module graph and loader data for the given route path.
 
 ## Stylesheets
@@ -51,19 +54,19 @@ export const links: LinksFunction = () => [
     rel: "preload",
     as: "image",
     href: "/img/hero.jpg",
-    imagesrcset: "/img/hero-sm.jpg 480w, /img/hero-lg.jpg 1200w",
-    imagesizes: "(max-width: 600px) 480px, 1200px",
+    imageSrcSet: "/img/hero-sm.jpg 480w, /img/hero-lg.jpg 1200w",
+    imageSizes: "(max-width: 600px) 480px, 1200px",
   },
 ];
 ```
 
-`imagesrcset` and `imagesizes` mirror the responsive-image attributes from
+`imageSrcSet` and `imageSizes` mirror the responsive-image attributes from
 `<img srcset>` / `<img sizes>`; together they let the browser pick the
 right asset to preload for the current viewport.
 
 ## Page Preloads
 
-`PageLinkDescriptor` triggers a module and loader-data preload for a route
+`PrefetchPageDescriptor` triggers a module and loader-data preload for a route
 the user is likely to visit:
 
 ```tsx
@@ -84,8 +87,8 @@ elements, dedicated SEO-stable links (canonical, alternate) live better in
 
 ```tsx
 export const links: LinksFunction = () => [
-  { rel: "canonical", href: "https://example.com/posts/intro" },
-  { rel: "alternate", hreflang: "fr", href: "https://example.com/fr/posts/intro" },
+  { rel: "canonical", href: "https://example.com/posts/intro" }, // canonical is not in the literal union; accepted via the open-string fallback
+  { rel: "alternate", hrefLang: "fr", href: "https://example.com/fr/posts/intro" },
 ];
 ```
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/links.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/links.md
@@ -1,0 +1,154 @@
+# Links Reference
+
+The Remix v2 `links` route export returns an array of `LinkDescriptor`
+objects, mirroring the shape of `meta`. `<Links />` (from `@remix-run/react`)
+placed inside `<head>` in `root.tsx` aggregates every matched route's links
+into the document head.
+
+## Imports
+
+```ts
+import type { LinksFunction } from "@remix-run/node";
+```
+
+A `LinkDescriptor` is one of two unions:
+
+- `HtmlLinkDescriptor` — fields mirror the `<link>` element:
+  `rel` (`stylesheet` | `preload` | `prefetch` | `dns-prefetch` |
+  `preconnect` | `icon` | `canonical` | `alternate`), `href`, `as`,
+  `type`, `media`, `crossOrigin`, `imagesrcset`, `imagesizes`,
+  `integrity`, `disabled`.
+- `PageLinkDescriptor` — `{ page: string }`. Tells Remix to preload the
+  module graph and loader data for the given route path.
+
+## Stylesheets
+
+The most common use is route-scoped stylesheets:
+
+```tsx
+// app/routes/dashboard.tsx
+import type { LinksFunction } from "@remix-run/node";
+import dashboardStyles from "~/styles/dashboard.css";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: dashboardStyles },
+];
+```
+
+When the user navigates away from `/dashboard`, Remix removes its stylesheet
+from the document head. Route-scoped stylesheets prevent CSS bleeding
+between unrelated parts of the app.
+
+## Preload, dns-prefetch, preconnect
+
+```tsx
+import type { LinksFunction } from "@remix-run/node";
+
+export const links: LinksFunction = () => [
+  { rel: "dns-prefetch", href: "https://cdn.example.com" },
+  { rel: "preconnect", href: "https://cdn.example.com", crossOrigin: "anonymous" },
+  {
+    rel: "preload",
+    as: "image",
+    href: "/img/hero.jpg",
+    imagesrcset: "/img/hero-sm.jpg 480w, /img/hero-lg.jpg 1200w",
+    imagesizes: "(max-width: 600px) 480px, 1200px",
+  },
+];
+```
+
+`imagesrcset` and `imagesizes` mirror the responsive-image attributes from
+`<img srcset>` / `<img sizes>`; together they let the browser pick the
+right asset to preload for the current viewport.
+
+## Page Preloads
+
+`PageLinkDescriptor` triggers a module and loader-data preload for a route
+the user is likely to visit:
+
+```tsx
+export const links: LinksFunction = () => [
+  { page: "/dashboard" },
+];
+```
+
+Use sparingly — every preloaded page fires its loaders. Reserve for
+genuinely likely next-clicks (a marketing page that almost always leads to
+`/signup`, for example).
+
+## Canonical and Alternate
+
+While `tagName: "link"` inside the `meta` export can emit `<link>`
+elements, dedicated SEO-stable links (canonical, alternate) live better in
+`links`:
+
+```tsx
+export const links: LinksFunction = () => [
+  { rel: "canonical", href: "https://example.com/posts/intro" },
+  { rel: "alternate", hreflang: "fr", href: "https://example.com/fr/posts/intro" },
+];
+```
+
+Per-request canonical URLs (those that depend on the request URL) still
+belong in the `meta` export via `{ tagName: "link", rel: "canonical" }` so
+they can read `location` and `data`.
+
+## Favicons and Icons
+
+```tsx
+export const links: LinksFunction = () => [
+  { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
+  { rel: "apple-touch-icon", href: "/apple-touch-icon.png" },
+];
+```
+
+These typically live in `root.tsx`'s `links` export so they appear on
+every page.
+
+## Parent Aggregation Behavior
+
+Unlike `meta`, `<Links />` **does** aggregate across the matched route
+tree. Every matched route contributes its `links` descriptors to the
+document head; on navigation, Remix removes the ones from routes that
+are no longer matched.
+
+This is the behavior most developers expect for stylesheets: the root
+stylesheet stays, the dashboard stylesheet appears when you navigate to
+`/dashboard`, and it disappears when you leave.
+
+## Root Document Scaffolding
+
+```tsx
+// app/root.tsx
+import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from "@remix-run/react";
+import type { LinksFunction } from "@remix-run/node";
+import globalStyles from "~/styles/global.css";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: globalStyles },
+  { rel: "icon", href: "/favicon.svg", type: "image/svg+xml" },
+];
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+```
+
+If `<Links />` is omitted from `<head>`, no stylesheets load and no preload
+hints fire — the symptom is "css is broken in production" with no errors
+in the console.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/meta-v2.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/meta-v2.md
@@ -28,7 +28,7 @@ A `MetaDescriptor` is a union of:
 | `{ name: string, content: string }` | `<meta name=... content=...>` |
 | `{ property: string, content: string }` | `<meta property=... content=...>` (OG, Twitter) |
 | `{ httpEquiv: string, content: string }` | `<meta http-equiv=... content=...>` |
-| `{ charset: "utf-8" }` | `<meta charset="utf-8">` |
+| `{ charSet: "utf-8" }` | `<meta charset="utf-8">` |
 | `{ tagName: "link", ...HtmlLinkAttrs }` | `<link>` (canonical, alternate) |
 | `{ "script:ld+json": object }` | `<script type="application/ld+json">` |
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/meta-v2.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/meta-v2.md
@@ -1,0 +1,193 @@
+# Meta v2 Reference
+
+The Remix v2 `meta` route export returns an **array of `MetaDescriptor`
+objects**. This is the single most important fact about v2 meta: a v1-style
+object literal (`{ title, description }`) typechecks against the old
+`MetaFunction` signature in stale codebases but produces zero rendered meta
+tags at runtime.
+
+## Imports
+
+```ts
+import type { MetaFunction } from "@remix-run/node";
+// MetaDescriptor union type is exported from @remix-run/react
+import type { MetaDescriptor } from "@remix-run/react";
+```
+
+`<Meta />` (from `@remix-run/react`) is the aggregator placed inside `<head>`
+in `root.tsx`. It walks the matched route tree and renders descriptors from
+the last matching route's `meta` export.
+
+## Descriptor Types
+
+A `MetaDescriptor` is a union of:
+
+| Shape | Renders as |
+|---|---|
+| `{ title: string }` | `<title>` |
+| `{ name: string, content: string }` | `<meta name=... content=...>` |
+| `{ property: string, content: string }` | `<meta property=... content=...>` (OG, Twitter) |
+| `{ httpEquiv: string, content: string }` | `<meta http-equiv=... content=...>` |
+| `{ charset: "utf-8" }` | `<meta charset="utf-8">` |
+| `{ tagName: "link", ...HtmlLinkAttrs }` | `<link>` (canonical, alternate) |
+| `{ "script:ld+json": object }` | `<script type="application/ld+json">` |
+
+Use the explicit `{ property, content }` shape for any `og:*` or `twitter:*`
+tag — the v1 shorthand `{ "og:title": "..." }` is silently dropped in v2.
+
+## Complete Example
+
+```tsx
+// app/routes/posts.$slug.tsx
+import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const post = await getPost(params.slug);
+  if (!post) throw new Response("Not Found", { status: 404 });
+  return json({ post });
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data, location }) => {
+  // Null-guard: meta runs on error/404 too; data may be undefined.
+  if (!data?.post) return [{ title: "Not Found" }];
+
+  const url = `https://example.com${location.pathname}`;
+  return [
+    { title: `${data.post.title} | My Blog` },
+    { name: "description", content: data.post.excerpt },
+    { property: "og:title", content: data.post.title },
+    { property: "og:description", content: data.post.excerpt },
+    { property: "og:url", content: url },
+    { property: "og:type", content: "article" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { tagName: "link", rel: "canonical", href: url },
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        headline: data.post.title,
+        datePublished: data.post.publishedAt,
+        author: { "@type": "Person", name: data.post.authorName },
+      },
+    },
+  ];
+};
+```
+
+## The `matches` Argument (parent meta access)
+
+v2 replaces v1's `parentsData` with a `matches` array. Each match exposes
+`id`, `pathname`, `params`, `data`, `handle`, and `meta` — the descriptors
+the parent route's `meta` function returned (or would return).
+
+```tsx
+import type { MetaFunction } from "@remix-run/node";
+
+export const meta: MetaFunction = ({ matches }) => {
+  const parentMeta = matches
+    .flatMap((m) => m.meta ?? [])
+    // Child overrides the title; everything else from parents is kept.
+    .filter((tag) => !("title" in tag));
+
+  return [...parentMeta, { title: "Dashboard" }];
+};
+```
+
+To read a specific parent loader's data:
+
+```tsx
+import type { MetaFunction } from "@remix-run/node";
+import type { loader as rootLoader } from "~/root";
+
+export const meta: MetaFunction<typeof loader, { root: typeof rootLoader }> = ({
+  data,
+  matches,
+}) => {
+  const rootMatch = matches.find((m) => m.id === "root");
+  const siteName = rootMatch?.data?.siteName ?? "Site";
+  return [{ title: `${data.title} | ${siteName}` }];
+};
+```
+
+## Parent Merge Behavior (v1 vs v2)
+
+v1 merged parent + child meta automatically with last-write-wins per key.
+v2 picks the array returned by the **last matching route only**; sibling
+routes are not combined and parent descriptors are NOT inherited unless the
+child opts in via `matches`.
+
+Consequence: if `root.tsx` defines its title via a `meta` export, every leaf
+route that needs a title must either return a `{ title }` of its own OR
+flatMap the parent meta. Most teams sidestep this by putting `charset`,
+`viewport`, and any truly site-wide tags as **plain JSX** inside `<head>`:
+
+```tsx
+// app/root.tsx
+<head>
+  <meta charSet="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <Meta />
+  <Links />
+</head>
+```
+
+This keeps site-wide tags out of the merge logic entirely.
+
+## JSON-LD (`script:ld+json`)
+
+The `"script:ld+json"` descriptor is the only supported way to emit
+structured-data scripts through the `meta` export. The value is a plain
+object that Remix serializes as JSON.
+
+```tsx
+{
+  "script:ld+json": {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Example Corp",
+    url: "https://example.com",
+  },
+}
+```
+
+Two routes both emitting `script:ld+json` with identical contents will
+produce a React "same key" warning. Remix does not auto-deduplicate; keep
+JSON-LD blocks in a single route (typically the leaf), not in `root` plus
+the leaf.
+
+## v1 → v2 Migration Pitfalls
+
+1. **Object return still typechecks against the v1 `MetaFunction`.** Grep
+   for `export const meta` followed by `return {` or `=> ({`. If the function
+   returns an object literal, the route renders no meta tags. Convert to an
+   array of descriptors.
+
+2. **`parentsData` was removed.** Replace with `matches`. The
+   `@remix-run/v1-meta` compatibility package exposes `getMatchesData()` for
+   gradual migration; new code should use `matches` directly.
+
+3. **OG shorthand keys are dropped.** Replace `{ "og:title": "..." }` with
+   `{ property: "og:title", content: "..." }`.
+
+4. **Default merge reversed.** Child routes inherit nothing from parents
+   unless they merge via `matches.flatMap`. Codebases relying on inherited
+   titles will render the parent's title on the leaf — or no title at all.
+
+5. **`v2_meta: true` future flag** was the migration switch in late v1.
+   Codebases that ran with it enabled before upgrading rarely have issues;
+   codebases that jumped straight to v2 with v1-shaped `meta` exports are
+   the ones that need cleanup.
+
+6. **`charset` and `viewport` rendered through the `meta` export** can
+   duplicate when parent merge happens manually. Most teams keep both as
+   inline JSX in `root.tsx` to avoid the issue.
+
+## Client-Side `document.title` Is Wrong
+
+Setting `document.title = "..."` (or doing the same inside `useEffect`)
+bypasses SSR — search bots and social previews see the default title, and
+users see a visible flash on hydration. Always use the `meta` export with
+`{ title }`. If the title must update from client state, return it from a
+loader and re-render via revalidation.

--- a/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/sessions.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-meta-sessions/references/sessions.md
@@ -1,0 +1,225 @@
+# Sessions Reference
+
+Remix v2 sessions are built around a storage factory that returns three
+functions: `getSession`, `commitSession`, and `destroySession`. The factory
+you choose controls where session data lives; the API is identical for all
+of them.
+
+## Storage Factories
+
+| Factory | Import | When to use |
+|---|---|---|
+| `createCookieSessionStorage<Data, Flash>` | `@remix-run/node` | Default. Payload lives in the cookie itself (signed, size-limited). |
+| `createMemorySessionStorage` | `@remix-run/node` | Dev-only. Lost on restart; not multi-process safe. |
+| `createFileSessionStorage` | `@remix-run/node` | Single-server Node/Deno deployments. |
+| `createSessionStorage` | `@remix-run/node` | Custom backend (DB, Redis) via `createData` / `readData` / `updateData` / `deleteData`. |
+
+For most apps `createCookieSessionStorage` is correct; cookies are signed,
+stateless, and require no separate session store. Switch to
+`createSessionStorage` only when payload size exceeds ~4 KB or you need
+server-side revocation.
+
+## Secure Cookie Configuration
+
+Remix sets NO secure defaults. Every flag is caller-responsibility. Missing
+`httpOnly` exposes the session to XSS; missing `secure` lets the cookie
+leak over HTTP; missing `sameSite` opens CSRF surface.
+
+```ts
+// app/session.server.ts
+import { createCookieSessionStorage } from "@remix-run/node";
+
+type SessionData = { userId: string };
+type SessionFlashData = { error: string };
+
+const SESSION_SECRET = process.env.SESSION_SECRET;
+if (!SESSION_SECRET) throw new Error("SESSION_SECRET is required");
+
+export const { getSession, commitSession, destroySession } =
+  createCookieSessionStorage<SessionData, SessionFlashData>({
+    cookie: {
+      name: "__session",
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+      secrets: [
+        SESSION_SECRET,
+        ...(process.env.SESSION_SECRET_OLD ? [process.env.SESSION_SECRET_OLD] : []),
+      ],
+    },
+  });
+```
+
+Notes on each flag:
+
+- `name`: Prefix `__` is a convention for "framework-owned" cookies; pick
+  something distinct from app data cookies.
+- `httpOnly: true`: Blocks `document.cookie` access from JavaScript.
+  Mandatory.
+- `secure`: Read from env. Hardcoding `true` breaks `http://localhost` dev;
+  hardcoding `false` ships an insecure cookie to production.
+- `sameSite`: `"lax"` is the modern default. Use `"strict"` if you can
+  accept that links from external sites to authenticated pages will land
+  the user logged-out on the first request. `"none"` requires `secure: true`.
+- `path: "/"`: Cookie sent on every request to the domain.
+- `maxAge`: Seconds. Omit for a session-lifetime cookie that disappears
+  when the browser closes.
+- `domain`: Set explicitly only when sharing the session across subdomains.
+- `secrets`: An array. See secret rotation below.
+
+## Secret Rotation
+
+Remix signs new cookies with `secrets[0]` and verifies incoming cookies
+against any entry in the array. Rotation is therefore a **prepend**:
+
+```ts
+secrets: [
+  process.env.SESSION_SECRET,         // new — used for signing
+  process.env.SESSION_SECRET_OLD,     // old — still validates existing sessions
+],
+```
+
+Replacing the secret outright (instead of prepending) instantly invalidates
+every existing session. After `maxAge` has elapsed since the rotation, you
+can drop the old entry.
+
+Never commit a real secret to source or to `.env.example`. Anyone with the
+secret can forge session cookies.
+
+## Reading and Writing Sessions
+
+```ts
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { getSession, commitSession } from "~/session.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const userId = session.get("userId");
+  return json({ userId });
+}
+```
+
+The `Session` instance exposes `get`, `set`, `has`, `unset`, and `flash`.
+
+## `commitSession` Is Mandatory on Mutations
+
+Remix does NOT auto-commit. Calling `session.set("userId", id)` and then
+`return json(data)` ships zero `Set-Cookie` header — the change exists only
+in memory and is dropped when the response sends.
+
+Every response that touches the session must attach the committed cookie:
+
+```ts
+import { redirect } from "@remix-run/node";
+import { getSession, commitSession } from "~/session.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  session.set("userId", user.id);
+
+  return redirect("/dashboard", {
+    headers: { "Set-Cookie": await commitSession(session) },
+  });
+}
+```
+
+Same pattern works with `json`:
+
+```ts
+return json(data, {
+  headers: { "Set-Cookie": await commitSession(session) },
+});
+```
+
+## `destroySession` for Logout
+
+```ts
+import { redirect } from "@remix-run/node";
+import { getSession, destroySession } from "~/session.server";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  return redirect("/login", {
+    headers: { "Set-Cookie": await destroySession(session) },
+  });
+}
+```
+
+`destroySession` returns a `Set-Cookie` header with an expired date,
+clearing the cookie in the browser. Logout MUST live in an `action`, not a
+`loader` — a `<Link to="/logout">` pointing at a loader is CSRF-able via
+`<img src="/logout">`. Use `<Form method="post" action="/logout">`.
+
+## Flash Messages
+
+`session.flash(key, value)` writes a value that is automatically cleared
+the first time it's read with `session.get(key)`. Useful for
+one-shot status messages (form errors, success toasts) that survive a
+single redirect.
+
+```ts
+// login action, failure case
+const session = await getSession(request.headers.get("Cookie"));
+session.flash("error", "Invalid email or password");
+return redirect("/login", {
+  headers: { "Set-Cookie": await commitSession(session) },
+});
+
+// login loader, reading the flash
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getSession(request.headers.get("Cookie"));
+  const error = session.get("error");
+  return json(
+    { error },
+    { headers: { "Set-Cookie": await commitSession(session) } },
+  );
+}
+```
+
+The loader **must** call `commitSession` after reading the flash — that's
+what writes the cleared state back to the cookie. Skipping the commit
+either keeps the message forever (if not read) or never clears it
+(depending on which side of the bug you hit).
+
+The typed second parameter on `createCookieSessionStorage<Data, Flash>`
+distinguishes flash keys from regular session keys at the type level, but
+both forms write to the same cookie.
+
+## Database-Backed Sessions
+
+When cookies aren't enough (large payloads, server-side revocation), use
+`createSessionStorage`:
+
+```ts
+import { createCookie, createSessionStorage } from "@remix-run/node";
+
+const sessionCookie = createCookie("__session", {
+  httpOnly: true,
+  secure: process.env.NODE_ENV === "production",
+  sameSite: "lax",
+  secrets: [process.env.SESSION_SECRET!],
+});
+
+export const { getSession, commitSession, destroySession } = createSessionStorage({
+  cookie: sessionCookie,
+  async createData(data, expires) {
+    const id = await db.session.insert({ data, expires });
+    return id;
+  },
+  async readData(id) {
+    return db.session.find(id);
+  },
+  async updateData(id, data, expires) {
+    await db.session.update(id, { data, expires });
+  },
+  async deleteData(id) {
+    await db.session.delete(id);
+  },
+});
+```
+
+The cookie holds only the session id; payload lives in your database.
+Public API is identical to `createCookieSessionStorage`.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/SKILL.md
@@ -20,7 +20,7 @@ Targets TypeScript route modules importing from `@remix-run/*`. See [beagle-remi
 ## Review Checklist
 
 - [ ] Routes serving data export `headers` (even if the answer is `no-store`)
-- [ ] Child routes serving personalized data export their own `headers` (parent's are dropped silently)
+- [ ] Child routes serving personalized data export their own `headers` (otherwise they silently inherit the parent's policy)
 - [ ] `Cache-Control: public` is never set on auth'd or cookie-bearing responses
 - [ ] `Vary: Cookie` is set when cache decision depends on session
 - [ ] Server-only libs (`prisma`, `bcrypt`, `node:fs`, `jsonwebtoken`) live in `*.server.ts` or `app/.server/`
@@ -60,7 +60,7 @@ Apply these only when the specific context applies:
 | Issue | Flag ONLY IF |
 |-------|--------------|
 | Missing `headers` export | Route serves cacheable public content (not auth'd, not personalized, not intentionally `no-store`) |
-| Child route missing `headers` | An ancestor route in the matched chain DOES export `headers` (otherwise it's "no cache configured," not "silent drop") |
+| Child route missing `headers` | An ancestor exports `headers` AND its policy is broader than the child's cacheability (e.g., parent caches public + s-maxage, child serves personalized data) |
 | `Cache-Control: public` | Loader actually reads session / user state (or response carries `Set-Cookie`) |
 | `Vary: Cookie` missing | Loader branches response shape on a cookie (theme, locale, session) AND the cache is `public`/`s-maxage` |
 | `new Date()` / `Math.random()` / `Date.now()` | Call site is in render path — NOT in `useEffect`, event handler, `<ClientOnly>`, or post-hydration code |
@@ -82,7 +82,7 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 
 3. **Hydration-context check** — **Pass:** Before flagging `new Date()`, `Math.random()`, `Date.now()`, `crypto.randomUUID()`, or locale formatting, confirm the call site is in the **render path** of a component. Calls inside `useEffect`, `useLayoutEffect`, event handlers, callbacks passed to `setTimeout`/`requestAnimationFrame`, or inside `<ClientOnly>{() => ...}</ClientOnly>` are post-hydration and must not be flagged.
 
-4. **Parent/child headers chain check** — **Pass:** Before flagging "missing `headers` on a child" as silent-cache-loss, confirm a parent route in the matched chain actually exports `headers` (search the route file tree for `export const headers` or `export function headers`). If no ancestor exports headers, there is nothing for the child to "drop" — the issue is just "no caching configured," not "cache silently lost."
+4. **Parent/child headers chain check** — **Pass:** Before flagging "missing `headers` on a child" as silent cache inheritance, confirm an ancestor route in the matched chain actually exports `headers` (search the route file tree for `export const headers` or `export function headers`) AND that the inherited policy is wider than the child's cacheability profile. If no ancestor exports headers, the issue is just "no caching configured," not "child silently inherits parent's cache."
 
 5. **Server/client boundary check** — **Pass:** Before flagging a server-lib import as a leak, confirm the importing file is reachable from the **client graph** — i.e., it's a route module, a non-`.server` utility transitively imported by a route's default export, or a `.client.ts` file. Imports inside `loader`, `action`, `headers`, or other `.server.ts` modules are not leaks.
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: remix-v2-perf-ssr-review
+description: Reviews Remix v2 code for caching header misuse, missing server/client split, hydration mismatches (Date, Math.random, locale), prefetch hygiene, and asset bottlenecks. Use when reviewing routes that export headers, use .server.ts/.client.ts, or render dates/IDs in a Remix v2 codebase.
+---
+
+# Remix v2 Performance / SSR Code Review
+
+Targets TypeScript route modules importing from `@remix-run/*`. See [beagle-remix-v2:remix-v2-perf-ssr](../remix-v2-perf-ssr/SKILL.md) for canonical patterns.
+
+## Quick Reference
+
+| Issue Type | Reference |
+|------------|-----------|
+| Missing `headers` export, unsafe `public` cache, child-drops-parent headers, missing `Vary: Cookie`, `Set-Cookie` + `public` | [references/caching-headers.md](references/caching-headers.md) |
+| Server libs imported without `.server.ts`, `process.env.SECRET_*` leaks, `typeof window` substituted for `.server.ts` | [references/server-client-split.md](references/server-client-split.md) |
+| `new Date()` in render, `Math.random()` in keys, locale formatting without explicit locale, missing `useId()`, blanket `suppressHydrationWarning` | [references/hydration.md](references/hydration.md) |
+| `prefetch="render"` on every link, `defer` for fast data, missing `<Suspense>` around `<Await>`, prefetch to side-effect routes | [references/prefetch-streaming.md](references/prefetch-streaming.md) |
+| `dangerouslySetInnerHTML` with untrusted data, missing `loading="lazy"`, missing `links` preload, stylesheet injected in body | [references/assets.md](references/assets.md) |
+
+## Review Checklist
+
+- [ ] Routes serving data export `headers` (even if the answer is `no-store`)
+- [ ] Child routes serving personalized data export their own `headers` (parent's are dropped silently)
+- [ ] `Cache-Control: public` is never set on auth'd or cookie-bearing responses
+- [ ] `Vary: Cookie` is set when cache decision depends on session
+- [ ] Server-only libs (`prisma`, `bcrypt`, `node:fs`, `jsonwebtoken`) live in `*.server.ts` or `app/.server/`
+- [ ] Secret env (`process.env.STRIPE_SECRET_KEY`, etc.) is read only inside loaders/actions or `.server` modules
+- [ ] Client-exposed env is whitelisted into `window.ENV`, never raw `process.env`
+- [ ] `typeof window === "undefined"` is not used as a substitute for `.server.ts` (treeshaking is unreliable)
+- [ ] No `new Date()`, `Math.random()`, `Date.now()`, `crypto.randomUUID()` in JSX render path
+- [ ] Locale formatting (`toLocaleDateString`, `Intl.DateTimeFormat`) passes an explicit locale
+- [ ] Components generating IDs use `useId()`, not `Math.random()` or counters
+- [ ] `suppressHydrationWarning` is scoped to a single element with a code comment explaining why
+- [ ] `<Link prefetch="render">` is reserved for above-the-fold critical nav, not lists
+- [ ] `<PrefetchPageLinks>` does not target routes whose loaders have side effects (analytics, mutations)
+- [ ] Every `<Await>` is wrapped in `<Suspense>` and has an `errorElement`
+- [ ] `defer()` is used only for genuinely slow data (>~50ms); fast data is awaited
+- [ ] Below-the-fold images use `loading="lazy"` and have `width`/`height`
+- [ ] Critical fonts/CSS are preloaded via the `links` export, not injected in body
+
+## Valid Patterns (Do NOT Flag)
+
+These are correct Remix v2 usage and must not be reported as issues:
+
+- **Route without `headers` export when caching is intentionally off** — auth'd dashboards, account pages, and routes wrapped in a layout that already returns `no-store` may legitimately omit `headers`. Flag only if the route serves cacheable public content with no `headers`.
+- **`new Date()` inside `useEffect`** — runs after hydration on the client only; no SSR mismatch possible. Same for `Date.now()`, `Math.random()`, `crypto.randomUUID()` inside effects.
+- **`Math.random()` / `new Date()` inside event handlers** — handlers run after hydration. Only flag when the value is used during render.
+- **`suppressHydrationWarning` on a single `<time>` (or similar) element with a clear comment** — accepted narrow escape for known-divergent values like absolute timestamps formatted client-side. Flag only when applied at a parent that wraps a large subtree or with no explanation.
+- **`.client.ts` files for client-only libraries** — Stripe.js, map widgets, chart libs that read `window` belong in `*.client.ts` by convention; do not flag the file extension.
+- **`useId()` with extra characters appended** — `` `${id}-input` `` is the documented pattern for multi-element components; do not flag as "non-stable id."
+- **Raw ISO string rendered in SSR + reformatted in `useEffect`** — the canonical hydration-safe time pattern; flag only if the reformat happens in render.
+- **`headers` export returning `{}` or `no-store`** — explicit "do not cache" is a deliberate decision and should not be flagged as misuse.
+- **`<Link prefetch="intent">` on standard nav** — the recommended default; flag only when the loader has side effects.
+- **`loaderHeaders` forwarded to the document via `headers` export** — co-locating data and document policy is the documented pattern, not duplication.
+
+## Context-Sensitive Rules
+
+Apply these only when the specific context applies:
+
+| Issue | Flag ONLY IF |
+|-------|--------------|
+| Missing `headers` export | Route serves cacheable public content (not auth'd, not personalized, not intentionally `no-store`) |
+| Child route missing `headers` | An ancestor route in the matched chain DOES export `headers` (otherwise it's "no cache configured," not "silent drop") |
+| `Cache-Control: public` | Loader actually reads session / user state (or response carries `Set-Cookie`) |
+| `Vary: Cookie` missing | Loader branches response shape on a cookie (theme, locale, session) AND the cache is `public`/`s-maxage` |
+| `new Date()` / `Math.random()` / `Date.now()` | Call site is in render path — NOT in `useEffect`, event handler, `<ClientOnly>`, or post-hydration code |
+| Locale formatting without locale | Result is rendered into JSX (not used only inside an effect / handler) |
+| `<Link prefetch="render">` | Link is inside a list / `.map()` iterator (not above-the-fold critical nav) |
+| `<Link prefetch="intent">` to side-effect loader | Loader has observable side effects (analytics write, counter increment, log emit) AND doesn't branch on the `Purpose: prefetch` header |
+| Server lib import without `.server.ts` | Importing file is reachable from the client graph (route module, non-`.server` util reached from a component) |
+| `process.env.SECRET_*` reference | Reference is in a component body or in a non-`.server` module reached from the client graph |
+| Missing `loading="lazy"` on image | Image is rendered below the fold (not in `<header>`, hero section, or above any `<main>` content) |
+| Missing `width`/`height` on image | Project does NOT use a build-time image processor that injects dimensions |
+
+## Hard gates (before writing findings)
+
+Run these in order. **Do not draft user-facing findings until every gate passes** for the batch you are about to report.
+
+1. **Location evidence** — **Pass:** Each issue lists the repo path and either a line range or a short verbatim quote from the file you read (not memory or diff-only guesswork). Cache, hydration, and `.server` claims without a concrete file path are not reportable.
+
+2. **Exemption check** — **Pass:** For each issue, you can state in one line why it is *not* covered by [Valid Patterns (Do NOT Flag)](#valid-patterns-do-not-flag). In particular: confirm a missing `headers` export is not on an intentionally-uncacheable route, confirm `.client.ts` is not a legitimate client-only library, confirm `suppressHydrationWarning` is not scoped + commented.
+
+3. **Hydration-context check** — **Pass:** Before flagging `new Date()`, `Math.random()`, `Date.now()`, `crypto.randomUUID()`, or locale formatting, confirm the call site is in the **render path** of a component. Calls inside `useEffect`, `useLayoutEffect`, event handlers, callbacks passed to `setTimeout`/`requestAnimationFrame`, or inside `<ClientOnly>{() => ...}</ClientOnly>` are post-hydration and must not be flagged.
+
+4. **Parent/child headers chain check** — **Pass:** Before flagging "missing `headers` on a child" as silent-cache-loss, confirm a parent route in the matched chain actually exports `headers` (search the route file tree for `export const headers` or `export function headers`). If no ancestor exports headers, there is nothing for the child to "drop" — the issue is just "no caching configured," not "cache silently lost."
+
+5. **Server/client boundary check** — **Pass:** Before flagging a server-lib import as a leak, confirm the importing file is reachable from the **client graph** — i.e., it's a route module, a non-`.server` utility transitively imported by a route's default export, or a `.client.ts` file. Imports inside `loader`, `action`, `headers`, or other `.server.ts` modules are not leaks.
+
+6. **Protocol** — **Pass:** You completed the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
+
+## When to Load References
+
+- Reviewing route `headers` exports, `Cache-Control` strings, CDN policy → [references/caching-headers.md](references/caching-headers.md)
+- Reviewing `.server.ts` / `.client.ts` files, imports of `prisma`/`bcrypt`/`fs`, or `process.env` access → [references/server-client-split.md](references/server-client-split.md)
+- Reviewing any component that renders dates, IDs, locale-formatted values, or browser globals → [references/hydration.md](references/hydration.md)
+- Reviewing `<Link prefetch>`, `<PrefetchPageLinks>`, `defer`, `<Await>`, `<Suspense>`, or `<RemixServer abortDelay>` → [references/prefetch-streaming.md](references/prefetch-streaming.md)
+- Reviewing `<img>`, `<link>`, `dangerouslySetInnerHTML`, font/CSS loading, or `links` export → [references/assets.md](references/assets.md)
+
+## Review Questions
+
+1. Does every route that serves cacheable data declare a `Cache-Control` policy, even if "no cache"?
+2. Are personalized routes free of `public` caching, with `Vary: Cookie` where session influences the response?
+3. Do server libs (`prisma`, `bcrypt`, `fs`, secret env access) live in `*.server.ts` modules that the build will reject if leaked?
+4. Are public env vars whitelisted into `window.ENV` rather than spread from `process.env`?
+5. Are `new Date()` / `Math.random()` / locale formatting calls limited to effects, handlers, or `<ClientOnly>` — not render?
+6. Do components needing IDs use `useId()`?
+7. Are `<Link prefetch>` modes matched to context (`render` only above the fold, `intent` for nav, `viewport`/`intent` in lists)?
+8. Is `defer()` used only for genuinely slow data, with `<Await>` always paired with `<Suspense>` AND `errorElement`?
+9. Are images sized, lazy-loaded below the fold, and critical fonts/CSS preloaded via the `links` export?
+10. Is `dangerouslySetInnerHTML` used only with sanitized HTML or safely serialized JS?
+
+## Before Submitting Findings
+
+Complete [Hard gates](#hard-gates-before-writing-findings) (especially gate 3 — hydration-context check, and gate 5 — server/client boundary check), then report only issues that still pass the [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) pre-report checks. Finding format: `[FILE:LINE] ISSUE_TITLE` with a verbatim quote of the offending code and a one-line rationale tied to the specific Remix v2 contract being violated.
+
+## Additional Documentation
+
+- Reviewing `headers` exports, CDN cache policy, `Vary`, parent/child merge, `Set-Cookie` interactions → [references/caching-headers.md](references/caching-headers.md)
+- Reviewing `.server.ts` / `.client.ts` boundaries, `process.env` access, `window.ENV` pattern → [references/server-client-split.md](references/server-client-split.md)
+- Reviewing render-time `Date`/`Math.random`/locale issues, `useId`, `suppressHydrationWarning` scope → [references/hydration.md](references/hydration.md)
+- Reviewing `<Link prefetch>` modes, `<PrefetchPageLinks>` targets, `defer`/`<Await>`/`<Suspense>` structure → [references/prefetch-streaming.md](references/prefetch-streaming.md)
+- Reviewing `dangerouslySetInnerHTML`, image `loading`/`width`/`height`, font/CSS preload, stylesheet placement → [references/assets.md](references/assets.md)
+- Canonical patterns and decision gates → [beagle-remix-v2:remix-v2-perf-ssr](../remix-v2-perf-ssr/SKILL.md)

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/assets.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/assets.md
@@ -1,0 +1,219 @@
+# Assets, Images, Fonts & CSS Review
+
+Anti-patterns in `dangerouslySetInnerHTML`, image attributes, `links` preload, and stylesheet placement.
+
+## What to flag
+
+### 1. `dangerouslySetInnerHTML` with untrusted content
+
+The literal definition of an XSS sink. Even "trusted" data fails: `JSON.stringify` does **not** escape `</script>` or U+2028 / U+2029 line separators, so an object containing the literal substring `</script>` breaks out of the script context.
+
+**Bad (untrusted):**
+```tsx
+<div dangerouslySetInnerHTML={{ __html: post.body }} /> // user-authored content
+```
+
+**Bad (trusted but unsafe encoding):**
+```tsx
+<script
+  dangerouslySetInnerHTML={{
+    __html: `window.ENV = ${JSON.stringify(data.ENV)}`, // </script> in data breaks out
+  }}
+/>
+```
+
+**Good (sanitize untrusted HTML):**
+```tsx
+import sanitize from "isomorphic-dompurify";
+
+<div dangerouslySetInnerHTML={{ __html: sanitize(post.body) }} />
+```
+
+**Good (serialize JS safely):**
+```tsx
+import serialize from "serialize-javascript";
+
+<script
+  dangerouslySetInnerHTML={{
+    __html: `window.ENV = ${serialize(data.ENV, { isJSON: true })}`,
+  }}
+/>
+```
+
+**Report as:** `[FILE:LINE] UNSAFE_INNER_HTML` — `dangerouslySetInnerHTML` with untrusted input or `JSON.stringify` for script injection.
+
+### 2. Below-the-fold images missing `loading="lazy"`
+
+Without `loading="lazy"`, every `<img>` is fetched immediately on parse, bloating the critical path. For images below the fold (testimonials, footer logos, gallery items beyond initial viewport), this is wasted bandwidth and delayed LCP.
+
+**Bad:**
+```tsx
+<img src="/screenshots/feature.png" alt="Feature screenshot" />
+{/* in a section below the hero */}
+```
+
+**Good:**
+```tsx
+<img
+  src="/screenshots/feature.png"
+  alt="Feature screenshot"
+  loading="lazy"
+  decoding="async"
+  width="1200"
+  height="630"
+/>
+```
+
+**Report as:** `[FILE:LINE] MISSING_LOADING_LAZY` — `<img>` rendered below the fold without `loading="lazy"`.
+
+**Do not flag:**
+- Above-the-fold images (hero, logo in header) — they should NOT be lazy
+- Images marked `fetchpriority="high"`
+- `<img>` inside `<picture>` where the `<picture>` source set is intentionally eager
+
+### 3. Images missing `width` and `height` attributes
+
+Without explicit dimensions, the browser reserves zero space until the image loads, causing layout shift (CLS hit). Set the intrinsic dimensions (the file's actual width/height in pixels), even when the CSS resizes the image.
+
+**Bad:**
+```tsx
+<img src="/avatar.png" alt="" className="w-12 h-12 rounded-full" />
+```
+
+**Good:**
+```tsx
+<img
+  src="/avatar.png"
+  alt=""
+  width="48"
+  height="48"
+  className="w-12 h-12 rounded-full"
+/>
+```
+
+**Report as:** `[FILE:LINE] MISSING_IMG_DIMENSIONS` — `<img>` rendered without `width` and `height` attributes.
+
+**Do not flag:** images sized via CSS aspect-ratio with explicit `style={{ aspectRatio: "16/9" }}` and `width="100%"` — that's an alternative CLS-safe pattern.
+
+### 4. Critical fonts/CSS not preloaded via `links` export
+
+`<link rel="preload">` for the document font and the route-critical CSS gets them on the wire during the HTML parse phase, ahead of when the layout engine discovers them. Without preload, fonts arrive late and the page either FOUTs (flash of unstyled text) or FOITs (flash of invisible text).
+
+**Bad (no preload):**
+```tsx
+// app/root.tsx
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: appStyles },
+];
+```
+
+**Good:**
+```tsx
+import interVar from "~/fonts/InterVariable.woff2";
+import appStyles from "~/styles/app.css?url";
+
+export const links: LinksFunction = () => [
+  // Preload critical font BEFORE the stylesheet so the browser knows it's needed
+  {
+    rel: "preload",
+    as: "font",
+    type: "font/woff2",
+    href: interVar,
+    crossOrigin: "anonymous", // required for cross-origin / signed-URL fonts
+  },
+  { rel: "stylesheet", href: appStyles },
+];
+```
+
+**Report as:** `[FILE:LINE] MISSING_CRITICAL_PRELOAD` — root or route-critical font/CSS loaded without an accompanying `rel="preload"` link.
+
+**Do not flag:** preload omission on a route that uses only system fonts (no custom font file).
+
+### 5. `<link rel="stylesheet">` injected in body instead of `links` export
+
+Stylesheets injected inside the document body (typically via `<link>` rendered in a component) ship after parse begins, causing FOUC and re-layout. Remix routes a stylesheet through the `links` export so it lands in the document `<head>` during SSR.
+
+**Bad:**
+```tsx
+export default function Page() {
+  return (
+    <>
+      <link rel="stylesheet" href="/styles/page.css" />
+      <Content />
+    </>
+  );
+}
+```
+
+**Good:**
+```tsx
+import pageStyles from "~/styles/page.css?url";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: pageStyles },
+];
+
+export default function Page() {
+  return <Content />;
+}
+```
+
+**Report as:** `[FILE:LINE] STYLESHEET_IN_BODY` — `<link rel="stylesheet">` rendered inside a component body instead of via the `links` export.
+
+### 6. Missing `crossOrigin` on font preload
+
+Fonts are always fetched in CORS mode (per the Fetch spec). A preload without `crossOrigin="anonymous"` is treated as a separate request from the font's actual load — so the preload is wasted and the font is fetched twice.
+
+**Bad:**
+```tsx
+{ rel: "preload", as: "font", type: "font/woff2", href: interVar }
+```
+
+**Good:**
+```tsx
+{
+  rel: "preload",
+  as: "font",
+  type: "font/woff2",
+  href: interVar,
+  crossOrigin: "anonymous",
+}
+```
+
+**Report as:** `[FILE:LINE] FONT_PRELOAD_MISSING_CROSSORIGIN` — font preload without `crossOrigin="anonymous"`.
+
+### 7. Missing `decoding="async"` on large images
+
+`decoding="async"` lets the browser decode the image off the main thread, keeping the interaction-ready threshold (FID/INP) tighter on image-heavy pages.
+
+**Suggested pattern:**
+```tsx
+<img
+  src="/hero.jpg"
+  alt="Hero"
+  width="1600"
+  height="900"
+  decoding="async"
+  fetchPriority="high"
+/>
+```
+
+**Report as:** `[FILE:LINE] MISSING_DECODING_ASYNC` — large image (>500px on either axis) without `decoding="async"`.
+
+Not a high-severity issue; flag only on hero / gallery / above-the-fold images.
+
+## Verify before flagging
+
+- For "below-the-fold image without `loading=lazy`," confirm the image is actually below the fold. Hero images, logos, anything in the header should NOT be lazy. When unsure, check the JSX hierarchy and CSS — an image inside a `<header>` or above any `<main>` content is likely above the fold.
+- For "missing `width`/`height`," confirm the project does NOT use a build-time image processor (`unpic`, `remix-image`, `sharp`-via-loader) that injects dimensions. If the project has a wrapper component, defer to that.
+- For "missing critical preload," confirm the project uses a custom font file (look in `~/fonts/` or `app/fonts/`). System-font-only projects don't need font preload.
+- For "stylesheet in body," confirm the `<link>` is inside a default-exported component (rendered into body), not inside `<head>` via a `Layout` component or `<Meta>`/`<Links>` placeholders.
+- For "unsafe innerHTML," confirm the data flowing in is genuinely untrusted (user input, CMS body, markdown) or genuinely unsafe-encoded (`JSON.stringify` in a `<script>`). HTML built from compile-time constants is fine.
+
+## Verbatim quote requirements
+
+Findings on this surface require a verbatim quote of:
+- the `<img>` / `<link>` / `dangerouslySetInnerHTML` JSX being flagged, AND
+- the surrounding context (above/below fold, inside `links` export vs component body, trusted vs untrusted data source).
+
+A finding like "images here need lazy loading" with no JSX or fold context is not reportable.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/caching-headers.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/caching-headers.md
@@ -1,0 +1,213 @@
+# Caching Headers Review
+
+Anti-patterns in the `headers` route export and `Cache-Control` policy.
+
+## What to flag
+
+### 1. Route serves data but exports no `headers` function
+
+The default Remix response carries no `Cache-Control` — CDN cache is effectively off and every navigation hits origin. Make caching a deliberate decision per route, even when the answer is "do not cache."
+
+**Bad:**
+```tsx
+// app/routes/blog.$slug.tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  return json(await cms.getPost(params.slug));
+}
+// no headers export — silent uncached document
+```
+
+**Good:**
+```tsx
+export const headers: HeadersFunction = ({ loaderHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+});
+```
+
+**Report as:** `[FILE:LINE] MISSING_HEADERS_EXPORT` — route serves cacheable content but does not declare a cache policy.
+
+### 2. Child route omits `headers`, parent's policy silently drops
+
+In Remix v2 only the **deepest matched route's** `headers` function runs. If the child route does not export one, the parent's headers are NOT inherited — they are dropped. The route ends up with no cache headers at all, defeating the parent's policy without an error.
+
+**Bad:**
+```tsx
+// app/routes/_layout.tsx
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=300, s-maxage=3600",
+});
+
+// app/routes/_layout.dashboard.tsx
+export async function loader() { return json({ user: await getUser() }); }
+// no headers export — parent's Cache-Control is dropped, not inherited
+```
+
+**Good (define on leaf):**
+```tsx
+// app/routes/_layout.dashboard.tsx
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "private, no-store",
+});
+```
+
+**Report as:** `[FILE:LINE] CHILD_DROPS_PARENT_HEADERS` — child route lacks `headers` export; parent's `Cache-Control` is silently discarded.
+
+**Verify before flagging:** confirm a parent route in the matched chain actually exports `headers` (grep the route tree for `export const headers` or `export function headers`).
+
+### 3. `Cache-Control: public` on an auth'd or personalized response
+
+`public` allows shared caches (CDNs, corporate proxies) to store and serve the response to other users. On any response that varies by user — dashboards, account pages, anything reading session — this leaks one user's HTML to others.
+
+**Bad:**
+```tsx
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=300", // dashboard data!
+});
+```
+
+**Good:**
+```tsx
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "private, max-age=0, must-revalidate",
+});
+```
+
+**Report as:** `[FILE:LINE] PUBLIC_CACHE_ON_AUTH_ROUTE` — `public` directive on a route that reads session/user data.
+
+**Verify before flagging:** check that the loader actually reads session/user state (look for `getSession`, `requireUserId`, `authenticator.isAuthenticated`, cookie-keyed reads).
+
+### 4. Missing `Vary: Cookie` when caching cookie-dependent responses
+
+If the response body changes based on a cookie (e.g. theme preference, session, feature flag) and the CDN caches it, every visitor sees the first cached variant. `Vary: Cookie` tells the cache to key on the cookie header.
+
+**Bad:**
+```tsx
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=60, s-maxage=3600",
+  // no Vary — CDN caches one variant for everyone
+});
+```
+
+**Good:**
+```tsx
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=60, s-maxage=3600",
+  "Vary": "Cookie",
+});
+```
+
+**Report as:** `[FILE:LINE] MISSING_VARY_COOKIE` — cacheable response varies by cookie but `Vary: Cookie` is not set.
+
+Note: `Vary: Cookie` is coarse — most CDNs treat any cookie change as a cache miss. Prefer a narrow custom header (e.g. `Vary: X-Theme`) plus an edge function that normalizes the cookie to that header, if CDN cache hit rate matters.
+
+### 5. `Set-Cookie` returned alongside `Cache-Control: public`
+
+Most CDNs refuse to cache responses that carry a `Set-Cookie` header. Fastly and Cloudflare strip it silently; some CDNs cache the cookie itself, which is worse — every visitor gets the first user's session.
+
+**Bad:**
+```tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const session = await getSession(request);
+  session.set("lastVisit", Date.now());
+  return json(data, {
+    headers: {
+      "Cache-Control": "public, max-age=300",
+      "Set-Cookie": await commitSession(session),
+    },
+  });
+}
+```
+
+**Good:** keep cookie-setting in actions; loaders should be cookie-free:
+```tsx
+// loader: no cookie
+export async function loader({ request }: LoaderFunctionArgs) {
+  return json(await getData(request), {
+    headers: { "Cache-Control": "public, max-age=300" },
+  });
+}
+```
+
+**Report as:** `[FILE:LINE] SET_COOKIE_WITH_PUBLIC_CACHE` — loader sets a cookie and declares `public` caching; CDN will either drop the cache or leak the cookie.
+
+### 6. Document `headers` not forwarded from loader
+
+The `headers` export controls the **document** response. The loader's `Cache-Control` controls the **data** response (the `?_data=` JSON fetched on client navigation). These are two separate caches. If the `headers` export does not forward `loaderHeaders`, the document is uncached even when the loader said `public, s-maxage=3600`.
+
+**Bad:**
+```tsx
+export async function loader() {
+  return json(data, {
+    headers: { "Cache-Control": "public, s-maxage=3600" },
+  });
+}
+
+export const headers: HeadersFunction = () => ({
+  // forgot to forward — document is uncached
+});
+```
+
+**Good:**
+```tsx
+export const headers: HeadersFunction = ({ loaderHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+});
+```
+
+**Report as:** `[FILE:LINE] DOCUMENT_HEADERS_NOT_FORWARDED` — loader sets `Cache-Control` but document `headers` export does not forward it.
+
+### 7. Child route widens parent's cache policy
+
+When merging in a child, pick the **smaller** `max-age` / `s-maxage`. A child that widens the parent's policy can cause stale data to be served beyond what the parent expected.
+
+**Bad:**
+```tsx
+// parent: max-age=60
+// child:
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=3600", // wider than parent
+});
+```
+
+**Good:** take the minimum:
+```tsx
+export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
+  const loader = parseCacheControl(loaderHeaders.get("Cache-Control"));
+  const parent = parseCacheControl(parentHeaders.get("Cache-Control"));
+  const maxAge = Math.min(loader["max-age"] ?? 0, parent["max-age"] ?? 0);
+  return { "Cache-Control": `private, max-age=${maxAge}` };
+};
+```
+
+**Report as:** `[FILE:LINE] CHILD_WIDENS_PARENT_CACHE` — child route's `max-age` exceeds parent's.
+
+### 8. Missing `Save-Data` consideration on heavy responses
+
+Clients on metered connections send `Save-Data: on`. Responses that bundle large payloads (images, video poster frames, analytics scripts) should branch on this header to return lighter variants. Not strictly a bug; flag only on routes that ship measurably heavy payloads.
+
+**Suggested pattern:**
+```tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const saveData = request.headers.get("Save-Data") === "on";
+  const data = saveData ? await getLightVariant() : await getFullVariant();
+  return json(data, { headers: { "Vary": "Save-Data" } });
+}
+```
+
+**Report as:** `[FILE:LINE] MISSING_SAVE_DATA_BRANCH` — heavy response does not honor `Save-Data` hint.
+
+## Verify before flagging
+
+- For "missing `headers` export," confirm the route is not in a path explicitly marked uncacheable (auth area, admin area). Look for an enclosing layout that returns `no-store`.
+- For "child drops parent headers," walk the route file tree and confirm a parent actually exports `headers`. If none does, the issue is "no caching configured" — a softer finding.
+- For "`public` on auth'd route," confirm the loader reads session state. A route that happens to be under an auth layout but reads only public data may legitimately use `public`.
+- For "missing `Vary: Cookie`," confirm the response body branches on a cookie. If the loader is cookie-independent (or short-circuits to a redirect when unauth'd), `Vary: Cookie` is not required.
+- For "`Set-Cookie` + `public`," confirm both are set on the same response. A loader that conditionally sets the cookie only on first visit, with a redirect, is fine.
+
+## Verbatim quote requirements
+
+Findings on this surface require a verbatim quote of:
+- the `headers` export (or its absence — quote the route module's exports and note the omission), AND
+- the `Cache-Control` string (or `Set-Cookie`, `Vary`) being flagged.
+
+A finding like "this route is missing a `headers` export" with no path or quote is not reportable.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/caching-headers.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/caching-headers.md
@@ -26,9 +26,9 @@ export const headers: HeadersFunction = ({ loaderHeaders }) => ({
 
 **Report as:** `[FILE:LINE] MISSING_HEADERS_EXPORT` — route serves cacheable content but does not declare a cache policy.
 
-### 2. Child route omits `headers`, parent's policy silently drops
+### 2. Child route omits `headers`, silently inherits parent's cache policy
 
-In Remix v2 only the **deepest matched route's** `headers` function runs. If the child route does not export one, the parent's headers are NOT inherited — they are dropped. The route ends up with no cache headers at all, defeating the parent's policy without an error.
+In Remix v2 only the **deepest matched route's** `headers` function runs by default. If the leaf route does not export one, Remix walks UP to the nearest ancestor's `headers` and uses it. The bug is the opposite of "dropped": a personalized child without its own `headers` silently inherits the parent's aggressive cache policy, leaking per-user HTML at the CDN.
 
 **Bad:**
 ```tsx
@@ -39,7 +39,8 @@ export const headers: HeadersFunction = () => ({
 
 // app/routes/_layout.dashboard.tsx
 export async function loader() { return json({ user: await getUser() }); }
-// no headers export — parent's Cache-Control is dropped, not inherited
+// no headers export — Remix walks up to _layout.tsx and serves
+// personalized dashboard HTML with public, s-maxage=3600 at the CDN.
 ```
 
 **Good (define on leaf):**
@@ -50,9 +51,9 @@ export const headers: HeadersFunction = () => ({
 });
 ```
 
-**Report as:** `[FILE:LINE] CHILD_DROPS_PARENT_HEADERS` — child route lacks `headers` export; parent's `Cache-Control` is silently discarded.
+**Report as:** `[FILE:LINE] CHILD_INHERITS_AGGRESSIVE_PARENT_CACHE` — child route serves personalized data but has no `headers` export; falls back to parent's permissive policy.
 
-**Verify before flagging:** confirm a parent route in the matched chain actually exports `headers` (grep the route tree for `export const headers` or `export function headers`).
+**Verify before flagging:** confirm an ancestor exports `headers` AND the inherited policy is wider than the child's actual cacheability profile (e.g., parent returns `public, s-maxage=...` while the child reads session/user state).
 
 ### 3. `Cache-Control: public` on an auth'd or personalized response
 
@@ -98,7 +99,7 @@ export const headers: HeadersFunction = () => ({
 
 **Report as:** `[FILE:LINE] MISSING_VARY_COOKIE` — cacheable response varies by cookie but `Vary: Cookie` is not set.
 
-Note: `Vary: Cookie` is coarse — most CDNs treat any cookie change as a cache miss. Prefer a narrow custom header (e.g. `Vary: X-Theme`) plus an edge function that normalizes the cookie to that header, if CDN cache hit rate matters.
+Note: `Vary: Cookie` is coarse — most CDNs treat any cookie change as a cache miss. Behavior is CDN-specific: Cloudflare ignores `Vary: Cookie` by default unless Cache Rules are configured; Fastly honors it; Akamai treats it as a poor-quality directive.
 
 ### 5. `Set-Cookie` returned alongside `Cache-Control: public`
 
@@ -199,7 +200,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 ## Verify before flagging
 
 - For "missing `headers` export," confirm the route is not in a path explicitly marked uncacheable (auth area, admin area). Look for an enclosing layout that returns `no-store`.
-- For "child drops parent headers," walk the route file tree and confirm a parent actually exports `headers`. If none does, the issue is "no caching configured" — a softer finding.
+- For "child inherits aggressive parent cache," walk the route file tree and confirm an ancestor actually exports `headers` AND that the inherited policy is wider than the child's cacheability profile. If no ancestor exports headers, the issue is "no caching configured" — a softer finding.
 - For "`public` on auth'd route," confirm the loader reads session state. A route that happens to be under an auth layout but reads only public data may legitimately use `public`.
 - For "missing `Vary: Cookie`," confirm the response body branches on a cookie. If the loader is cookie-independent (or short-circuits to a redirect when unauth'd), `Vary: Cookie` is not required.
 - For "`Set-Cookie` + `public`," confirm both are set on the same response. A loader that conditionally sets the cookie only on first visit, with a redirect, is fine.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/hydration.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/hydration.md
@@ -1,0 +1,284 @@
+# Hydration Safety Review
+
+Anti-patterns that produce SSR/client divergence.
+
+## What to flag
+
+### 1. `new Date()` / `Date.now()` in render path
+
+Server and client compute different values microseconds apart — different HTML, hydration mismatch, React 18 logs a warning and re-renders the entire subtree on the client. Common offenders: rendering "last updated X ago," "current time," default-form values, copyright years (sometimes).
+
+**Bad:**
+```tsx
+export default function Page() {
+  return <p>Rendered at {new Date().toLocaleString()}</p>;
+}
+```
+
+**Bad (same problem, different shape):**
+```tsx
+const NOW = Date.now(); // module-level — evaluated at first import
+export default function Page() {
+  return <p>Now: {NOW}</p>;
+}
+```
+
+**Good (render a stable value, format client-side after hydration):**
+```tsx
+import { useEffect, useState } from "react";
+
+export default function Page() {
+  const iso = useLoaderData<typeof loader>().renderedAt;
+  const [pretty, setPretty] = useState<string | null>(null);
+  useEffect(() => setPretty(new Date(iso).toLocaleString()), [iso]);
+  return <p>Rendered at {pretty ?? iso}</p>;
+}
+```
+
+**Report as:** `[FILE:LINE] DATE_IN_RENDER` — `new Date()` / `Date.now()` evaluated in JSX render path.
+
+**Do not flag when the call site is:**
+- inside `useEffect` / `useLayoutEffect`
+- inside an event handler (`onClick`, `onChange`, etc.)
+- inside a `setTimeout`/`requestAnimationFrame` callback
+- inside `<ClientOnly>{() => ...}</ClientOnly>`
+- inside a render branch gated by `useHydrated()` returning `true`
+
+### 2. `Math.random()` / `crypto.randomUUID()` in render or as React keys
+
+Server picks one value, client picks another — different HTML, different keys, hydration mismatch and remount of subtree.
+
+**Bad:**
+```tsx
+export default function List({ items }: { items: string[] }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li key={Math.random()}>{item}</li> // different key every render
+      ))}
+    </ul>
+  );
+}
+```
+
+**Bad (same problem):**
+```tsx
+const id = `widget-${crypto.randomUUID()}`; // module-level random
+export function Widget() {
+  return <div id={id}>...</div>;
+}
+```
+
+**Good (stable identity from data, or `useId` for ID generation):**
+```tsx
+{items.map((item) => <li key={item.id}>{item.label}</li>)}
+```
+
+```tsx
+import { useId } from "react";
+export function Widget() {
+  const id = useId();
+  return <div id={id}>...</div>;
+}
+```
+
+**Report as:** `[FILE:LINE] RANDOM_IN_RENDER_OR_KEY` — `Math.random()` / `crypto.randomUUID()` used in render path or as a key.
+
+**Do not flag when:** the call is inside an effect, event handler, or `<ClientOnly>` body.
+
+### 3. Locale formatting without explicit locale
+
+`new Intl.DateTimeFormat()` and `date.toLocaleDateString()` without arguments use the runtime's default locale. The server's default locale (typically `en-US` from `ICU_DATA` or system) almost never matches a visitor's locale → divergent strings → hydration mismatch.
+
+**Bad:**
+```tsx
+<time>{new Date(iso).toLocaleDateString()}</time>           // implicit locale
+<time>{new Intl.DateTimeFormat().format(new Date(iso))}</time>
+<span>{n.toLocaleString()}</span>                            // implicit locale
+```
+
+**Good (explicit locale — pass via loader or hardcode if appropriate):**
+```tsx
+<time>{new Date(iso).toLocaleDateString("en-US")}</time>
+<time>{new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(iso))}</time>
+```
+
+**Better (render ISO on server, reformat in `useEffect` using the visitor's locale):**
+```tsx
+import { useEffect, useState } from "react";
+
+export function Date({ iso }: { iso: string }) {
+  const [formatted, setFormatted] = useState<string | null>(null);
+  useEffect(() => {
+    setFormatted(new Date(iso).toLocaleDateString());
+  }, [iso]);
+  return <time dateTime={iso}>{formatted ?? iso}</time>;
+}
+```
+
+**Report as:** `[FILE:LINE] LOCALE_FORMAT_WITHOUT_LOCALE` — `toLocaleString`/`toLocaleDateString`/`toLocaleTimeString`/`Intl.*` called without an explicit `locale` argument.
+
+**Do not flag when:** the call is inside `useEffect` / event handler / `<ClientOnly>`.
+
+### 4. Hand-rolled IDs in components that should use `useId()`
+
+Counters, timestamps, random IDs in render path all break SSR. React's `useId` returns a stable ID across server and client.
+
+**Bad:**
+```tsx
+let counter = 0;
+export function LabeledInput({ label }: { label: string }) {
+  const id = `input-${++counter}`; // increments per render; ordering differs SSR vs client
+  return (<><label htmlFor={id}>{label}</label><input id={id} /></>);
+}
+```
+
+**Bad:**
+```tsx
+export function LabeledInput({ label }: { label: string }) {
+  const id = `input-${Math.random()}`;
+  return (<><label htmlFor={id}>{label}</label><input id={id} /></>);
+}
+```
+
+**Good:**
+```tsx
+import { useId } from "react";
+export function LabeledInput({ label }: { label: string }) {
+  const id = useId();
+  return (<><label htmlFor={id}>{label}</label><input id={id} /></>);
+}
+```
+
+**Report as:** `[FILE:LINE] MISSING_USE_ID` — component generates ID from counter/random/timestamp instead of `useId()`.
+
+**Do not flag:** `` `${id}-input` ``-style append for multi-element components — that's the documented pattern.
+
+### 5. Blanket `suppressHydrationWarning` on a parent that wraps a large subtree
+
+`suppressHydrationWarning` silences React's mismatch warning for ONE element and its **immediate** text children. Applying it to a `<div>` or `<body>` that wraps a large subtree hides every bug under it, including critical ones (XSS, broken interactivity, leaked secrets). It's also misleading — the prop only suppresses the *warning*; the underlying mismatch still causes a client re-render.
+
+**Bad:**
+```tsx
+<body suppressHydrationWarning>
+  {/* everything below silenced */}
+</body>
+```
+
+**Bad:**
+```tsx
+<div suppressHydrationWarning>
+  <SomeComponent />
+  <AnotherComponent />
+</div>
+```
+
+**Good (narrow scope, comment why):**
+```tsx
+{/* suppress: server returns ISO, client reformats post-hydration */}
+<time dateTime={iso} suppressHydrationWarning>
+  {formatted}
+</time>
+```
+
+**Report as:** `[FILE:LINE] BLANKET_SUPPRESS_HYDRATION_WARNING` — `suppressHydrationWarning` applied to a wrapper element or without an explanatory comment.
+
+**Do not flag:** the prop on a single leaf element (`<time>`, `<span>`, `<input value>`) with a comment explaining why divergence is expected.
+
+### 6. `window.` / `document.` / `localStorage` / `navigator.` in render path
+
+These globals are undefined on the server. Reading them in render crashes SSR or — when wrapped in `typeof` guards — produces different output on server and client, causing mismatch.
+
+**Bad:**
+```tsx
+export default function Page() {
+  const width = window.innerWidth; // crashes on SSR
+  return <p>Width: {width}</p>;
+}
+```
+
+**Bad (guarded but still mismatched):**
+```tsx
+export default function Page() {
+  const dark = typeof window !== "undefined" && localStorage.getItem("theme") === "dark";
+  return <div className={dark ? "dark" : "light"}>...</div>; // SSR says "light", client says "dark"
+}
+```
+
+**Good (initialize state from a stable default; sync in `useEffect`):**
+```tsx
+import { useEffect, useState } from "react";
+
+export default function Page() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => setDark(localStorage.getItem("theme") === "dark"), []);
+  return <div className={dark ? "dark" : "light"}>...</div>;
+}
+```
+
+**Or:** wrap the component in `<ClientOnly>` if there's no acceptable SSR fallback.
+
+**Report as:** `[FILE:LINE] BROWSER_API_IN_RENDER` — `window.*`/`document.*`/`localStorage`/`navigator.*` read in render path.
+
+### 7. `typeof window` ternaries that produce different JSX
+
+A ternary on `typeof window` in render produces a different element tree on server vs client. This is the most common deliberate hydration mismatch — and it's always wrong; use `useHydrated` for the two-pass pattern.
+
+**Bad:**
+```tsx
+export function Widget() {
+  return typeof window !== "undefined"
+    ? <ClientWidget />
+    : <Skeleton />;
+}
+```
+
+**Good:**
+```tsx
+import { useHydrated } from "remix-utils/use-hydrated";
+
+export function Widget() {
+  const isHydrated = useHydrated();
+  return isHydrated ? <ClientWidget /> : <Skeleton />;
+}
+```
+
+`useHydrated` is `false` on SSR **and** the first client render, then flips to `true` — the two-pass keeps HTML matched.
+
+**Report as:** `[FILE:LINE] TYPEOF_WINDOW_TERNARY` — render returns different JSX based on `typeof window`.
+
+### 8. Render-time `Date()` for the year (the "current year" footer)
+
+This is the most-shipped hydration bug. `new Date().getFullYear()` in a footer renders one year on server, possibly another on client during a year boundary, but more importantly tools and linters often miss it.
+
+**Acceptable (build-time):**
+```tsx
+const YEAR = 2026; // hardcoded or injected via build env
+<p>© {YEAR} Company</p>
+```
+
+**Acceptable (loader):**
+```tsx
+export async function loader() {
+  return json({ year: new Date().getFullYear() });
+}
+// component reads from useLoaderData
+```
+
+**Report as:** `[FILE:LINE] DATE_GETFULLYEAR_IN_RENDER` — `new Date().getFullYear()` in JSX (a special case of `DATE_IN_RENDER`, but distinct enough to call out).
+
+## Verify before flagging
+
+- **Confirm the call site is in render.** Walk up from the offending line. If the nearest enclosing function is a `useEffect`/`useLayoutEffect` callback, an event handler (`onClick`, `onChange`, `onSubmit`, etc.), a `setTimeout`/`setInterval`/`requestAnimationFrame` callback, or a `<ClientOnly>{() => ...}</ClientOnly>` child function — do not flag.
+- For locale formatting, confirm no `locale` arg is passed. `toLocaleDateString("en-US")` is fine; `toLocaleDateString()` is the bug.
+- For `suppressHydrationWarning`, confirm it's NOT on a single leaf element with a code comment. If it is, the narrow escape is acceptable.
+- For browser-API reads, confirm the read is in render. `window.scrollTo()` in `useEffect` is fine.
+- For `useId` issues, confirm the component generates IDs that need to match between SSR and CSR (label-for, aria-controls, aria-labelledby). A `data-test-id` that doesn't need to match is not the same thing.
+
+## Verbatim quote requirements
+
+Findings on this surface require a verbatim quote of:
+- the offending expression (e.g. `new Date().toLocaleString()`), AND
+- the enclosing function signature (so the reviewer can verify it's render, not effect/handler).
+
+A finding like "this component has hydration issues" with no expression or call site is not reportable.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/prefetch-streaming.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/prefetch-streaming.md
@@ -1,0 +1,214 @@
+# Prefetch & Streaming Review
+
+Anti-patterns in `<Link prefetch>`, `<PrefetchPageLinks>`, `defer()`, `<Await>`, and `<Suspense>`.
+
+## What to flag
+
+### 1. `<Link prefetch="render">` on every link in a long list
+
+`prefetch="render"` fires `<link rel="prefetch">` tags immediately on mount — one data request per link, plus JS and CSS for each target route. On a 200-row table this is 200 simultaneous prefetches: network thrash, wasted bandwidth, possible rate-limit hits.
+
+**Bad:**
+```tsx
+{rows.map((row) => (
+  <Link key={row.id} to={`/products/${row.id}`} prefetch="render">
+    {row.name}
+  </Link>
+))}
+```
+
+**Good:** use `intent` (fires on hover) or `viewport` (fires when scrolled in):
+```tsx
+{rows.map((row) => (
+  <Link key={row.id} to={`/products/${row.id}`} prefetch="intent">
+    {row.name}
+  </Link>
+))}
+```
+
+**Report as:** `[FILE:LINE] PREFETCH_RENDER_ON_LIST` — `prefetch="render"` applied to a link rendered inside a list / `.map()`.
+
+### 2. `<Link prefetch="intent">` on a link whose loader has side effects
+
+Hover-prefetch fires the target route's loader. If the loader logs an analytics event, increments a counter, or has any side effect, hovering over the link inflates those metrics — and may even trigger work that should only happen on actual navigation.
+
+**Bad:**
+```tsx
+// app/routes/article.$id.tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  await analytics.trackView(params.id); // side effect — fires on hover-prefetch
+  return json(await getArticle(params.id));
+}
+
+// somewhere else:
+<Link to={`/article/${id}`} prefetch="intent">...</Link>
+```
+
+**Good options:**
+- Move the side effect to an `action` triggered by a beacon
+- Detect `Purpose: prefetch` in the loader and skip the side effect:
+  ```tsx
+  export async function loader({ request, params }: LoaderFunctionArgs) {
+    const purpose = request.headers.get("Purpose")
+      ?? request.headers.get("Sec-Purpose")
+      ?? request.headers.get("X-Purpose");
+    if (purpose !== "prefetch") await analytics.trackView(params.id);
+    return json(await getArticle(params.id));
+  }
+  ```
+- Set `prefetch="none"` on the link
+
+**Report as:** `[FILE:LINE] PREFETCH_INTENT_TO_SIDE_EFFECT_LOADER` — link with `prefetch="intent"`/`"render"`/`"viewport"` points to a route whose loader has side effects.
+
+### 3. `<PrefetchPageLinks>` to a mutation-triggering route
+
+`<PrefetchPageLinks>` programmatically prefetches data, JS, and CSS for a target route. If that route's loader has any side effect (or worse, if it actually triggers a mutation via redirect / cookie set), the prefetch fires the side effect on render — possibly N times if the component remounts.
+
+**Bad:**
+```tsx
+<PrefetchPageLinks page="/api/track/view" /> // POST-like loader semantics
+```
+
+**Bad:**
+```tsx
+<PrefetchPageLinks page="/logout" /> // loader signs out, sets cookie
+```
+
+**Good:** reserve `<PrefetchPageLinks>` for cacheable read-only routes that the user is highly likely to navigate to next.
+
+**Report as:** `[FILE:LINE] PREFETCH_PAGE_LINKS_TO_SIDE_EFFECT_ROUTE` — `<PrefetchPageLinks>` targets a route with side-effecting loader.
+
+### 4. `defer()` for data that resolves in under ~50ms
+
+Streaming adds protocol overhead: `<script>` tags appended to the HTML stream, an extra render pass for the suspense boundary, a brief flash of the skeleton. For data from in-memory cache or a fast local DB, this is net-negative — TTI worsens.
+
+**Bad:**
+```tsx
+export async function loader() {
+  const cached = inMemoryCache.get("hot-data"); // <1ms
+  return defer({ data: Promise.resolve(cached) });
+}
+```
+
+**Good:** `await` fast data:
+```tsx
+export async function loader() {
+  const data = inMemoryCache.get("hot-data");
+  return json({ data });
+}
+```
+
+**Report as:** `[FILE:LINE] DEFER_ON_FAST_DATA` — `defer()` wraps a promise that resolves synchronously / from in-memory cache / from a sub-50ms call.
+
+**Verify before flagging:** the data has to actually be fast. A `defer` on a cross-region DB call is correct. Look for `await` chains, network requests, or external API calls before flagging this — and prefer a softer "consider awaiting" note when unsure.
+
+### 5. `<Await>` without an enclosing `<Suspense>`
+
+`<Await>` requires a `<Suspense>` boundary to render its fallback. Without one, the throw bubbles up to the route's `ErrorBoundary` (which is not the streaming behavior anyone wants) or, in some configurations, crashes the entire route on the server before streaming begins.
+
+**Bad:**
+```tsx
+<Await resolve={reviews} errorElement={<ReviewsError />}>
+  {(r) => <ReviewList reviews={r} />}
+</Await>
+```
+
+**Good:**
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews} errorElement={<ReviewsError />}>
+    {(r) => <ReviewList reviews={r} />}
+  </Await>
+</Suspense>
+```
+
+**Report as:** `[FILE:LINE] AWAIT_WITHOUT_SUSPENSE` — `<Await>` rendered without an enclosing `<Suspense>`.
+
+### 6. `<Await>` without `errorElement`
+
+A rejected deferred promise inside `<Await>` without `errorElement` bubbles to the route's `ErrorBoundary` — tearing down the entire route, including the parts that already rendered successfully. That defeats the streaming benefit (graceful degradation of slow secondary data).
+
+**Bad:**
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews}>
+    {(r) => <ReviewList reviews={r} />}
+  </Await>
+</Suspense>
+```
+
+**Good:**
+```tsx
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews} errorElement={<ReviewsError />}>
+    {(r) => <ReviewList reviews={r} />}
+  </Await>
+</Suspense>
+```
+
+**Report as:** `[FILE:LINE] AWAIT_WITHOUT_ERROR_ELEMENT` — `<Await>` has no `errorElement` prop; rejection tears down the entire route.
+
+### 7. `defer()` where the promise is created AFTER an `await`
+
+The point of `defer` is that the loader returns before slow data resolves. If the slow promise is created after an `await`, the loader still blocks on the prior `await` — streaming gains nothing.
+
+**Bad:**
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = await db.getProduct(params.id);
+  const reviews = await db.getReviews(params.id); // awaited!
+  return defer({ product, reviews });             // not actually deferred
+}
+```
+
+**Bad (subtle — promise created after await):**
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = await db.getProduct(params.id);
+  const reviews = db.getReviews(params.id); // created AFTER await — sequential
+  return defer({ product, reviews });
+}
+```
+
+**Good (kick off slow promise before any await):**
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const reviewsPromise = db.getReviews(params.id); // BEFORE any await
+  const product = await db.getProduct(params.id);
+  return defer({ product, reviews: reviewsPromise });
+}
+```
+
+**Report as:** `[FILE:LINE] DEFER_PROMISE_AFTER_AWAIT` — deferred promise created after an `await`; loader still blocks.
+
+### 8. `<RemixServer abortDelay>` set to a very high value
+
+`abortDelay` (default 5000ms) caps how long the server holds the connection open waiting for deferred promises before aborting and sending what's resolved. Setting it to 30s "to be safe" holds slow upstream calls open, exhausts server worker pools, and pushes latency p99 sky-high.
+
+**Bad:**
+```tsx
+<RemixServer context={remixContext} url={request.url} abortDelay={30_000} />
+```
+
+**Good:** keep near the default; set per-call timeouts inside loaders instead:
+```tsx
+<RemixServer context={remixContext} url={request.url} />
+```
+
+**Report as:** `[FILE:LINE] HIGH_ABORT_DELAY` — `abortDelay` >10s on `<RemixServer>`.
+
+## Verify before flagging
+
+- For "prefetch render on list," confirm the link is inside an iterator (`.map()`, a loop). A single prefetch="render" on a high-priority above-the-fold nav link is fine.
+- For "prefetch to side-effect loader," confirm the loader actually has side effects. Read the loader body. A pure read loader with `prefetch="intent"` is the correct pattern.
+- For "defer on fast data," confirm the deferred promise resolves synchronously / from cache / from a sub-50ms call. When unsure, prefer a softer "consider awaiting" note.
+- For "Await without Suspense / errorElement," confirm both wrappers are missing from the same `<Await>` instance, not from a different one in the same file.
+- For "defer after await," confirm the promise is genuinely created after the await — not just used in JSX after an await.
+
+## Verbatim quote requirements
+
+Findings on this surface require a verbatim quote of:
+- the `<Link prefetch="...">` / `<PrefetchPageLinks page="...">` / `defer({ ... })` / `<Await ...>` call being flagged, AND
+- for loader-side-effect claims: the loader body that contains the side effect.
+
+A finding like "prefetch is misconfigured here" with no JSX or loader quote is not reportable.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/server-client-split.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr-review/references/server-client-split.md
@@ -1,0 +1,220 @@
+# Server/Client Split Review
+
+Anti-patterns in `.server.ts` / `.client.ts` boundaries, env var access, and module hygiene.
+
+## What to flag
+
+### 1. Server library imported in a route file without `.server.ts`
+
+Remix's compiler strips `loader`, `action`, and `headers` from the client bundle along with the dependencies used **inside them** — but only if those dependencies have no module side effects. A top-level `new PrismaClient()`, an `initializeApp()` call, or even a `console.log` defeats tree-shaking. The dep leaks into the client bundle, breaks the build at runtime, or worse, ships secrets.
+
+**Bad:**
+```tsx
+// app/lib/db.ts  -- no .server suffix
+import { PrismaClient } from "@prisma/client";
+export const prisma = new PrismaClient(); // top-level side effect
+
+// app/routes/users.tsx
+import { prisma } from "~/lib/db"; // leaks into client graph
+```
+
+**Good:**
+```tsx
+// app/lib/db.server.ts  -- never reaches client bundle
+import { PrismaClient } from "@prisma/client";
+export const prisma = new PrismaClient();
+
+// app/routes/users.tsx
+import { prisma } from "~/lib/db.server";
+```
+
+**Report as:** `[FILE:LINE] SERVER_LIB_WITHOUT_SERVER_SUFFIX` — `<lib>` imported from a non-`.server` module reachable from the client graph.
+
+**Common server-only imports to scan for:** `@prisma/client`, `prisma`, `bcrypt`, `bcryptjs`, `argon2`, `jsonwebtoken`, `node:fs`, `node:path`, `node:crypto`, `fs`, `path`, `redis`, `ioredis`, `mongodb`, `pg`, `mysql2`, `aws-sdk`, `@aws-sdk/*`, `nodemailer`, `stripe` (server SDK — `@stripe/stripe-js` is the client version).
+
+### 2. Secret env vars referenced in a component body or non-`.server` utility
+
+`process.env` does not exist in the browser. References from a component body either crash at runtime, get inlined as `undefined`, or — worst case — get inlined as the actual secret string by some bundlers / Vite plugins.
+
+**Bad:**
+```tsx
+// app/components/Checkout.tsx
+export function Checkout() {
+  const key = process.env.STRIPE_SECRET_KEY; // leaks to client
+  return <CheckoutForm secretKey={key} />;
+}
+```
+
+**Bad (transitive leak):**
+```tsx
+// app/lib/stripe.ts  -- no .server suffix
+export const stripeKey = process.env.STRIPE_SECRET_KEY;
+```
+
+**Good:** read secrets only inside loaders/actions, or inside a `.server.ts` module:
+```tsx
+// app/lib/stripe.server.ts
+import Stripe from "stripe";
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+```
+
+**Report as:** `[FILE:LINE] SECRET_ENV_LEAK` — `process.env.<NAME>` read from a non-`.server` module reachable from the client graph.
+
+**Scan for env names containing:** `SECRET`, `PRIVATE_KEY`, `TOKEN`, `PASSWORD`, `DATABASE_URL`, `API_KEY` (any provider), `JWT_*`, `WEBHOOK_SECRET`, `SESSION_SECRET`.
+
+### 3. Raw `process.env` returned from root loader to client
+
+Returning `process.env` (or even a large subset) from the root loader exposes every environment variable to every visitor as part of `window.ENV`. Common variant: spreading `...process.env` into a returned object.
+
+**Bad:**
+```tsx
+// app/root.tsx
+export async function loader() {
+  return json({ ENV: process.env }); // every secret to every browser
+}
+```
+
+**Also bad:**
+```tsx
+return json({ ENV: { ...process.env, EXTRA: "x" } });
+```
+
+**Good:** explicit whitelist of public keys only:
+```tsx
+return json({
+  ENV: {
+    STRIPE_PUBLIC_KEY: process.env.STRIPE_PUBLIC_KEY,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    PUBLIC_API_URL: process.env.PUBLIC_API_URL,
+  },
+});
+```
+
+**Report as:** `[FILE:LINE] PROCESS_ENV_RETURNED_FROM_LOADER` — entire `process.env` (or a spread of it) returned from a loader.
+
+### 4. `typeof window === "undefined"` used as a substitute for `.server.ts`
+
+Treeshaking is unreliable. A common pattern is to gate server code with `typeof window === "undefined"` at module top level — but the dead branch still pulls server deps into the client graph because the static `import` is hoisted regardless. The bundle either grows by megabytes, breaks at build time, or surfaces secrets.
+
+**Bad:**
+```tsx
+// app/lib/logger.ts
+import { createLogger } from "pino"; // hoisted import — always in client bundle
+const logger = typeof window === "undefined"
+  ? createLogger({ level: "info" })
+  : { info: console.log, error: console.error };
+export { logger };
+```
+
+**Good (split files):**
+```tsx
+// app/lib/logger.server.ts
+import { createLogger } from "pino";
+export const logger = createLogger({ level: "info" });
+
+// app/lib/logger.client.ts
+export const logger = { info: console.log, error: console.error };
+
+// Import the right one from a route based on where it runs:
+//   loader: import { logger } from "~/lib/logger.server";
+//   component effect: import { logger } from "~/lib/logger.client";
+```
+
+**Good (function-body branch — acceptable for isomorphic helpers that don't import server libs):**
+```tsx
+export function getEnvLabel(): "server" | "client" {
+  return typeof window === "undefined" ? "server" : "client";
+}
+```
+
+**Report as:** `[FILE:LINE] TYPEOF_WINDOW_INSTEAD_OF_SERVER_SUFFIX` — module top-level branches on `typeof window` but still imports server-only deps.
+
+### 5. Higher-order function wrapping a loader
+
+`export const loader = withAuth(async (args) => { ... })` evaluates `withAuth` at module load — a module-level side effect that pins server-only deps into the client graph. The compiler's `loader` stripping can't see through the wrapper.
+
+**Bad:**
+```tsx
+import { withAuth } from "~/lib/auth"; // wrapper imports prisma at top
+export const loader = withAuth(async ({ params }) => { /* ... */ });
+```
+
+**Good (call the helper inside the loader body):**
+```tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { requireAuth } from "~/lib/auth.server";
+
+export async function loader(args: LoaderFunctionArgs) {
+  await requireAuth(args);
+  // ...
+}
+```
+
+**Report as:** `[FILE:LINE] HOF_WRAPPING_LOADER` — `loader` (or `action`) is wrapped in a higher-order function; helpers should be called inside the body.
+
+### 6. `.client.ts` module imported into a server-only path
+
+`.client.ts` modules are stripped from the server bundle — their exports are `undefined` during SSR. If a loader, action, or `.server` module imports from `.client.ts`, calls into it will throw `Cannot read properties of undefined`.
+
+**Bad:**
+```tsx
+// app/lib/analytics.client.ts
+export function track(event: string) { window.posthog.capture(event); }
+
+// app/routes/checkout.tsx
+import { track } from "~/lib/analytics.client";
+export async function loader() {
+  track("checkout_loaded"); // undefined.call during SSR — crash
+  return null;
+}
+```
+
+**Good:** call `.client` code only inside `useEffect`/event handlers:
+```tsx
+import { useEffect } from "react";
+import { track } from "~/lib/analytics.client";
+
+export default function Checkout() {
+  useEffect(() => track("checkout_loaded"), []);
+  return <CheckoutForm />;
+}
+```
+
+**Report as:** `[FILE:LINE] CLIENT_MODULE_USED_ON_SERVER` — `.client.ts` import called from loader/action/`.server` module.
+
+### 7. Secret env in a `links` or `meta` export
+
+`links` and `meta` exports run on both server and client. References to `process.env.SECRET_*` inside them will be inlined into the client document.
+
+**Bad:**
+```tsx
+export const meta: MetaFunction = () => [
+  { name: "x-admin-token", content: process.env.ADMIN_TOKEN }, // leaked
+];
+```
+
+**Good:** never read secrets in `links`/`meta`. If a route's meta legitimately depends on server-side config, return the value from the loader and read it via `useLoaderData()` in the component (not in `meta`, which receives only loader data anyway):
+```tsx
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  { name: "x-feature", content: data?.featureFlag ?? "" },
+];
+```
+
+**Report as:** `[FILE:LINE] SECRET_ENV_IN_META_OR_LINKS` — secret env value referenced in `meta` or `links` export.
+
+## Verify before flagging
+
+- For "server lib without `.server.ts`," confirm the importing file is reachable from the client graph (route module, non-`.server` utility transitively imported by a component). Imports from inside another `.server.ts` are fine.
+- For "secret env leak," confirm the env name actually looks secret. `STRIPE_PUBLIC_KEY`, `POSTHOG_KEY`, `PUBLIC_API_URL` are conventionally public. `STRIPE_SECRET_KEY`, `JWT_SECRET`, `DATABASE_URL` are conventionally private. If the project uses a different convention (`NEXT_PUBLIC_*`, `PUBLIC_*`, `VITE_*`), note that.
+- For "`typeof window` substitute," confirm the file actually imports server deps. A pure isomorphic helper that branches on `typeof window` is fine — the issue is the static import at the top.
+- For "HOF wrapping loader," confirm the wrapper actually imports server deps. A trivial type-only wrapper is fine.
+- For "client module used on server," confirm the call site is in loader/action/`.server` code, not in `useEffect`/handler/`<ClientOnly>`.
+
+## Verbatim quote requirements
+
+Findings on this surface require a verbatim quote of:
+- the `import` statement being flagged, OR
+- the `process.env.<NAME>` reference being flagged, AND
+- the surrounding context (file path + whether the call site is loader/action/component body/effect/handler).
+
+A finding like "this file leaks prisma to the client" with no import path or call site is not reportable.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/SKILL.md
@@ -89,7 +89,7 @@ See [references/headers-caching.md](references/headers-caching.md).
 
 ## Server/Client Split
 
-The compiler strips `loader`, `action`, and `headers` exports from client bundles along with the dependencies used **inside them** — but only if those dependencies have no module side effects. A top-level `new PrismaClient()`, a `console.log`, an `initializeApp` call all defeat tree-shaking. Rule: any module that imports `node:fs`, `prisma`, `bcrypt`, `jsonwebtoken`, or reads `process.env` should be named `*.server.ts` (or live under `app/.server/`). Build fails loud if it reaches the client graph — silent leaks are eliminated.
+The compiler strips `loader`, `action`, and `headers` exports from client bundles along with the dependencies used **inside them** — but only if those dependencies have no module side effects. A top-level `new PrismaClient()`, a `console.log`, an `initializeApp` call all defeat tree-shaking. Rule: any module that imports `node:fs`, `prisma`, `bcrypt`, `jsonwebtoken`, or reads `process.env` should be named `*.server.ts` (or live under `app/.server/` — directory form requires the Remix Vite plugin; Classic Compiler supports only the filename suffix). Build fails loud if it reaches the client graph — silent leaks are eliminated.
 
 Public env vars reach the browser via a root-loader `window.ENV` pattern. Never return raw `process.env` from a loader. See [references/server-client-split.md](references/server-client-split.md).
 
@@ -97,7 +97,7 @@ Public env vars reach the browser via a root-loader `window.ENV` pattern. Never 
 
 `useHydrated()` returns `false` during SSR and on the very first client render, then flips to `true` on the next render — that two-pass behavior is what keeps HTML matched. For components that should never SSR (maps, charts that read `window`), wrap in `<ClientOnly fallback={...}>`. For SSR-safe IDs use React's `useId()`, never `Math.random()` or `crypto.randomUUID()` in render.
 
-The hydration-mismatch grep list: `new Date(`, `Math.random(`, `crypto.randomUUID(`, `Date.now(`, `window.`, `document.`, `localStorage`, `navigator.`, `Intl.DateTimeFormat()` without an explicit locale, `process.env.` in component bodies, `typeof window` ternaries that produce different JSX, third-party scripts that mutate the DOM, browser extensions injecting nodes into `<body>`. See [references/hydration.md](references/hydration.md).
+The hydration-mismatch grep list: `new Date(`, `Math.random(`, `crypto.randomUUID(`, `Date.now(`, `window.`, `document.`, `localStorage`, `sessionStorage`, `navigator.`, `Intl.DateTimeFormat()` without an explicit locale, `Intl.NumberFormat`, `.toLocaleDateString`, `.toLocaleTimeString`, `.toLocaleString`, `process.env.` in component bodies, `typeof window` ternaries that produce different JSX, third-party scripts that mutate the DOM, browser extensions injecting nodes into `<body>`. See [references/hydration.md](references/hydration.md).
 
 ## Prefetching
 
@@ -125,7 +125,7 @@ Answer **in order**. **Pass** means the condition is true; pick the API on the s
 ### `.server.ts` vs runtime `typeof window` check
 
 1. **Does the module import `node:*`, `prisma`, `bcrypt`, `jsonwebtoken`, `fs`, `path`, or read `process.env` at the top level**?
-   - **Pass →** Name the file `*.server.ts` (or place under `app/.server/`). Build fails loud if leaked to client. **Stop.**
+   - **Pass →** Name the file `*.server.ts` (or place under `app/.server/` — directory form requires the Remix Vite plugin; Classic Compiler supports only the filename suffix). Build fails loud if leaked to client. **Stop.**
    - **Fail →** Step 2.
 2. **Is the module called only inside `loader`/`action`/`headers`** with no top-level side effects?
    - **Pass →** `.server.ts` is still preferred for clarity; tree-shaking may work but is unreliable. **Stop.**
@@ -150,7 +150,7 @@ Answer **in order**. **Pass** means the condition is true; pick the API on the s
 
 - **Headers and caching**: see [references/headers-caching.md](references/headers-caching.md) for `HeadersFunction` signature, `loaderHeaders`/`parentHeaders`/`actionHeaders`/`errorHeaders`, SWR patterns, and parent/child merge semantics.
 - **Streaming**: see [references/streaming.md](references/streaming.md) for `defer()`, `<Await>`, `<Suspense>`, `abortDelay`, error handling, CSP interactions.
-- **Server/client split**: see [references/server-client-split.md](references/server-client-split.md) for `.server.*` / `.client.*`, env var handling, the `window.ENV` pattern.
+- **Server/client split**: see [references/server-client-split.md](references/server-client-split.md) for `.server.*` / `.client.*` (directory form requires the Remix Vite plugin; Classic Compiler supports only the filename suffix), env var handling, the `window.ENV` pattern.
 - **Hydration**: see [references/hydration.md](references/hydration.md) for `useHydrated`, `<ClientOnly>`, `useId`, mismatch grep list.
 - **Prefetch**: see [references/prefetch.md](references/prefetch.md) for `<Link prefetch>` modes, `<PrefetchPageLinks>`, the `Purpose: prefetch` header trick.
 - **Preload links**: see [references/links-preload.md](references/links-preload.md) for `links` export, font/CSS preload, image guidance.
@@ -170,5 +170,5 @@ Answer **in order**. **Pass** means the condition is true; pick the API on the s
 | Branch after hydration | `useHydrated()` | `remix-utils/use-hydrated` |
 | Prefetch on hover | `<Link prefetch="intent">` | `@remix-run/react` |
 | Prefetch on render (above-fold) | `<Link prefetch="render">` | `@remix-run/react` |
-| Programmatic prefetch | `<PrefetchPageLinks page="/abs">` | `@remix-run/react` |
+| Programmatic prefetch | `<PrefetchPageLinks page="/absolute/path">` | `@remix-run/react` |
 | Preload font/CSS | `links` export | route module |

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: remix-v2-perf-ssr
+description: Remix v2 performance, streaming, caching, and server/client boundaries. Use when configuring HTTP caching, server-only modules, hydration safety, or prefetch. Triggers on headers export, Cache-Control, PrefetchPageLinks, Link prefetch, .server.ts, .client.ts, useHydrated, ClientOnly, window.ENV, links preload, useId.
+---
+
+# Remix v2 Performance, Streaming, Caching, Server/Client Split
+
+Remix v2 has no built-in image optimizer and no opaque framework cache — it pushes everything to the standard HTTP layer. The performance surface is four pillars: streaming (`defer`/`<Await>`), HTTP caching (`headers` export), prefetching (`<Link prefetch>` and `<PrefetchPageLinks>`), and a hard server/client split (`.server.*` / `.client.*` file conventions).
+
+## Quick Reference
+
+**`headers` export with SWR (forward loader headers to the document)**:
+```tsx
+import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const post = await cms.getPost(params.slug);
+  return json(post, {
+    headers: {
+      "Cache-Control":
+        "public, max-age=60, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+});
+```
+
+**`.server.ts` for server-only modules** — build fails loud if the file leaks into the client graph:
+```tsx
+// app/lib/db.server.ts — never bundled into the client
+import { PrismaClient } from "@prisma/client";
+export const db = new PrismaClient();
+```
+
+**`defer()` for slow secondary data**:
+```tsx
+import { defer } from "@remix-run/node";
+import { Await, useLoaderData } from "@remix-run/react";
+import { Suspense } from "react";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const product = await db.getProduct(params.id);   // critical, awaited
+  const reviews = db.getReviews(params.id);          // slow, not awaited
+  return defer({ product, reviews });
+}
+
+export default function Product() {
+  const { product, reviews } = useLoaderData<typeof loader>();
+  return (
+    <>
+      <ProductHeader product={product} />
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Await resolve={reviews} errorElement={<ReviewsError />}>
+          {(r) => <ReviewList reviews={r} />}
+        </Await>
+      </Suspense>
+    </>
+  );
+}
+```
+
+## Streaming with `defer` and `<Await>`
+
+Every promise passed to `defer` must be created **before** any `await` in the loader, otherwise the loader still blocks on the slow call and streaming gains nothing. Always pair `<Await>` with `errorElement` — without it, a rejected deferred promise bubbles to the route's `ErrorBoundary` and tears down the whole route, defeating the streaming benefit.
+
+See [references/streaming.md](references/streaming.md) for full coverage.
+
+## HTTP Caching via `headers`
+
+`max-age` controls browser cache; `s-maxage` controls shared/CDN cache and overrides `max-age` at the CDN; `stale-while-revalidate` lets the CDN serve stale content while it refreshes in the background. Two cache scopes exist per route: the **document** response (controlled by the `headers` export) and the **data** request (the `?_data=` JSON request fired on client-side navigation — controlled by the loader's response headers). They can — and often should — carry different policies.
+
+**Parent/child merge is "deepest route wins"**: only the deepest matched route's `headers` runs by default. If a child route has no `headers` export, Remix walks up to the nearest parent that does. The safest rule: define `headers` only on leaf routes, never on layouts that wrap personalized children. Otherwise an aggressive parent policy silently caches per-user HTML at the CDN.
+
+When merging in a child, pick the **smaller** `max-age` — never widen a parent's caching policy from a child:
+```tsx
+export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
+  const loader = parseCacheControl(loaderHeaders.get("Cache-Control"));
+  const parent = parseCacheControl(parentHeaders.get("Cache-Control"));
+  const maxAge = Math.min(loader["max-age"] ?? 0, parent["max-age"] ?? 0);
+  return { "Cache-Control": `private, max-age=${maxAge}` };
+};
+```
+
+See [references/headers-caching.md](references/headers-caching.md).
+
+## Server/Client Split
+
+The compiler strips `loader`, `action`, and `headers` exports from client bundles along with the dependencies used **inside them** — but only if those dependencies have no module side effects. A top-level `new PrismaClient()`, a `console.log`, an `initializeApp` call all defeat tree-shaking. Rule: any module that imports `node:fs`, `prisma`, `bcrypt`, `jsonwebtoken`, or reads `process.env` should be named `*.server.ts` (or live under `app/.server/`). Build fails loud if it reaches the client graph — silent leaks are eliminated.
+
+Public env vars reach the browser via a root-loader `window.ENV` pattern. Never return raw `process.env` from a loader. See [references/server-client-split.md](references/server-client-split.md).
+
+## Hydration Safety
+
+`useHydrated()` returns `false` during SSR and on the very first client render, then flips to `true` on the next render — that two-pass behavior is what keeps HTML matched. For components that should never SSR (maps, charts that read `window`), wrap in `<ClientOnly fallback={...}>`. For SSR-safe IDs use React's `useId()`, never `Math.random()` or `crypto.randomUUID()` in render.
+
+The hydration-mismatch grep list: `new Date(`, `Math.random(`, `crypto.randomUUID(`, `Date.now(`, `window.`, `document.`, `localStorage`, `navigator.`, `Intl.DateTimeFormat()` without an explicit locale, `process.env.` in component bodies, `typeof window` ternaries that produce different JSX, third-party scripts that mutate the DOM, browser extensions injecting nodes into `<body>`. See [references/hydration.md](references/hydration.md).
+
+## Prefetching
+
+Four `<Link prefetch>` modes: `"none"` (default), `"intent"` (hover/focus), `"render"` (immediate, on render), `"viewport"` (scrolled into view). Prefetch fires `<link rel="prefetch">` tags as siblings of the anchor — use `:last-of-type` in CSS, not `:last-child`, because the prefetch tags briefly become last child.
+
+A subtle gotcha: hover-prefetch with no `Cache-Control` on the loader doubles the request count because the browser doesn't cache the prefetch response. Detect the `Purpose: prefetch` header in the loader and return `Cache-Control: private, max-age=10`. See [references/prefetch.md](references/prefetch.md).
+
+## Asset Preloading via `links`
+
+The `links` export injects `<link>` tags into the document head — preload critical fonts and CSS, prefetch likely-next-page assets. Remix has no built-in image optimizer; size images at build time (`sharp`, `unpic`, `remix-image`) and always set `width`/`height`. See [references/links-preload.md](references/links-preload.md).
+
+## Gates (decision sequencing)
+
+Answer **in order**. **Pass** means the condition is true; pick the API on the same line and **stop**.
+
+### `defer()` vs awaiting in the loader
+
+1. **Is this data required for the initial paint, meta tags, or SEO** (e.g. product title, page title)?
+   - **Pass →** `await` it in the loader, return via `json()`. **Stop.**
+   - **Fail →** Step 2.
+2. **Is the call genuinely slow** (>~50ms, cross-region DB, external API — not in-memory cache)?
+   - **Pass →** Pass the unresolved promise through `defer()`, wrap in `<Suspense>` + `<Await errorElement={...}>`. **Stop.**
+   - **Fail →** `await` it. Deferring fast data adds streaming overhead and flashes a skeleton for no gain.
+
+### `.server.ts` vs runtime `typeof window` check
+
+1. **Does the module import `node:*`, `prisma`, `bcrypt`, `jsonwebtoken`, `fs`, `path`, or read `process.env` at the top level**?
+   - **Pass →** Name the file `*.server.ts` (or place under `app/.server/`). Build fails loud if leaked to client. **Stop.**
+   - **Fail →** Step 2.
+2. **Is the module called only inside `loader`/`action`/`headers`** with no top-level side effects?
+   - **Pass →** `.server.ts` is still preferred for clarity; tree-shaking may work but is unreliable. **Stop.**
+   - **Fail →** Step 3.
+3. **Is the code legitimately isomorphic but needs to branch on environment** (logger, feature flag)?
+   - **Pass →** `typeof window === "undefined"` is acceptable inside a function body — never at module top level (the dead branch can pull server deps into the client graph).
+
+### `<Link prefetch>` mode selection
+
+1. **Is the link sensitive, expensive, or has loader side effects** (logout, analytics-instrumented page view, mutation-triggering loader)?
+   - **Pass →** `prefetch="none"`. **Stop.**
+   - **Fail →** Step 2.
+2. **Is this an above-the-fold critical nav link** likely to be the next click?
+   - **Pass →** `prefetch="render"`. Loader/JS/CSS prefetched immediately. **Stop.**
+   - **Fail →** Step 3.
+3. **Is the link in a long list** (table row, search results, feed)?
+   - **Pass →** `prefetch="viewport"` (fires when scrolled in) or `"intent"` (fires on hover). Never `"render"` on long lists. **Stop.**
+   - **Fail →** Step 4.
+4. **Default**: `prefetch="intent"` for standard nav (header, sidebar, footer).
+
+## Additional Documentation
+
+- **Headers and caching**: see [references/headers-caching.md](references/headers-caching.md) for `HeadersFunction` signature, `loaderHeaders`/`parentHeaders`/`actionHeaders`/`errorHeaders`, SWR patterns, and parent/child merge semantics.
+- **Streaming**: see [references/streaming.md](references/streaming.md) for `defer()`, `<Await>`, `<Suspense>`, `abortDelay`, error handling, CSP interactions.
+- **Server/client split**: see [references/server-client-split.md](references/server-client-split.md) for `.server.*` / `.client.*`, env var handling, the `window.ENV` pattern.
+- **Hydration**: see [references/hydration.md](references/hydration.md) for `useHydrated`, `<ClientOnly>`, `useId`, mismatch grep list.
+- **Prefetch**: see [references/prefetch.md](references/prefetch.md) for `<Link prefetch>` modes, `<PrefetchPageLinks>`, the `Purpose: prefetch` header trick.
+- **Preload links**: see [references/links-preload.md](references/links-preload.md) for `links` export, font/CSS preload, image guidance.
+
+## Comparison: When to use which API
+
+| Need | API | Module |
+|---|---|---|
+| Stream slow secondary data | `defer()` + `<Await>` | `@remix-run/node` + `@remix-run/react` |
+| CDN-cache document response | `headers` export | route module |
+| CDN-cache data response | `Cache-Control` on `json()`/`Response` | loader return |
+| Server-only module | `*.server.ts` filename | file convention |
+| Browser-only module | `*.client.ts` filename | file convention |
+| Public env vars in client | `window.ENV` via root loader | pattern |
+| SSR-safe IDs | `useId()` | `react` |
+| Suppress SSR for one component | `<ClientOnly>` | `remix-utils/client-only` |
+| Branch after hydration | `useHydrated()` | `remix-utils/use-hydrated` |
+| Prefetch on hover | `<Link prefetch="intent">` | `@remix-run/react` |
+| Prefetch on render (above-fold) | `<Link prefetch="render">` | `@remix-run/react` |
+| Programmatic prefetch | `<PrefetchPageLinks page="/abs">` | `@remix-run/react` |
+| Preload font/CSS | `links` export | route module |

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/SKILL.md
@@ -93,6 +93,33 @@ The compiler strips `loader`, `action`, and `headers` exports from client bundle
 
 Public env vars reach the browser via a root-loader `window.ENV` pattern. Never return raw `process.env` from a loader. See [references/server-client-split.md](references/server-client-split.md).
 
+## `clientLoader` and `clientAction`
+
+v2 added optional `clientLoader` / `clientAction` exports that run in the browser alongside (or instead of) the server `loader`/`action`. By default `clientLoader` does **NOT** run on initial hydration — the server `loader` SSRs the page, and `clientLoader` only fires on subsequent client navigations. Opt in to first-render execution with `clientLoader.hydrate = true` and export a `HydrateFallback` component to render while it executes:
+
+```tsx
+import type { ClientLoaderFunctionArgs } from "@remix-run/react";
+
+export async function loader() {
+  return json({ /* SSR data */ });
+}
+
+export async function clientLoader({ serverLoader }: ClientLoaderFunctionArgs) {
+  const cached = clientCache.get();
+  if (cached) return cached;
+  const fresh = await serverLoader<typeof loader>(); // round-trip to server loader
+  clientCache.set(fresh);
+  return fresh;
+}
+clientLoader.hydrate = true; // opt in to running on initial hydration
+
+export function HydrateFallback() {
+  return <Skeleton />;
+}
+```
+
+Use `clientLoader` for: client-side caching of server payloads, reading from IndexedDB / `localStorage` after hydration, fully client-only routes (skip `loader` entirely). **Do NOT** re-fetch the same server payload SSR'd by the route's `loader` — that's a wasted round-trip; either call `serverLoader()` and cache, or only run on transitions (leave `hydrate` `false`).
+
 ## Hydration Safety
 
 `useHydrated()` returns `false` during SSR and on the very first client render, then flips to `true` on the next render — that two-pass behavior is what keeps HTML matched. For components that should never SSR (maps, charts that read `window`), wrap in `<ClientOnly fallback={...}>`. For SSR-safe IDs use React's `useId()`, never `Math.random()` or `crypto.randomUUID()` in render.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/headers-caching.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/headers-caching.md
@@ -1,0 +1,261 @@
+# HTTP Caching with the `headers` Route Export
+
+Remix v2 has no built-in framework cache. All caching is plain HTTP, which means the `headers` route export and the loader's response headers are the only knobs — and they control two different responses.
+
+## Two cache scopes per route
+
+Every Remix route serves two response types:
+
+1. **Document response** — full server-rendered HTML, returned on hard navigations and initial loads. `Cache-Control` here comes from the route's `headers` export.
+2. **Data response** — JSON returned for `?_data=` requests on client-side navigations. `Cache-Control` here comes from the headers on the `Response`/`json()` the loader returns.
+
+They can and usually should differ. A long-form blog post might cache the document for 1 hour at the CDN but cache the data for 5 minutes — so client-side navigations re-fetch sooner while reused HTML stays cheap.
+
+## `HeadersFunction` signature
+
+```tsx
+import type { HeadersFunction } from "@remix-run/node";
+
+export const headers: HeadersFunction = ({
+  loaderHeaders,   // Headers from the loader's Response
+  parentHeaders,   // Headers the parent route would have sent
+  actionHeaders,   // Headers from the action's Response (if this was a POST)
+  errorHeaders,    // Headers from the boundary, when an error renders
+}) => {
+  return {
+    "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+  };
+};
+```
+
+All four `*Headers` properties are `Headers` instances — use `.get(key)`, `.has(key)`, `.entries()`. The return value can be a `Headers`, a `HeadersInit`, or a plain object.
+
+## Stale-While-Revalidate (SWR) pattern
+
+```tsx
+import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const post = await cms.getPost(params.slug);
+  return json(post, {
+    headers: {
+      "Cache-Control":
+        "public, max-age=60, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+});
+```
+
+Directive cheat sheet:
+
+| Directive | Audience | Effect |
+|---|---|---|
+| `max-age=N` | browser + CDN | Fresh for N seconds. CDN obeys unless `s-maxage` overrides. |
+| `s-maxage=N` | CDN only | Fresh for N seconds at the shared cache; overrides `max-age` there. |
+| `stale-while-revalidate=N` | CDN | After freshness expires, serve stale for up to N more seconds while refreshing in background. |
+| `public` | both | Cacheable by shared caches. **Refused by most CDNs if `Set-Cookie` is present**. |
+| `private` | browser only | Per-user; CDN must not cache. |
+| `no-store` | both | Never cache. Use for personalized data. |
+
+## Parent/child merge — the notorious gotcha
+
+**Default behavior: only the deepest matched route's `headers` runs.** If a leaf route has no `headers` export, Remix walks up to the nearest ancestor that does. This is the biggest source of cache misconfiguration in Remix v2 apps.
+
+Concrete failure mode:
+
+```tsx
+// app/routes/_layout.tsx — parent layout
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "public, max-age=300, s-maxage=3600",
+});
+
+// app/routes/_layout.dashboard.tsx — child renders per-user data
+// NO headers export!
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireUser(request);
+  return json({ user, balance: await getBalance(user.id) });
+}
+```
+
+Result: the dashboard HTML — which contains user-specific data — gets cached at the CDN for an hour with the parent's `public, s-maxage=3600` headers, and **every visitor sees the first cache fill's data**. Severe data-leak bug.
+
+### Two defenses
+
+**1. Leaf-only headers (recommended):**
+Never export `headers` from layout/parent routes. Only leaves declare caching policy. Every personalized route then defaults to `no-store` if you forget — failing closed, not open.
+
+**2. Defensive merging in the child:**
+If a parent must set headers, every child must explicitly merge — picking the most conservative (smallest `max-age`, `private` over `public`):
+
+```tsx
+import type { HeadersFunction } from "@remix-run/node";
+import { parseCacheControl } from "~/utils/cache";
+
+export const headers: HeadersFunction = ({ loaderHeaders, parentHeaders }) => {
+  const loader = parseCacheControl(loaderHeaders.get("Cache-Control"));
+  const parent = parseCacheControl(parentHeaders.get("Cache-Control"));
+
+  // Never widen a parent's caching policy from a child
+  const maxAge = Math.min(loader["max-age"] ?? 0, parent["max-age"] ?? 0);
+
+  return {
+    "Cache-Control": `private, max-age=${maxAge}`,
+  };
+};
+```
+
+## When `headers` runs
+
+| Trigger | Source headers passed |
+|---|---|
+| GET on the leaf route | `loaderHeaders`, `parentHeaders` |
+| POST/PUT/PATCH/DELETE | `actionHeaders`, `loaderHeaders` (post-action loader run), `parentHeaders` |
+| Error boundary rendered | `errorHeaders`, `parentHeaders` |
+| Resource route | The route's `headers` export does NOT run — set headers directly on the loader's `Response`. |
+
+## Combining with `Set-Cookie`
+
+CDNs refuse to cache responses with `Set-Cookie` when `Cache-Control` is `public`. Two safe shapes:
+
+```tsx
+// Shape A: cookie-setting loader returns private/no-store
+return json(data, {
+  headers: {
+    "Set-Cookie": await commitSession(session),
+    "Cache-Control": "private, no-store",
+  },
+});
+
+// Shape B: move cookie-setting into the action, keep loaders cookie-free
+// so loaders can return public caching headers safely.
+```
+
+## `Vary` header
+
+When response varies by `Accept-Language`, `Cookie`, or `Accept`, declare it explicitly so the CDN keys its cache entries correctly:
+
+```tsx
+export const headers: HeadersFunction = ({ loaderHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+  Vary: "Accept-Language",
+});
+```
+
+Be conservative with `Vary` — high cardinality (e.g. `Vary: User-Agent`) destroys hit rate.
+
+## Debugging
+
+- Production CDN logs are the source of truth. Don't trust dev — most local servers don't apply `Cache-Control`.
+- Check both response types: `curl -I https://site.com/page` for the document, `curl -I 'https://site.com/page?_data=routes/page'` for the data.
+- `Cache-Status` and `Age` response headers from your CDN tell you HIT/MISS and how long the entry has been cached.
+
+## When to return `no-store`
+
+- Authentication callback routes
+- Routes that show user-specific data (account, dashboard, cart)
+- Routes that set/read sensitive cookies
+- API/resource routes returning per-request computed values
+- Form action POST responses (Remix usually redirects these anyway)
+
+When unsure, return `no-store` and measure. Caching personalized data is a much worse bug than missing a perf win.
+
+## Per-route examples
+
+### Marketing page — long cache, SWR
+
+```tsx
+export async function loader() {
+  return json(await cms.getPage("home"), {
+    headers: {
+      "Cache-Control":
+        "public, max-age=300, s-maxage=86400, stale-while-revalidate=604800",
+    },
+  });
+}
+
+export const headers: HeadersFunction = ({ loaderHeaders }) => ({
+  "Cache-Control": loaderHeaders.get("Cache-Control") ?? "no-store",
+});
+```
+
+The CDN holds the page for a day, serving stale for a week while refreshing in the background. The browser caches for 5 minutes.
+
+### Blog post — moderate cache, SWR
+
+```tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const post = await cms.getPost(params.slug);
+  return json(post, {
+    headers: {
+      "Cache-Control":
+        "public, max-age=60, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}
+```
+
+### Authenticated dashboard — no cache
+
+```tsx
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireUser(request);
+  return json(
+    { user, balance: await getBalance(user.id) },
+    {
+      headers: { "Cache-Control": "private, no-store" },
+    }
+  );
+}
+
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "private, no-store",
+});
+```
+
+### API/resource route — JSON with short cache
+
+```tsx
+// app/routes/api.products.tsx — resource route, no default component
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const products = await db.getProducts({
+    category: url.searchParams.get("category"),
+  });
+  return json(products, {
+    headers: { "Cache-Control": "public, max-age=60, s-maxage=300" },
+  });
+}
+```
+
+Resource routes do not run a `headers` export; set headers on the returned `Response`/`json()` only.
+
+## ETags and conditional requests
+
+For revalidation efficiency, return an `ETag` header. Modern clients send `If-None-Match` on revalidation; if the loader can cheaply check whether the ETag still matches, return `204` to skip the body:
+
+```tsx
+import { json } from "@remix-run/node";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const post = await cms.getPost(params.slug);
+  const etag = `"${post.id}-${post.updatedAt}"`;
+
+  if (request.headers.get("If-None-Match") === etag) {
+    return new Response(null, { status: 304 });
+  }
+
+  return json(post, {
+    headers: {
+      "Cache-Control": "public, max-age=60, s-maxage=3600",
+      ETag: etag,
+    },
+  });
+}
+```
+
+ETags are most useful when origin compute is cheap but bandwidth is not.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/hydration.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/hydration.md
@@ -1,0 +1,193 @@
+# Hydration Safety
+
+A hydration mismatch happens when the HTML React renders on the server differs from what it produces on the client during the first render. React 18 logs a warning and re-renders the affected subtree on the client, destroying any SSR perf benefit and sometimes producing visible flicker.
+
+## Why mismatches happen
+
+Server and client are different environments. The same render function can produce different output when it depends on:
+
+- Time: `new Date()`, `Date.now()`, anything that reads "now."
+- Randomness: `Math.random()`, `crypto.randomUUID()`.
+- Locale: `Intl.DateTimeFormat()`, `Intl.NumberFormat()`, `toLocaleDateString()` — server defaults to system locale (often `en-US`), browser uses visitor's.
+- Environment: `window.`, `document.`, `localStorage`, `navigator.`, `process.env.` in component bodies.
+- Conditional branches: `typeof window === "undefined" ? A : B` produces different JSX on each side.
+- External mutation: third-party scripts that mutate the DOM before React hydrates (chat widgets, A/B test scripts), browser extensions injecting nodes into `<body>` (Grammarly, password managers).
+
+## The grep list
+
+Before shipping, search the codebase for these patterns in components or hooks that aren't already inside `useEffect`, `<ClientOnly>`, or `useHydrated()` gates:
+
+```text
+new Date(
+Math.random(
+crypto.randomUUID(
+Date.now(
+window.
+document.
+localStorage
+sessionStorage
+navigator.
+Intl.DateTimeFormat()
+Intl.NumberFormat()
+.toLocaleDateString
+.toLocaleTimeString
+.toLocaleString
+process.env.
+typeof window
+```
+
+Each one is a potential mismatch.
+
+## `useHydrated()` — two-pass conditional UI
+
+`useHydrated()` returns `false` during SSR and during the **first client render**, then flips to `true` on the next render. That two-pass behavior is what keeps server HTML and the initial client HTML identical — only the second render diverges, which React handles correctly.
+
+```tsx
+import { useHydrated } from "remix-utils/use-hydrated";
+
+export function TimezoneBadge({ iso }: { iso: string }) {
+  const isHydrated = useHydrated();
+  if (!isHydrated) return <time dateTime={iso}>{iso}</time>;
+  return (
+    <time dateTime={iso}>
+      {new Intl.DateTimeFormat().format(new Date(iso))}
+    </time>
+  );
+}
+```
+
+`remix-utils/use-hydrated` exports the standard implementation. The hook can also be hand-rolled in any project:
+
+```tsx
+import { useEffect, useState } from "react";
+
+export function useHydrated() {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => setHydrated(true), []);
+  return hydrated;
+}
+```
+
+Use `useHydrated()` for **conditional UI inside an already-rendered component** — the component itself SSRs, but a slice of it switches to a richer client-only representation after hydration.
+
+## `<ClientOnly>` — suppress SSR entirely
+
+When a component cannot SSR at all (Leaflet maps, Mapbox, charts that read `window`, Three.js canvases), wrap it in `<ClientOnly>`:
+
+```tsx
+import { ClientOnly } from "remix-utils/client-only";
+
+export function MapPanel() {
+  return (
+    <ClientOnly fallback={<MapPlaceholder aspect="16/9" />}>
+      {() => <LeafletMap />}
+    </ClientOnly>
+  );
+}
+```
+
+The `fallback` renders during SSR and during the first client render; the child renders after hydration. The child is a **function** (`() => <LeafletMap />`), not a JSX expression — this defers evaluation so that imports inside `LeafletMap` (which may touch `window`) don't run on the server.
+
+Use `<ClientOnly>` for **entire subtrees that can't SSR**. Don't reach for it as a hammer for every browser API — most cases are better handled with `useEffect` and `useHydrated`.
+
+## `useId()` — SSR-safe IDs
+
+React's `useId()` generates an ID that is stable across server and client. Use it for label-for, ARIA references, and anywhere else you'd hand-roll an ID:
+
+```tsx
+import { useId } from "react";
+
+export function LabeledInput({ label }: { label: string }) {
+  const id = useId();
+  return (
+    <>
+      <label htmlFor={id}>{label}</label>
+      <input id={id} />
+    </>
+  );
+}
+```
+
+Never hand-roll IDs with `Math.random()`, `crypto.randomUUID()`, or `Date.now()` in render. Server and client produce different values; every label-for, ARIA reference, and CSS hook breaks.
+
+## Common mismatches and their fixes
+
+### `new Date()` / `Date.now()`
+
+```tsx
+// BROKEN — server and client compute different "now"
+<p>Updated {new Date().toLocaleString()}</p>
+
+// FIX A — render the ISO from the loader, format after hydration
+const { updatedAtIso } = useLoaderData<typeof loader>();
+const isHydrated = useHydrated();
+return (
+  <p>
+    Updated{" "}
+    {isHydrated
+      ? new Date(updatedAtIso).toLocaleString()
+      : <time dateTime={updatedAtIso}>{updatedAtIso}</time>}
+  </p>
+);
+```
+
+### `Intl.DateTimeFormat()` without locale
+
+```tsx
+// BROKEN — server default locale != visitor's locale
+new Intl.DateTimeFormat().format(date);
+
+// FIX — pass locale explicitly (use a server-known value, or render
+// ISO server-side and reformat in useEffect/useHydrated)
+new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(date);
+```
+
+### `Math.random()`
+
+```tsx
+// BROKEN
+const id = `widget-${Math.random()}`;
+
+// FIX — useId() for IDs, or generate the value in the loader and pass via props
+const id = useId();
+```
+
+### `localStorage` in a `useState` initializer
+
+```tsx
+// BROKEN — localStorage is undefined on the server
+const [theme, setTheme] = useState(localStorage.getItem("theme"));
+
+// FIX — initialize to a server-safe default, sync in useEffect
+const [theme, setTheme] = useState<"light" | "dark">("light");
+useEffect(() => {
+  const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+  if (stored) setTheme(stored);
+}, []);
+```
+
+### Third-party scripts mutating the DOM
+
+Chat widgets, A/B test loaders, Sentry, analytics — if they inject DOM before React hydrates, hydration sees unexpected nodes. Defenses:
+
+- Load them after hydration (in `useEffect`).
+- Inject the script with `async` or `defer` and a known-stable mounting point that React doesn't manage.
+- Set `suppressHydrationWarning` on container nodes whose content the script controls.
+
+### Browser extensions injecting nodes
+
+Grammarly, password managers, ad blockers can add attributes (`data-gramm`, `cz-shortcut-listen`) or wrap inputs. There's no clean fix — the standard workaround is `suppressHydrationWarning` on the affected element. Use sparingly; it silences real bugs too.
+
+## Debugging hydration errors
+
+React's hydration error message includes both the server HTML and the client-rendered output. Diff them character by character — the first divergence is your bug. Then grep the component tree for the patterns in the grep list above, starting at the deepest node.
+
+If the mismatch is inside a third-party component, file an issue upstream and wrap the component in `<ClientOnly>` as a workaround.
+
+## When `suppressHydrationWarning` is justified
+
+- Browser extension DOM mutation that you can't prevent.
+- Intentional time-since-now displays where the server value is acceptable for the first render.
+- Cases where the difference is invisible (whitespace differences from a third-party script).
+
+It only silences the warning for the **single element** it's attached to — children still report mismatches. Don't slap it at the root to suppress all warnings.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/links-preload.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/links-preload.md
@@ -1,0 +1,139 @@
+# `links` Export — Preloading and Image Notes
+
+The `links` export injects `<link>` tags into the document `<head>`. It's the canonical way to preload critical assets (fonts, CSS), prefetch next-page assets, and set page-level resource hints (`dns-prefetch`, `preconnect`).
+
+## `LinksFunction` shape
+
+```tsx
+import type { LinksFunction } from "@remix-run/node";
+import interVar from "~/fonts/InterVariable.woff2";
+import appStyles from "~/styles/app.css?url";
+
+export const links: LinksFunction = () => [
+  // Preload a variable font — must be `crossOrigin: "anonymous"` for woff2 in most setups
+  {
+    rel: "preload",
+    as: "font",
+    type: "font/woff2",
+    href: interVar,
+    crossOrigin: "anonymous",
+  },
+  // Stylesheet
+  { rel: "stylesheet", href: appStyles },
+  // Favicon
+  { rel: "icon", href: "/favicon.png", type: "image/png" },
+  // Resource hint for an external API
+  { rel: "preconnect", href: "https://api.example.com" },
+  // Page link descriptor — Remix expands into the right prefetch tags
+  { page: "/dashboard" },
+];
+```
+
+Each entry is either an `HtmlLinkDescriptor` (standard `<link>` tag attributes) or a `PageLinkDescriptor` (`{ page: "/path" }`).
+
+## Asset preload patterns
+
+### Preload critical font
+
+```tsx
+{
+  rel: "preload",
+  as: "font",
+  type: "font/woff2",
+  href: interVar,
+  crossOrigin: "anonymous",
+}
+```
+
+Preloading fonts that are used immediately in the initial render eliminates the font-swap flash. Only preload fonts that are **actually used above the fold** — preloading an unused weight is wasted bandwidth.
+
+### Stylesheet
+
+```tsx
+{ rel: "stylesheet", href: appStyles }
+```
+
+Use `?url` import (`import appStyles from "~/styles/app.css?url"`) to get a hashed URL pointing at the built CSS file.
+
+### Resource hints
+
+```tsx
+// Just resolves DNS — cheap, useful when you'll connect later
+{ rel: "dns-prefetch", href: "https://api.example.com" }
+
+// Resolves DNS + opens TCP + TLS — more expensive, do this for hostnames
+// you know you'll connect to during initial render
+{ rel: "preconnect", href: "https://api.example.com" }
+```
+
+Don't `preconnect` to more than 3-4 hosts; it costs sockets.
+
+### Page link descriptor
+
+```tsx
+{ page: "/dashboard" }
+```
+
+Remix expands this into the right combination of `<link rel="prefetch">` and `<link rel="modulepreload">` tags for the route's data, JS, and CSS. Equivalent to a `<PrefetchPageLinks page="/dashboard" />` but at the route's link level — fires on render of the route that exports it.
+
+## Nested route inheritance
+
+The `links` exports from every matched route in the route tree are **concatenated** into the document head. So a layout's `links` provides app-wide assets; a child route's `links` adds page-specific assets without losing the parent's.
+
+```tsx
+// app/root.tsx
+export const links: LinksFunction = () => [
+  { rel: "preload", as: "font", type: "font/woff2", href: interVar, crossOrigin: "anonymous" },
+  { rel: "stylesheet", href: appStyles },
+];
+
+// app/routes/blog.tsx
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: blogStyles },
+];
+```
+
+Both stylesheets render in the head on a `/blog/*` route.
+
+## Image handling — there is no built-in optimizer
+
+Remix v2 has **no built-in image optimizer**, unlike Next.js. You're responsible for serving correctly sized images. Options:
+
+- Process at build time with `sharp`, `unpic`, or `remix-image`.
+- Use a third-party CDN with image transforms (Cloudinary, imgix, Cloudflare Images).
+- Pre-render multiple sizes and use `<picture>` / `srcset`.
+
+Two rules that apply regardless of how you serve images:
+
+**1. Always set `width` and `height`.** Reserves layout space, eliminates Cumulative Layout Shift (CLS).
+
+```tsx
+<img src="/hero.jpg" alt="..." width={1200} height={800} />
+```
+
+**2. Use `loading="lazy"` for below-the-fold images.** Native browser lazy-loading; no JS required.
+
+```tsx
+<img src="/below-fold.jpg" alt="..." width={800} height={600} loading="lazy" />
+```
+
+Don't `loading="lazy"` above-the-fold images — they're needed for LCP, lazy-loading delays them.
+
+## Common mistakes
+
+- **Preloading a font that's not used above the fold** — wasted bandwidth, the file downloads but the user never sees it before the page is interactive.
+- **Forgetting `crossOrigin: "anonymous"` on font preload** — browser issues the preload, then a second request for the actual font use because the credentials mode doesn't match.
+- **Preloading every CSS file** — bundle the critical CSS into a single file, preload that one.
+- **Image tag with no `width`/`height`** — layout shift, poor CLS score.
+- **`loading="lazy"` on the hero image** — slows LCP.
+- **Preconnecting to 10+ hosts** — opens too many sockets, may starve the connections you actually need.
+
+## Resource hint cheat sheet
+
+| Hint | Cost | When to use |
+|---|---|---|
+| `dns-prefetch` | Resolves DNS | Hostnames you might use later (analytics, fallback API) |
+| `preconnect` | DNS + TCP + TLS handshake | Hostnames you definitely use during initial render |
+| `prefetch` | Full resource download, low priority | Resources for the next page |
+| `preload` | Full resource download, high priority | Resources used in current render but discovered late by the browser (fonts referenced in CSS, hero image referenced in inline style) |
+| `modulepreload` | Module + dependency graph fetch | JS modules used in current render |

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/prefetch.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/prefetch.md
@@ -1,0 +1,141 @@
+# Prefetching with `<Link>` and `<PrefetchPageLinks>`
+
+Remix's prefetch turns `<Link>` into a portal that fetches the target route's data, JS modules, and CSS **before** the user clicks — so the navigation feels instant. The mechanism is browser-native: Remix inserts `<link rel="prefetch">` tags as siblings of the anchor.
+
+## `<Link prefetch>` modes
+
+```tsx
+import { Link } from "@remix-run/react";
+
+<Link to="/dashboard" prefetch="none">    // default — never prefetch
+<Link to="/dashboard" prefetch="intent">  // fires on hover/focus
+<Link to="/dashboard" prefetch="render">  // fires when the link renders
+<Link to="/dashboard" prefetch="viewport"> // fires when scrolled into view
+```
+
+| Mode | Trigger | Use for |
+|---|---|---|
+| `"none"` | Never | Sensitive links (logout), mutation-triggering loaders, analytics-instrumented routes |
+| `"intent"` | Hover or focus | Default for nav menus, content cards, anywhere user hover signals intent |
+| `"render"` | Immediately, when the link enters the React tree | Above-the-fold critical "next click" (e.g. paginated next-page button) |
+| `"viewport"` | When the link scrolls into view (IntersectionObserver) | Long lists, infinite scrolls — prefetch only what's seen |
+
+## When prefetch is harmful
+
+- **Loaders with side effects** — page-view analytics, view counters, mutation-triggering reads. Hover-prefetch inflates the count. Either move side effects out of the loader (do them in an `action` or a separate beacon endpoint), or set `prefetch="none"` on those links.
+- **`prefetch="render"` on a 200-row table** — each row fires a prefetch immediately. Network thrash, wasted bandwidth, possible upstream rate-limit hits. Use `"intent"` or `"viewport"` for long lists.
+- **Logout / destructive routes** — even if the loader is GET-safe, hover-prefetch is wasted work and may show up in logs as suspicious traffic. Use `prefetch="none"`.
+- **Routes behind paywalls** — prefetching content the user isn't entitled to load wastes server CPU; gate at the loader anyway, but skip prefetch.
+
+## The double-data-request gotcha
+
+When the user hovers a link with `prefetch="intent"`, the browser issues a prefetch request for the route's data. If the loader response has no `Cache-Control` header, the browser **does not cache the response**. When the user then clicks, the browser fires the **same request again** — defeating the prefetch entirely.
+
+The fix: detect the `Purpose: prefetch` header in the loader and return a short `Cache-Control`:
+
+```tsx
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const data = await getData(request);
+
+  // Browsers and Remix use several header names for this — check all
+  const purpose =
+    request.headers.get("Purpose") ||
+    request.headers.get("X-Purpose") ||
+    request.headers.get("Sec-Purpose") ||
+    request.headers.get("Sec-Fetch-Purpose") ||
+    request.headers.get("X-Moz");
+
+  const headers = new Headers();
+  if (purpose === "prefetch") {
+    // Cache just long enough that the click finds a hit
+    headers.set("Cache-Control", "private, max-age=10");
+  }
+  return json(data, { headers });
+}
+```
+
+Without this header, your CDN logs will show 2x the request count on every prefetched route — easy to miss in dev but obvious in production.
+
+## CSS selector gotcha: `:last-of-type`, not `:last-child`
+
+Remix injects the `<link rel="prefetch">` tags as **siblings** of the `<a>` element. Briefly, those prefetch tags become the last child of the parent — so any CSS rule like `nav a:last-child` momentarily misses its target during prefetch.
+
+```css
+/* BROKEN — prefetch tags break this */
+nav a:last-child { margin-right: 0; }
+
+/* CORRECT */
+nav a:last-of-type { margin-right: 0; }
+```
+
+## `<PrefetchPageLinks>` — programmatic prefetch
+
+When you want to prefetch a route without an associated `<Link>` (e.g. the most likely next page based on user behavior), use `<PrefetchPageLinks>`:
+
+```tsx
+import { PrefetchPageLinks, useLoaderData } from "@remix-run/react";
+
+export default function ArticleList() {
+  const { articles } = useLoaderData<typeof loader>();
+  return (
+    <>
+      {articles.map((a) => <ArticleCard key={a.id} article={a} />)}
+      {/* Preload the most likely next page */}
+      <PrefetchPageLinks page={`/articles/${articles[0]?.slug}`} />
+    </>
+  );
+}
+```
+
+Prefetches data, JS modules, and CSS for the target route.
+
+**Gotcha**: the `page` prop must be an **absolute path** (starts with `/`). Relative paths silently fail — no warning, no prefetch.
+
+```tsx
+<PrefetchPageLinks page="articles/foo" />   // BROKEN — silently does nothing
+<PrefetchPageLinks page="/articles/foo" />  // works
+```
+
+## Decision matrix
+
+| Scenario | Choice |
+|---|---|
+| Header nav link to a static page | `prefetch="intent"` |
+| Header nav link to a logged-out-only page (e.g. `/login` when already logged in) | `prefetch="none"` |
+| Logout button | `prefetch="none"` |
+| "Next page" pagination button above the fold | `prefetch="render"` |
+| Row in a 100+ row table | `prefetch="viewport"` |
+| Search result card | `prefetch="intent"` |
+| Predictive prefetch (programmatic, no link) | `<PrefetchPageLinks page="/abs" />` |
+| Loader has side effects (logs a view, increments a counter) | `prefetch="none"`, or fix the loader |
+
+## Verifying prefetch works
+
+In DevTools Network panel, filter by Initiator → "Other" or look for the `Purpose: prefetch` request header. On hover (with `prefetch="intent"`) you should see the data request fire **once** with `Purpose: prefetch`, then on click **no** additional request (cache hit). If you see two requests, your loader is missing the `Purpose: prefetch` cache header.
+
+## What prefetch actually downloads
+
+When prefetch fires for a route, Remix inserts three categories of `<link>` tags:
+
+1. `<link rel="prefetch" as="fetch" href="/path?_data=routes/path">` — the loader's JSON data.
+2. `<link rel="modulepreload" href="/build/routes/path-HASH.js">` — the route's JS module.
+3. `<link rel="prefetch" href="/build/routes/path-HASH.css">` — the route's CSS, if any.
+
+All three need cache headers (or browser caching defaults) to be effective. The data request is the most common to misconfigure because the loader controls its `Cache-Control` and most apps default to none.
+
+## Interaction with `headers` export
+
+Prefetch fires `GET` requests with the same headers as a normal navigation, including the `Purpose: prefetch` marker (and friends). Your `headers` export receives them like any other request; you can branch on `Purpose` inside the loader (as shown above), but the `headers` export itself doesn't usually need to differ — the loader's response headers are the lever.
+
+If you cache the data response with a longer `max-age` on prefetch-marked requests than on regular requests, click navigations after a prefetch will reuse the cached entry — exactly what you want. Keep the value small (5-30s) so stale data doesn't outlive its usefulness.
+
+## Mobile and slow networks
+
+On mobile or slow connections, prefetch competes with the resources needed for the current page. Aggressive `prefetch="render"` on many links can starve the critical render path. Two mitigations:
+
+- Use `prefetch="intent"` (only fires on hover/focus, which mobile users rarely trigger casually) for less-likely destinations.
+- Use `prefetch="viewport"` for long lists so prefetch only fires for visible rows.
+
+The browser also respects the `Save-Data` request header on metered connections — Remix-injected prefetch tags are still issued, but the browser may skip them. You can also gate prefetch in your own code based on `navigator.connection.effectiveType` if you need finer control.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/server-client-split.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/server-client-split.md
@@ -1,0 +1,196 @@
+# Server/Client Split — `.server.ts`, `.client.ts`, and Env Vars
+
+Remix v2 enforces a hard split between server-only and browser-only code through file naming conventions. This is not optional ergonomics — it's the only reliable way to keep server libraries out of the client bundle.
+
+## Why tree-shaking is not enough
+
+Remix's compiler strips `loader`, `action`, and `headers` exports from client bundles **and** the dependencies used inside them — but only if those dependencies have no module side effects. Real-world code routinely violates that:
+
+```tsx
+// app/lib/db.ts — looks fine, but tree-shaking is broken here
+import { PrismaClient } from "@prisma/client";
+
+// Top-level side effect — even if no client code calls `db`,
+// this `new` expression cannot be tree-shaken out.
+export const db = new PrismaClient();
+```
+
+Common side-effect patterns that defeat tree-shaking:
+
+- Top-level `new` expressions (`new PrismaClient()`, `new OpenAI()`).
+- Top-level function calls (`initializeApp(config)`, `console.log("...")`).
+- Module-evaluation imports with effects (Sentry init, OpenTelemetry instrumentation).
+- Higher-order function wrappers around loaders: `export const loader = withAuth(async (args) => {...})` — `withAuth` runs at module evaluation time and pins server-only deps into the client graph.
+
+**Rule**: any module that imports `node:*` builtins (`fs`, `path`, `crypto`), database clients (`prisma`, `pg`, `mysql2`), crypto/auth libs (`bcrypt`, `jsonwebtoken`, `argon2`), or reads `process.env` at the top level must be named `*.server.ts` or live under `app/.server/`.
+
+## `.server.*` file convention
+
+Two equivalent forms:
+
+```text
+app/lib/db.server.ts          # filename suffix — works in both compilers
+app/.server/db.ts             # directory form — Vite-only
+```
+
+Build behavior:
+
+- **Vite plugin** (`@remix-run/dev` with Vite): if a `.server` module is reachable from the client graph, the build **fails loud** with an error pointing at the offending import chain.
+- **Classic Compiler** (legacy `esbuild`-based): `.server` violations are **silent** — the bad import is replaced with an empty module at runtime, producing confusing `X is not a function` errors. The Classic Compiler also supports only the filename suffix, not the directory form.
+
+Prefer Vite for new projects. If stuck on the Classic Compiler, be extra vigilant about `.server` naming.
+
+```tsx
+// app/lib/db.server.ts — never bundled into the client
+import { PrismaClient } from "@prisma/client";
+import { env } from "./env.server";
+
+export const db = new PrismaClient({
+  datasources: { db: { url: env.DATABASE_URL } },
+});
+
+// app/routes/users.tsx — safe to import a .server module
+import { json } from "@remix-run/node";
+import { db } from "~/lib/db.server";
+
+export async function loader() {
+  return json({ users: await db.user.findMany() });
+}
+```
+
+## `.client.*` file convention
+
+The mirror of `.server`: modules that should never be bundled or evaluated on the server.
+
+```text
+app/lib/analytics.client.ts
+app/.client/leaflet-init.ts
+```
+
+On the server, exports from a `.client` module are `undefined`. This matters: a route component that imports a `.client` value at the top level and uses it in render will crash during SSR. Use `.client` modules from inside `useEffect`, event handlers, or `<ClientOnly>` children — never in render or at module top level of a server-rendered component.
+
+```tsx
+// app/lib/analytics.client.ts
+import posthog from "posthog-js";
+
+export function track(event: string, props?: Record<string, unknown>) {
+  posthog.capture(event, props);
+}
+
+// In a route component:
+import { useEffect } from "react";
+import { track } from "~/lib/analytics.client";
+
+export default function Page() {
+  useEffect(() => {
+    track("page_viewed");  // safe — useEffect runs only on the client
+  }, []);
+  return <h1>Hello</h1>;
+}
+```
+
+## Env vars: server vs `window.ENV`
+
+Server-only env vars are read via `process.env.X` **only inside `loader`, `action`, or a `.server` module**:
+
+```tsx
+// app/lib/env.server.ts
+export const env = {
+  DATABASE_URL: must("DATABASE_URL"),
+  STRIPE_SECRET_KEY: must("STRIPE_SECRET_KEY"),
+};
+
+function must(key: string): string {
+  const v = process.env[key];
+  if (!v) throw new Error(`Missing env: ${key}`);
+  return v;
+}
+```
+
+**Never** reference `process.env` in a component body or in a non-`.server` utility imported by a component. `process.env` doesn't exist in the browser, and the bundler may inline the value, leaking the secret.
+
+### Public env vars via `window.ENV`
+
+Public values (Stripe publishable key, PostHog key, public API URLs) reach the client through the root loader, injected into `window.ENV` via a `<script>` tag:
+
+```tsx
+// app/root.tsx
+import { json, type LoaderFunctionArgs } from "@remix-run/node";
+import { Outlet, Scripts, ScrollRestoration, useLoaderData } from "@remix-run/react";
+
+export async function loader(_args: LoaderFunctionArgs) {
+  return json({
+    ENV: {
+      STRIPE_PUBLIC_KEY: process.env.STRIPE_PUBLIC_KEY,
+      POSTHOG_KEY: process.env.POSTHOG_KEY,
+      PUBLIC_API_URL: process.env.PUBLIC_API_URL,
+    },
+  });
+}
+
+export default function App() {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <html lang="en">
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.ENV = ${JSON.stringify(data.ENV)}`,
+          }}
+        />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+
+// app/types/globals.d.ts
+declare global {
+  interface Window {
+    ENV: {
+      STRIPE_PUBLIC_KEY: string;
+      POSTHOG_KEY: string;
+      PUBLIC_API_URL: string;
+    };
+  }
+}
+```
+
+**Critical**: only put **public** values into `ENV`. Anything in `window.ENV` is exposed to every visitor. Never `return json({ ENV: process.env })` — that ships every secret.
+
+### `JSON.stringify` is not safe-for-inline-script
+
+`JSON.stringify` does **not** escape `</script>` or U+2028/U+2029 line separators. If any string in your `ENV` payload contains `</script>`, it breaks out of the script context — an XSS vector. For hardened apps use `serialize-javascript`:
+
+```tsx
+import serialize from "serialize-javascript";
+
+<script
+  dangerouslySetInnerHTML={{
+    __html: `window.ENV = ${serialize(data.ENV, { isJSON: true })}`,
+  }}
+/>
+```
+
+Or hand-escape `<`, `>`, `&`, `'`, U+2028, U+2029 before injection.
+
+## Anti-patterns
+
+- **`import { prisma } from "~/lib/db"`** with no `.server` suffix. Fix: rename to `db.server.ts`.
+- **`process.env.STRIPE_SECRET_KEY` in a component**. Fix: read in loader, pass via `useLoaderData()` only if it's the **publishable** key — never the secret.
+- **`export const loader = withAuth(async (args) => {...})`** — wrapper runs at module evaluation. Fix: call `await requireAuth(args)` **inside** the loader body.
+- **`useState(localStorage.getItem("theme"))`** in a server-rendered component. Fix: initialize to a server-safe default, then sync from `localStorage` in `useEffect`; or wrap in `<ClientOnly>`.
+- **Importing `node:fs`, `path`, `bcrypt`, `jsonwebtoken` from a non-`.server` utility consumed by a route component**. Fix: rename the file to `*.server.ts`.
+- **`typeof window === "undefined"` at module top level** to branch imports — the dead branch can still pull server deps into the client graph. Fix: split into `.server.ts` and `.client.ts` files.
+
+## Diagnosing leaks
+
+If a build succeeds but the client bundle crashes with `Module not found: 'fs'` or `prisma is undefined`:
+
+1. Grep for the offending import in any non-`.server` file.
+2. Use Remix's build output to inspect what's in the client bundle (`build/client/assets/`).
+3. Move the import into a `.server.ts` module and re-build. Vite will surface any remaining client-graph references.
+
+The whole point of the `.server` convention is to convert silent runtime leaks into loud build failures. Use it liberally.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/streaming.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/streaming.md
@@ -1,0 +1,175 @@
+# Streaming with `defer` and `<Await>`
+
+Streaming lets a Remix route return its initial HTML quickly while slow promises resolve afterward, with the browser progressively rendering as each chunk arrives. Useful for routes where critical data (page title, hero content) is fast but secondary data (recommendations, related items, reviews) is slow.
+
+## When streaming actually helps
+
+Streaming improves **TTFB** (time to first byte) and **LCP** (largest contentful paint) only when:
+
+1. The critical data is meaningfully faster than the secondary data (≥100ms gap).
+2. The hosting platform supports streamed responses (Node, Cloudflare Workers with streaming, Vercel Edge with streaming — **not** all edge runtimes; many buffer the full response).
+3. The slow data takes >50ms — otherwise the suspense skeleton flashes and net perceived performance regresses.
+
+If those don't hold, await everything and return a `json()` response.
+
+## Canonical `defer` shape
+
+```tsx
+import { defer, type LoaderFunctionArgs } from "@remix-run/node";
+import { Await, useLoaderData } from "@remix-run/react";
+import { Suspense } from "react";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  // Critical: await — needed for the initial paint, meta tags, SEO
+  const product = await db.getProduct(params.id);
+
+  // Secondary: kick off BEFORE any other await, pass the unresolved promise
+  const reviewsPromise = db.getReviews(params.id); // NO await
+
+  return defer({ product, reviews: reviewsPromise });
+}
+
+export default function Product() {
+  const { product, reviews } = useLoaderData<typeof loader>();
+  return (
+    <>
+      <ProductHeader product={product} />
+      <Suspense fallback={<ReviewsSkeleton />}>
+        <Await resolve={reviews} errorElement={<ReviewsError />}>
+          {(r) => <ReviewList reviews={r} />}
+        </Await>
+      </Suspense>
+    </>
+  );
+}
+```
+
+**Invariant**: every promise passed to `defer()` must be created **before** any subsequent `await` in the loader. Otherwise the loader still blocks on the slow call before returning, and streaming gains nothing.
+
+```tsx
+// BROKEN — reviewsPromise starts AFTER awaiting db.getOrders, so the loader
+// doesn't return until orders finishes. Streaming achieves nothing.
+const product = await db.getProduct(params.id);
+const orders = await db.getOrders(params.id);    // blocks
+const reviewsPromise = db.getReviews(params.id); // too late
+return defer({ product, orders, reviews: reviewsPromise });
+```
+
+## Error handling in `<Await>`
+
+Always pass `errorElement`. Without it, a rejected deferred promise bubbles to the route's `ErrorBoundary` and tears down the **whole route** — defeating the streaming benefit (the user already saw partial content, then it vanishes).
+
+```tsx
+import { Await, useAsyncError } from "@remix-run/react";
+import { Suspense } from "react";
+
+function ReviewsError() {
+  const err = useAsyncError() as Error;
+  return <p role="alert">Reviews unavailable: {err.message}</p>;
+}
+
+<Suspense fallback={<ReviewsSkeleton />}>
+  <Await resolve={reviews} errorElement={<ReviewsError />}>
+    {(r) => <ReviewList reviews={r} />}
+  </Await>
+</Suspense>
+```
+
+`useAsyncValue()` reads the resolved value. `useAsyncError()` reads the rejection.
+
+## `abortDelay` — keep it low
+
+```tsx
+// app/entry.server.tsx
+import { RemixServer } from "@remix-run/react";
+
+export default function handleRequest(/* ... */) {
+  return /* renderToPipeableStream */(
+    <RemixServer context={remixContext} url={request.url} abortDelay={5000} />
+    // ...
+  );
+}
+```
+
+Default is 5000ms. **Don't bump it to 30s "to be safe"** — slow upstream calls then hold the connection open, exhausting server worker pools and pushing p99 latency through the floor. If upstreams are slow, set per-call timeouts inside the loader:
+
+```tsx
+const reviewsPromise = Promise.race([
+  db.getReviews(params.id),
+  new Promise((_, reject) =>
+    setTimeout(() => reject(new Error("reviews timeout")), 3000)
+  ),
+]);
+```
+
+## Interaction with `headers` export
+
+Streaming and `Cache-Control` interact awkwardly:
+
+- The HTTP response headers go out **before** any deferred data resolves — so `headers` must commit to a caching policy without knowing whether the slow data succeeds.
+- If you cache a deferred response and a deferred promise rejected, the cached HTML contains the partial-then-error UI for everyone.
+
+Safer defaults:
+
+```tsx
+// Avoid public caching on deferred responses
+export const headers: HeadersFunction = () => ({
+  "Cache-Control": "private, no-store",
+});
+```
+
+Or only `defer` on routes where every deferred promise is idempotent and resilient.
+
+## TypeScript: `<Await resolve={...}>` types
+
+`useLoaderData<typeof loader>()` returns `Promise<T>` for deferred fields. Pass that promise directly to `<Await resolve={...}>` — **don't** call `.then()` on it during render:
+
+```tsx
+const { reviews } = useLoaderData<typeof loader>();
+// reviews: Promise<Review[]>
+
+// CORRECT
+<Await resolve={reviews}>{(r) => <ReviewList reviews={r} />}</Await>
+
+// WRONG — calling .then() in render kicks off another async chain every render
+<Await resolve={reviews.then((r) => r.filter(/*...*/))}>
+```
+
+If you need to transform, do it in the loader before passing through `defer`:
+
+```tsx
+const reviewsPromise = db.getReviews(params.id).then((r) => r.filter(visible));
+return defer({ reviews: reviewsPromise });
+```
+
+## Streaming and CSS-in-JS
+
+Emotion, styled-components, and similar libraries with default config in `entry.server.tsx` require collecting styles during a **full server render** — incompatible with streaming. The page can't stream until rendering completes. Use Tailwind, Vanilla Extract, CSS Modules, or a CSS-in-JS library with documented streaming support.
+
+## CSP and streaming
+
+Streaming appends `<script>` chunks to the HTML to resolve deferred promises in the browser. These trip strict Content Security Policy:
+
+- Easy escape: allow `'unsafe-inline'` for `script-src` (degrades CSP value).
+- Hard but correct: thread a nonce through `<RemixServer>`, `<Scripts>`, `<ScrollRestoration>`, and `<LiveReload>`, and set `script-src 'self' 'nonce-...'`.
+
+## Anti-patterns
+
+- **`<Suspense>` wrapping awaited data** — Suspense never triggers; dead code that misleads future readers. Remove the boundary, or move the field to `defer`.
+- **`defer` for data that comes from an in-memory cache** — protocol overhead (extra script tags, extra render pass) makes TTI worse for sub-50ms data.
+- **Mounting `<Await>` without `<Suspense>`** — React throws.
+- **`await Promise.all([...])` of deferred fields in the loader before `defer`** — same as creating the promise after an `await`: kills streaming.
+- **High `abortDelay`** — exhausts worker pools.
+
+## Deferring multiple values
+
+```tsx
+return defer({
+  product,                              // awaited
+  reviews: db.getReviews(params.id),    // promise
+  related: db.getRelated(params.id),    // promise
+  recommendations: db.getRecs(params.id), // promise
+});
+```
+
+Each is independently rendered through its own `<Await>`. Order them by likely resolution time so the fastest chunks appear first.

--- a/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/streaming.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-perf-ssr/references/streaming.md
@@ -91,7 +91,7 @@ export default function handleRequest(/* ... */) {
 }
 ```
 
-Default is 5000ms. **Don't bump it to 30s "to be safe"** — slow upstream calls then hold the connection open, exhausting server worker pools and pushing p99 latency through the floor. If upstreams are slow, set per-call timeouts inside the loader:
+Default is 5000ms. **Don't bump it to 30s "to be safe"** — slow upstream calls then hold the connection open, exhausting server worker pools and pushing p99 latency through the roof. If upstreams are slow, set per-call timeouts inside the loader:
 
 ```tsx
 const reviewsPromise = Promise.race([

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: remix-v2-routing-review
 description: Reviews Remix v2 route files for naming convention violations, missing layouts, resource-route shape, and v1 holdovers. Use when reviewing files under app/routes/ in a Remix v2 codebase.
+user-invocable: false
 ---
 
 # Remix v2 Routing Code Review

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/SKILL.md
@@ -15,6 +15,7 @@ Loaded by `review-remix-v2` (umbrella) to flag routing anti-patterns in `app/rou
 | Missing `<Outlet />`, orphan dotted segments, duplicated layout logic | [references/layouts-outlets.md](references/layouts-outlets.md) |
 | Default export on a resource, `<Link>` without `reloadDocument`, splat params | [references/resource-routes.md](references/resource-routes.md) |
 | `react-router-dom` imports, `__double` folders, v1-adapter fallback | [references/v1-holdovers.md](references/v1-holdovers.md) |
+| Missing `<Meta />`/`<Links />`/`<Scripts />`/`<ScrollRestoration />`, Vite-vs-Classic `<LiveReload />`, root `ErrorBoundary` without document shell | [references/root-shell.md](references/root-shell.md) |
 
 ## Scope
 
@@ -40,12 +41,12 @@ Out of scope: loader/action data contracts (covered by `remix-v2-data-flow-revie
 - [ ] Imports come from `@remix-run/react`, not `react-router-dom`
 - [ ] Non-route files (CSS, helpers, tests) live in a folder with `route.tsx`, or are listed in `ignoredRouteFiles`
 - [ ] Trailing-underscore opt-outs only used when a parent layout actually exists to escape
-- [ ] Optional segments `($lang)` narrow `params.lang` in the loader
+- [ ] Optional segments `($lang)` narrow `params.lang` in the loader (see [references/route-files.md](references/route-files.md#optional-segments-lang-without-narrowing-in-the-loader))
 
 ## Valid Patterns (Do NOT Flag)
 
 - **Resource route with no default export** — this *is* the convention that makes it a resource route. Never flag.
-- **`_layout.tsx` (or any `_`-prefixed file) without `<Outlet />`** when the module is intentionally a wrapper that renders fixed UI only. Confirm by checking children — if no `*.{segment}.tsx` siblings exist, the wrapper-only shape is intentional.
+- **Any `_`-prefixed pathless layout file without `<Outlet />`** when the module is intentionally a wrapper that renders fixed UI only. Confirm by checking children — if no `*.{segment}.tsx` siblings exist, the wrapper-only shape is intentional.
 - **Files prefixed with `_` that don't appear in any URL** — pathless layouts and `_index` are supposed to be hidden from the URL.
 - **`@remix-run/v1-route-convention`** wired up in `remix.config.js` — legitimate migration adapter, not a smell on its own. Only flag if v1-style files appear *without* the adapter installed.
 - **`useLoaderData<typeof loader>()`** — type annotation, not assertion.
@@ -84,6 +85,7 @@ Run these in order. **Do not draft user-facing findings until every gate passes*
 - Reviewing parent modules and shared chrome → [references/layouts-outlets.md](references/layouts-outlets.md)
 - Reviewing a module that returns non-HTML, or any `<Link>` to such a module → [references/resource-routes.md](references/resource-routes.md)
 - Reviewing imports or filenames that look like v1 → [references/v1-holdovers.md](references/v1-holdovers.md)
+- Reviewing `app/root.tsx` (document shell, `<Meta />`/`<Links />`/`<Scripts />`/`<ScrollRestoration />`, `<LiveReload />` on Vite vs Classic Compiler, root `ErrorBoundary`) → [references/root-shell.md](references/root-shell.md)
 
 ## Review Questions
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: remix-v2-routing-review
+description: Reviews Remix v2 route files for naming convention violations, missing layouts, resource-route shape, and v1 holdovers. Use when reviewing files under app/routes/ in a Remix v2 codebase.
+---
+
+# Remix v2 Routing Code Review
+
+Loaded by `review-remix-v2` (umbrella) to flag routing anti-patterns in `app/routes/` modules. See [beagle-remix-v2:remix-v2-routing](../remix-v2-routing/SKILL.md) for canonical patterns.
+
+## Quick Reference
+
+| Issue Type | Reference |
+|------------|-----------|
+| Filename smells (`index.tsx`, `__auth`, wrong escape, non-route files) | [references/route-files.md](references/route-files.md) |
+| Missing `<Outlet />`, orphan dotted segments, duplicated layout logic | [references/layouts-outlets.md](references/layouts-outlets.md) |
+| Default export on a resource, `<Link>` without `reloadDocument`, splat params | [references/resource-routes.md](references/resource-routes.md) |
+| `react-router-dom` imports, `__double` folders, v1-adapter fallback | [references/v1-holdovers.md](references/v1-holdovers.md) |
+
+## Scope
+
+This skill flags issues in:
+
+- Files under `app/routes/` (filenames, exports, imports, JSX shape)
+- `app/root.tsx` (document shell, root `<Outlet />`)
+- `remix.config.js` (entries that change route discovery: `routes()`, `ignoredRouteFiles`, `@remix-run/v1-route-convention`)
+- Any module that links to a resource route (`<Link>` usage)
+
+Out of scope: loader/action data contracts (covered by `remix-v2-data-flow-review`), form behavior (`remix-v2-forms-review`), meta/headers (`remix-v2-meta-sessions-review`).
+
+## Review Checklist
+
+- [ ] Index routes named `_index.tsx`, not `index.tsx`
+- [ ] Pathless layouts use single underscore (`_auth.tsx`), not double (`__auth/`)
+- [ ] Dotted child routes (`users.profile.tsx`) have a parent module *or* use trailing underscore (`users_.profile.tsx`)
+- [ ] Parent route modules render `<Outlet />`
+- [ ] Splat segments read `params["*"]`, never `params.splat` / `params.rest`
+- [ ] Literal dots/special chars escaped with brackets (`sitemap[.]xml.tsx`)
+- [ ] Resource routes have **no** `default` export
+- [ ] `<Link>` to a resource route uses `reloadDocument` (or is a plain `<a>`)
+- [ ] Imports come from `@remix-run/react`, not `react-router-dom`
+- [ ] Non-route files (CSS, helpers, tests) live in a folder with `route.tsx`, or are listed in `ignoredRouteFiles`
+- [ ] Trailing-underscore opt-outs only used when a parent layout actually exists to escape
+- [ ] Optional segments `($lang)` narrow `params.lang` in the loader
+
+## Valid Patterns (Do NOT Flag)
+
+- **Resource route with no default export** — this *is* the convention that makes it a resource route. Never flag.
+- **`_layout.tsx` (or any `_`-prefixed file) without `<Outlet />`** when the module is intentionally a wrapper that renders fixed UI only. Confirm by checking children — if no `*.{segment}.tsx` siblings exist, the wrapper-only shape is intentional.
+- **Files prefixed with `_` that don't appear in any URL** — pathless layouts and `_index` are supposed to be hidden from the URL.
+- **`@remix-run/v1-route-convention`** wired up in `remix.config.js` — legitimate migration adapter, not a smell on its own. Only flag if v1-style files appear *without* the adapter installed.
+- **`useLoaderData<typeof loader>()`** — type annotation, not assertion.
+- **Splat route accessing `params["*"]`** with bracket syntax — that is the only correct access pattern.
+- **Folder `app/routes/dashboard/` with `route.tsx` plus sibling `.server.ts`, `.css`, component files** — co-location is the documented pattern.
+- **Trailing underscore (`concerts_.mine.tsx`)** when a sibling `concerts.tsx` layout exists and this URL intentionally skips it.
+
+## Context-Sensitive Rules
+
+Only flag these issues when the specific context applies:
+
+| Issue | Flag ONLY IF |
+|-------|--------------|
+| `index.tsx` under `app/routes/` | Project is v2 and `@remix-run/v1-route-convention` is NOT wired in `remix.config.js` |
+| Parent module without `<Outlet />` | Sibling dotted children (`parent.*.tsx`) exist in `app/routes/` |
+| `__double` underscore folder | No v1-convention adapter is installed |
+| Trailing-underscore segment | No corresponding parent layout exists (nothing to opt out of) |
+| Default export on a module returning non-HTML | The loader/action actually returns a raw `Response` (PDF, JSON, RSS) |
+| `<Link>` to resource route | Target route has no `default` export AND `<Link>` lacks `reloadDocument` |
+
+## Hard gates (before writing findings)
+
+Run these in order. **Do not draft user-facing findings until every gate passes** for the batch you are about to report.
+
+1. **Location evidence** — **Pass:** Each issue lists a repo path (file under `app/routes/` or `remix.config.js`) and either a line range or a short verbatim quote from the file you read. Filename-only smells must quote the literal filename.
+
+2. **Exemption check** — **Pass:** For each issue, state in one line why it is *not* covered by [Valid Patterns (Do NOT Flag)](#valid-patterns-do-not-flag). Resource-route flags require explicit evidence of a `default` export or a `<Link>` without `reloadDocument`.
+
+3. **Version check** — **Pass:** Confirm the project is Remix v2 (check `package.json` for `@remix-run/react` ^2, *or* presence of v2 flat-routes filenames elsewhere in `app/routes/`). If `@remix-run/v1-route-convention` is wired in `remix.config.js`, v1 filenames (`__auth/`, `index.tsx`) are intentional — do not flag them as smells.
+
+4. **Protocol** — **Pass:** Complete the Pre-Report Verification Checklist in [review-verification-protocol](../../../beagle-core/skills/review-verification-protocol/SKILL.md) for this review.
+
+## When to Load References
+
+- Reviewing filenames under `app/routes/` → [references/route-files.md](references/route-files.md)
+- Reviewing parent modules and shared chrome → [references/layouts-outlets.md](references/layouts-outlets.md)
+- Reviewing a module that returns non-HTML, or any `<Link>` to such a module → [references/resource-routes.md](references/resource-routes.md)
+- Reviewing imports or filenames that look like v1 → [references/v1-holdovers.md](references/v1-holdovers.md)
+
+## Review Questions
+
+1. Does every parent route render `<Outlet />`, or is it a deliberate wrapper-only?
+2. Do filenames match the v2 grammar (single `_` for pathless, `_index` for index, `[...]` for escapes)?
+3. Are resource routes free of `default` exports, and do all `<Link>`s to them use `reloadDocument`?
+4. Are all router imports from `@remix-run/react` (and server helpers from `@remix-run/node`)?
+5. If v1 filenames exist, is `@remix-run/v1-route-convention` wired up — or are they accidental?
+
+## Additional Documentation
+
+- **Route file naming smells**: [references/route-files.md](references/route-files.md) — `index.tsx`, `__double` folders, wrong escape syntax, dot/underscore confusion, non-route files under `app/routes/`.
+- **Layouts and outlets**: [references/layouts-outlets.md](references/layouts-outlets.md) — pathless layout misuse, missing `<Outlet />`, orphan dotted children, duplicated layout logic.
+- **Resource routes**: [references/resource-routes.md](references/resource-routes.md) — accidental default export, `<Link>` without `reloadDocument`, splat `params["*"]` access.
+- **v1 holdovers**: [references/v1-holdovers.md](references/v1-holdovers.md) — `react-router-dom` imports, `__auth` folders, `@remix-run/v1-route-convention` as a deliberate-vs-accidental tell.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/layouts-outlets.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/layouts-outlets.md
@@ -1,0 +1,195 @@
+# Layouts and Outlets
+
+Parent route modules must render `<Outlet />` so children can mount inside them. Pathless layouts (`_auth.tsx`) wrap URLs without adding a segment. Misuse shows up as blank pages, duplicated chrome, and dotted routes whose authors *thought* there was a layout.
+
+See [beagle-remix-v2:remix-v2-routing](../../remix-v2-routing/SKILL.md) for canonical layout shape.
+
+---
+
+## Parent module missing `<Outlet />`
+
+**Pattern**: A route module that has dotted child routes (`concerts.$city.tsx`, `concerts._index.tsx`) but its parent (`concerts.tsx`) does not render `<Outlet />`.
+
+```tsx
+// app/routes/concerts.tsx — smell
+import { useLoaderData } from "@remix-run/react";
+
+export default function ConcertsLayout() {
+  const data = useLoaderData<typeof loader>();
+  return (
+    <section>
+      <nav>{/* subnav */}</nav>
+      {/* missing <Outlet /> — children never render */}
+    </section>
+  );
+}
+```
+
+**Why bad**: Without `<Outlet />`, the parent renders but children mount nowhere. `/concerts/salt-lake-city` shows the parent chrome and a blank where the city detail should be.
+
+**Fix**:
+
+```tsx
+import { Outlet } from "@remix-run/react";
+
+export default function ConcertsLayout() {
+  return (
+    <section>
+      <nav>{/* subnav */}</nav>
+      <Outlet />
+    </section>
+  );
+}
+```
+
+**Do NOT flag** when the parent module is intentionally a wrapper with fixed content and *no* sibling children exist in `app/routes/`. Check: if no `concerts.*.tsx` siblings exist, the wrapper-only shape may be deliberate (rare; usually a refactor remnant).
+
+---
+
+## Pathless layout that forgets to be a layout
+
+**Pattern**: A `_auth.tsx` module that renders standalone content with no `<Outlet />`, while sibling `_auth.login.tsx` / `_auth.signup.tsx` files exist.
+
+```tsx
+// app/routes/_auth.tsx — smell
+export default function AuthLayout() {
+  return <div className="auth-shell"><h1>Sign in</h1></div>;
+  // no Outlet — /login renders the AuthLayout but never the Login child
+}
+```
+
+**Why bad**: The pathless parent owns the URL match for `/login`, but its render output replaces the child instead of wrapping it.
+
+**Fix**:
+
+```tsx
+import { Outlet } from "@remix-run/react";
+
+export default function AuthLayout() {
+  return (
+    <div className="auth-shell">
+      <Outlet />
+    </div>
+  );
+}
+```
+
+---
+
+## Orphan dotted children with no parent module
+
+**Pattern**: Files like `users.profile.settings.tsx` exist but `users.tsx` and `users.profile.tsx` do not.
+
+```text
+app/routes/
+  users.profile.settings.tsx         # exists
+  users.tsx                          # missing
+  users.profile.tsx                  # missing
+```
+
+**Why bad**: The URL `/users/profile/settings` works, but reviewers (and the next developer) will look for a `users.tsx` layout that doesn't exist. The dotted name implies nesting that the filesystem doesn't back up.
+
+**Fix**: Either add the missing parent layouts, or use trailing-underscore segments to make the flat intent explicit:
+
+```text
+# Make nesting real
+app/routes/users.tsx
+app/routes/users.profile.tsx
+app/routes/users.profile.settings.tsx
+
+# Or make flatness explicit
+app/routes/users_.profile_.settings.tsx       → /users/profile/settings (flat)
+```
+
+---
+
+## Duplicated layout chrome in every child
+
+**Pattern**: Each child route (`dashboard.home.tsx`, `dashboard.billing.tsx`, `dashboard.team.tsx`) renders the same header/sidebar JSX inline instead of pulling it from a parent.
+
+```tsx
+// app/routes/dashboard.home.tsx — smell
+export default function DashboardHome() {
+  return (
+    <div>
+      <DashboardSidebar />        {/* duplicated */}
+      <DashboardHeader />         {/* duplicated */}
+      <main>{/* page content */}</main>
+    </div>
+  );
+}
+```
+
+**Why bad**: Layout duplication causes flash-on-navigation (the chrome unmounts and remounts between sibling routes), keyboard-focus loss, and divergence over time as one copy gets updated and others don't. The whole point of nested routes is that the parent stays mounted.
+
+**Fix**: Lift chrome into `dashboard.tsx` and render `<Outlet />`.
+
+```tsx
+// app/routes/dashboard.tsx — single source
+import { Outlet } from "@remix-run/react";
+
+export default function DashboardLayout() {
+  return (
+    <div>
+      <DashboardSidebar />
+      <DashboardHeader />
+      <main><Outlet /></main>
+    </div>
+  );
+}
+
+// app/routes/dashboard.home.tsx — child renders only its content
+export default function DashboardHome() {
+  return <h1>Home</h1>;
+}
+```
+
+---
+
+## `_index` under a pathless parent at root
+
+**Pattern**: A file named `_auth._index.tsx`.
+
+**Why bad**: This renders at `/` wrapped in the `_auth` layout — almost never what was intended. Authors usually want `_auth.login.tsx` (renders at `/login`) or a top-level `_index.tsx` outside the auth shell.
+
+**Fix**: Decide what URL you actually want.
+
+```text
+_auth._index.tsx       → /  (wrapped in AuthLayout) — usually wrong
+_auth.login.tsx        → /login (wrapped in AuthLayout)
+_index.tsx             → /  (no AuthLayout)
+```
+
+---
+
+## Index file at a URL where it conflicts with a sibling
+
+**Pattern**: Both `users.tsx` and `users._index.tsx` rendering content, where `users.tsx` does not render `<Outlet />`.
+
+**Why bad**: `users.tsx` is the layout for the `/users` segment; `users._index.tsx` is the child that renders at exactly `/users`. If the parent doesn't outlet, the index never shows.
+
+**Fix**: Parent renders `<Outlet />`, index renders the at-segment content.
+
+```tsx
+// app/routes/users.tsx
+import { Outlet } from "@remix-run/react";
+export default function UsersLayout() {
+  return <section><Outlet /></section>;
+}
+
+// app/routes/users._index.tsx
+export default function UsersIndex() {
+  return <h1>All users</h1>;
+}
+```
+
+---
+
+## Verification
+
+For each layout/outlet flag:
+
+1. Quote the relevant module(s) and confirm `<Outlet />` is absent.
+2. List the sibling files in `app/routes/` that depend on the parent.
+3. Confirm the parent isn't a deliberate wrapper-only (no children → not a layout violation).
+4. If pathless: check the URL the file actually produces against the URL the author commented.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/resource-routes.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/resource-routes.md
@@ -13,9 +13,11 @@ See [beagle-remix-v2:remix-v2-routing](../../remix-v2-routing/SKILL.md) for cano
 ```tsx
 // app/routes/reports.$id[.pdf].tsx — smell
 import type { LoaderFunctionArgs } from "@remix-run/node";
+import invariant from "tiny-invariant";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const pdf = await generateReportPDF(params.id!);
+  invariant(params.id, "id is required");
+  const pdf = await generateReportPDF(params.id);
   return new Response(pdf, { headers: { "Content-Type": "application/pdf" } });
 }
 
@@ -31,9 +33,11 @@ export default function ReportPage() {     // <-- turns it into a UI route
 ```tsx
 // app/routes/reports.$id[.pdf].tsx — correct resource route
 import type { LoaderFunctionArgs } from "@remix-run/node";
+import invariant from "tiny-invariant";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const pdf = await generateReportPDF(params.id!);
+  invariant(params.id, "id is required");
+  const pdf = await generateReportPDF(params.id);
   return new Response(pdf, { headers: { "Content-Type": "application/pdf" } });
 }
 // No default export — that is what makes this a resource route.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/resource-routes.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/resource-routes.md
@@ -1,0 +1,149 @@
+# Resource Routes
+
+A route module without a `default` export is a **resource route**: it returns raw `Response` objects (PDF, JSON, RSS, sitemap, webhook). Parent loaders do not run, no UI mounts, and `<Link>` cannot navigate to it client-side without a full document request.
+
+See [beagle-remix-v2:remix-v2-routing](../../remix-v2-routing/SKILL.md) for canonical resource-route shape.
+
+---
+
+## Accidental `default` export on a resource route
+
+**Pattern**: A module meant to serve JSON, a PDF, or a webhook target also exports a default component.
+
+```tsx
+// app/routes/reports.$id[.pdf].tsx — smell
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const pdf = await generateReportPDF(params.id!);
+  return new Response(pdf, { headers: { "Content-Type": "application/pdf" } });
+}
+
+export default function ReportPage() {     // <-- turns it into a UI route
+  return <div>Report</div>;
+}
+```
+
+**Why bad**: A default export turns the module into a UI route. Parent loaders run, the error boundary mounts, Remix expects HTML, and the raw-Response fast path is dropped. The downstream symptom is a blank page or a parse error in the browser.
+
+**Fix**: Delete the default export.
+
+```tsx
+// app/routes/reports.$id[.pdf].tsx — correct resource route
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const pdf = await generateReportPDF(params.id!);
+  return new Response(pdf, { headers: { "Content-Type": "application/pdf" } });
+}
+// No default export — that is what makes this a resource route.
+```
+
+**Do NOT flag** absence of a default export on its own. Absence *is* the convention. Only flag when a default export is present *and* the loader/action returns a non-HTML `Response`.
+
+---
+
+## `<Link>` to a resource route without `reloadDocument`
+
+**Pattern**: Standard `<Link to="/api/report.pdf">` or `<Link to="/sitemap.xml">` pointing at a resource route.
+
+```tsx
+// smell
+import { Link } from "@remix-run/react";
+
+export function DownloadButton({ id }: { id: string }) {
+  return <Link to={`/reports/${id}.pdf`}>Download</Link>;
+}
+```
+
+**Why bad**: Client-side navigation tries to fetch the resource as a Remix route module. The browser ends up with a PDF byte stream where it expected route data, producing a parse error or blank page. The user clicks the link and nothing happens.
+
+**Fix**: Use `reloadDocument` on the `<Link>` (forces a full document request) or use a plain `<a>`.
+
+```tsx
+import { Link } from "@remix-run/react";
+
+export function DownloadButton({ id }: { id: string }) {
+  return <Link reloadDocument to={`/reports/${id}.pdf`}>Download</Link>;
+}
+
+// Or:
+export function DownloadAnchor({ id }: { id: string }) {
+  return <a href={`/reports/${id}.pdf`}>Download</a>;
+}
+```
+
+---
+
+## Splat params accessed by the wrong key
+
+**Pattern**: A splat route reading `params.splat`, `params.rest`, `params.path`, or any name other than `"*"`.
+
+```tsx
+// app/routes/files.$.tsx — smell
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const path = params.splat;           // undefined — wrong key
+  return new Response(await readBlob(path), { /* … */ });
+}
+```
+
+**Why bad**: Splat values are stored under the `"*"` key in `params`, not under a name derived from the filename. `params.splat` is always `undefined`, so the resource serves nothing or 500s on the `undefined` argument.
+
+**Fix**: Bracket-access `params["*"]` and narrow before use.
+
+```tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const rest = params["*"];
+  if (!rest) throw new Response("Not found", { status: 404 });
+  return new Response(await readBlob(rest), { /* … */ });
+}
+```
+
+There is no named splat in v2 — bracket access is the only correct way.
+
+---
+
+## Relying on parent loader side effects in a resource route
+
+**Pattern**: A resource route assumes its `_auth.tsx` parent runs first and rejects unauthenticated requests, but the resource is requested directly (e.g., a `<Link reloadDocument>` or external curl).
+
+**Why bad**: Parent loaders do **not** run for resource routes. Auth checks living only in a parent `_layout.tsx` are silently skipped on `GET /api/sensitive.json`.
+
+**Fix**: Run the auth check inside the resource route's own loader (or action), not in a parent layout.
+
+```tsx
+// app/routes/api.sensitive[.]json.tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { requireUser } from "~/sessions.server";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireUser(request);     // local auth check
+  return json(await loadSensitiveDataFor(user.id));
+}
+```
+
+---
+
+## Mixing `<Form>` action with a resource-route action
+
+**Pattern**: A resource route exposes `action()` and is the target of a `<Form action="/api/webhook">`, but the form expects to revalidate parent loaders or navigate after submit.
+
+**Why bad**: Resource-route actions don't trigger parent-loader revalidation the way UI-route actions do. Forms posting to a resource route should expect a raw `Response` back, not a navigation.
+
+**Fix**: For mutations that need revalidation, post to the owning UI route's action. Reserve resource-route actions for webhooks or programmatic clients that consume the raw `Response`.
+
+---
+
+## Verification
+
+For each resource-route finding:
+
+1. Confirm the module has (or lacks) a `default` export — quote the export line.
+2. Confirm what the `loader`/`action` returns (HTML, JSON, raw Response).
+3. For `<Link>` flags: confirm the `to` target maps to a resource route (no default export) and the `<Link>` lacks `reloadDocument`.
+4. For splat flags: quote the `params.<key>` access — if it's not `params["*"]`, it's wrong.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/root-shell.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/root-shell.md
@@ -1,0 +1,107 @@
+# Root Shell Smells (`app/root.tsx`)
+
+`app/root.tsx` owns the entire document. The six elements (`<Meta />`, `<Links />`, `<Outlet />`, `<ScrollRestoration />`, `<Scripts />`, and `<LiveReload />` for Classic Compiler only) are load-bearing. Each smell below is a missing or misplaced shell element that breaks a documented Remix feature.
+
+See [beagle-remix-v2:remix-v2-routing/references/root.md](../../remix-v2-routing/references/root.md) for the canonical scaffold and the `Layout` export pattern.
+
+---
+
+## Missing `<Meta />` in `<head>`
+
+**Pattern**: `app/root.tsx` renders a `<head>` block without `<Meta />`.
+
+```tsx
+// app/root.tsx — smell
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <title>My App</title>
+        <Links />
+      </head>
+      <body>{/* ... */}</body>
+    </html>
+  );
+}
+```
+
+**Why bad**: Without `<Meta />`, every `meta` export from descendant routes is silently dropped. `<title>`, `og:`, `twitter:`, viewport, and description tags from route modules never reach the document.
+
+**Fix**: Add `<Meta />` to `<head>` (it may sit alongside hand-written tags).
+
+---
+
+## Missing `<Links />` in `<head>`
+
+**Pattern**: `app/root.tsx` omits `<Links />`.
+
+**Why bad**: Stylesheet, preload, and icon `links` exports from descendant routes never render. CSS doesn't reach the browser, and the page flashes unstyled or never styles at all.
+
+**Fix**: Include `<Links />` in `<head>`.
+
+---
+
+## Missing `<Scripts />` in `<body>`
+
+**Pattern**: `app/root.tsx` renders without `<Scripts />`.
+
+**Why bad**: The Remix runtime and route-module bundles never load. Server HTML renders, but the app never hydrates — no client loaders, no client actions, no SPA navigation, no prefetch. Forms still submit because the browser handles them natively, but everything Remix-specific is dead.
+
+**Fix**: Include `<Scripts />` in `<body>`, after `<Outlet />` and `<ScrollRestoration />`.
+
+---
+
+## Missing `<ScrollRestoration />`
+
+**Pattern**: `app/root.tsx` omits `<ScrollRestoration />` (or places it *after* `<Scripts />`).
+
+**Why bad**: Back/forward navigation doesn't restore scroll. New navigations don't reset to top. Placing it after `<Scripts />` lets hydration clobber the scroll-restore script. Place it before `<Scripts />`.
+
+**Fix**: First element in `<body>` after `<Outlet />`, before `<Scripts />`.
+
+---
+
+## Conditional `<LiveReload />` (Classic Compiler vs Vite)
+
+**Pattern A — Classic Compiler, conditionally rendered**: `{process.env.NODE_ENV === "development" && <LiveReload />}`.
+
+**Why bad**: `<LiveReload />` already no-ops in production. The conditional is dead weight and signals the author doesn't trust the framework.
+
+**Fix (Classic Compiler)**: Render `<LiveReload />` unconditionally.
+
+**Pattern B — Vite plugin, `<LiveReload />` still rendered**: The project uses `@remix-run/dev/vite` (default for new v2 apps) and `app/root.tsx` still imports and renders `<LiveReload />`.
+
+**Why bad**: `<LiveReload />` is for the Classic Compiler only. Vite has its own HMR and the Remix element is dead weight (or a runtime warning) under Vite.
+
+**Fix (Vite)**: Delete the `LiveReload` import and the `<LiveReload />` element entirely.
+
+See [routing/references/root.md](../../remix-v2-routing/references/root.md) for the Vite-vs-Classic-Compiler split.
+
+---
+
+## Root `ErrorBoundary` without document shell
+
+**Pattern**: An `ErrorBoundary` export in `app/root.tsx` that returns a bare fragment or `<div>`.
+
+```tsx
+// app/root.tsx — smell
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return <h1>Application Error</h1>;
+}
+```
+
+**Why bad**: The root `ErrorBoundary` replaces the **entire** document (it is not mounted inside `<Outlet />`). Without `<html>`, `<head>`, `<body>`, `<Meta />`, `<Links />`, `<Scripts />`, and `<ScrollRestoration />`, the error page renders unstyled, unhydrated, and without the document shell — often as a stark white page with raw text.
+
+**Fix**: Return the full document, or use the `Layout` export pattern (Remix >= 2.4) so `Layout` wraps `ErrorBoundary` automatically. See [routing/references/root.md](../../remix-v2-routing/references/root.md#layout-export-remix-v2--24).
+
+---
+
+## Verification
+
+For each root-shell finding:
+
+1. Quote the missing/misplaced element from `app/root.tsx`.
+2. Confirm the project's compiler — Classic vs Vite — by checking `vite.config.ts` or `remix.config.js`. `<LiveReload />` is correct on Classic and wrong on Vite; do not flag without confirming.
+3. Confirm Remix version. The `Layout` export is >= 2.4; on older versions the hand-rolled `Document` wrapper is the correct fix.
+4. For `ErrorBoundary` flags, confirm the boundary actually returns a fragment / partial DOM, not a full document.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/route-files.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/route-files.md
@@ -1,0 +1,155 @@
+# Route File Naming Smells
+
+Flat-routes v2 reads filenames literally: dots become URL slashes, `_` prefixes hide segments, brackets escape, and anything under `app/routes/` without a folder wrapper is treated as a route module. The smells below are violations of that grammar.
+
+See [beagle-remix-v2:remix-v2-routing](../../remix-v2-routing/SKILL.md) for the canonical filename table.
+
+---
+
+## `index.tsx` instead of `_index.tsx`
+
+**Pattern**: A file named `index.tsx` (no leading underscore) under `app/routes/` in a v2 project.
+
+**Why bad**: In v2 flat-routes, `index.tsx` is interpreted as a literal URL segment, producing `/index`. The leading underscore is what marks it as an index route. Files left over from a v1 codebase silently route to the wrong URL after upgrade.
+
+**Fix**:
+
+```text
+# Before
+app/routes/index.tsx                 → /index   (wrong)
+app/routes/concerts/index.tsx        → /concerts/index   (wrong, also v1 folder shape)
+
+# After
+app/routes/_index.tsx                → /
+app/routes/concerts._index.tsx       → /concerts
+```
+
+---
+
+## `__double` underscore folders (v1 pathless layouts)
+
+**Pattern**: A folder under `app/routes/` named `__auth/`, `__app/`, etc., containing route files.
+
+**Why bad**: v1 used double-underscore *folders* for pathless layouts (`app/routes/__auth/login.tsx`). v2 flat-routes uses a single-underscore *file* (`app/routes/_auth.tsx` + `app/routes/_auth.login.tsx`). v2's filesystem walker does not recognize the double-underscore folder convention — the routes either fail to mount or mount with the wrong URL.
+
+**Fix**:
+
+```text
+# Before (v1)
+app/routes/__auth/login.tsx          → expected /login under shared layout
+app/routes/__auth/signup.tsx
+
+# After (v2)
+app/routes/_auth.tsx                 → pathless layout module with <Outlet />
+app/routes/_auth.login.tsx           → /login   (inherits _auth)
+app/routes/_auth.signup.tsx          → /signup  (inherits _auth)
+```
+
+If the v1 tree must stay during migration, wire `@remix-run/v1-route-convention` in `remix.config.js` — see [references/v1-holdovers.md](v1-holdovers.md). Don't flag double-underscore folders when the adapter is installed.
+
+---
+
+## Wrong escape syntax for literal characters
+
+**Pattern**: Attempting to escape a literal dot, dollar, or other convention character with a backslash, quotes, or HTML entities.
+
+```text
+sitemap\.xml.tsx          # backslash — no
+"sitemap.xml".tsx         # quotes   — no
+$.cash.tsx                # trying to escape $ unprintably
+```
+
+**Why bad**: Only `[...]` brackets escape convention characters in v2. Anything else leaves the special character active — the dot becomes a path delimiter, the `$` becomes a dynamic segment.
+
+**Fix**: Wrap the literal character(s) in brackets.
+
+```text
+sitemap[.]xml.tsx                    → /sitemap.xml
+reports.$id[.pdf].tsx                → /reports/:id.pdf
+[$]bill.tsx                          → /$bill   (literal dollar sign in URL)
+```
+
+---
+
+## Dot vs underscore confusion
+
+**Pattern**: Using a dot where an underscore was meant (or vice versa), creating routes that don't match the URL the author wrote in the comment.
+
+```text
+_auth.login.tsx     → /login              (correct — pathless _auth, child login)
+_auth_login.tsx     → /_auth_login        (literal — author probably wanted /login)
+_auth/login.tsx     → ignored or broken   (v1-style folder, no route.tsx)
+auth._login.tsx     → /auth/_login        (leading underscore on child is a hidden index)
+```
+
+**Why bad**: Each character is grammar:
+- `.` = URL slash and parent nesting
+- `_` prefix = pathless (no URL contribution) or index marker
+- `_` suffix on a segment = opt-out of layout nesting
+
+Mixing them produces URLs that don't match intent and routes that miss their layout.
+
+**Fix**: Pick the right grammar. Quick guide:
+
+| Goal                                    | Filename                  | URL                |
+|-----------------------------------------|---------------------------|--------------------|
+| URL with shared layout                  | `parent.child.tsx`        | `/parent/child`    |
+| URL **without** shared layout           | `parent_.child.tsx`       | `/parent/child`    |
+| Shared layout, **no** URL segment       | `_auth.tsx` + `_auth.x.tsx` | `/x`             |
+| Index under a layout                    | `parent._index.tsx`       | `/parent`          |
+
+---
+
+## Non-route files directly under `app/routes/`
+
+**Pattern**: CSS, server-only helpers, test files, or component files placed at `app/routes/something.css`, `app/routes/utils.server.ts`, `app/routes/Chart.test.tsx`, etc.
+
+**Why bad**: Remix's filesystem walker treats every file in `app/routes/` as a route module unless told otherwise. Non-route files surface as build warnings, mount as broken routes, or land at unexpected URLs.
+
+**Fix**: Either move into a folder with a `route.tsx`, or list them in `ignoredRouteFiles`.
+
+```text
+# Folder convention — only route.tsx becomes a route
+app/routes/dashboard/
+  route.tsx
+  queries.server.ts        # not a route
+  Chart.tsx                # not a route
+  Chart.test.tsx           # not a route
+```
+
+```js
+// remix.config.js — ignore by glob
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  ignoredRouteFiles: ["**/.*", "**/*.css", "**/*.test.*", "**/*.server.*"],
+};
+```
+
+---
+
+## Trailing-underscore opt-out with no layout to escape
+
+**Pattern**: A file named `admin_.users.tsx` when no sibling `admin.tsx` (parent layout) exists.
+
+**Why bad**: The trailing underscore is meaningful only when there is a parent layout to skip. Without one, the underscore is noise — reviewers waste time looking for the layout it's escaping. Also signals the author misunderstands the grammar, which often hides a deeper routing bug.
+
+**Fix**: Drop the trailing underscore. Or, if a parent layout *should* exist, add it (`admin.tsx`).
+
+```text
+# Smell
+app/routes/admin_.users.tsx          # no admin.tsx exists
+
+# Fix
+app/routes/admin.users.tsx
+```
+
+---
+
+## Verification
+
+For each route-file smell:
+
+1. List the path (`app/routes/<file>`).
+2. Quote the literal filename.
+3. Confirm v2 (see Hard gate 3 in [SKILL.md](../SKILL.md)).
+4. Cross-check against `remix.config.js` — `@remix-run/v1-route-convention` and `ignoredRouteFiles` change which files are legitimate.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/route-files.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/route-files.md
@@ -56,10 +56,10 @@ If the v1 tree must stay during migration, wire `@remix-run/v1-route-convention`
 ```text
 sitemap\.xml.tsx          # backslash — no
 "sitemap.xml".tsx         # quotes   — no
-$.cash.tsx                # trying to escape $ unprintably
+$bill.tsx                 # author meant literal /$bill but $ is a dynamic param marker
 ```
 
-**Why bad**: Only `[...]` brackets escape convention characters in v2. Anything else leaves the special character active — the dot becomes a path delimiter, the `$` becomes a dynamic segment.
+**Why bad**: Only `[...]` brackets escape convention characters in v2. Anything else leaves the special character active — the dot becomes a path delimiter, the `$` becomes a dynamic segment (`$bill.tsx` matches `/anything` and stores it under `params.bill`).
 
 **Fix**: Wrap the literal character(s) in brackets.
 
@@ -68,6 +68,8 @@ sitemap[.]xml.tsx                    → /sitemap.xml
 reports.$id[.pdf].tsx                → /reports/:id.pdf
 [$]bill.tsx                          → /$bill   (literal dollar sign in URL)
 ```
+
+Splat misuse (`$.tsx` placed somewhere it shouldn't be) is a separate smell — it is the *correct* escape for "catch the rest", not a literal-character problem. See [resource-routes.md](resource-routes.md) for splat-key errors.
 
 ---
 
@@ -120,10 +122,12 @@ app/routes/dashboard/
 ```js
 // remix.config.js — ignore by glob
 /** @type {import('@remix-run/dev').AppConfig} */
-module.exports = {
+export default {
   ignoredRouteFiles: ["**/.*", "**/*.css", "**/*.test.*", "**/*.server.*"],
 };
 ```
+
+Vite-based v2 projects use `vite.config.ts` with the Remix Vite plugin instead of `remix.config.js`.
 
 ---
 
@@ -141,6 +145,33 @@ app/routes/admin_.users.tsx          # no admin.tsx exists
 
 # Fix
 app/routes/admin.users.tsx
+```
+
+---
+
+## Optional segments `($lang)` without narrowing in the loader
+
+**Pattern**: A route uses an optional segment like `($lang)._index.tsx` and the loader uses `params.lang` without checking for `undefined`.
+
+```tsx
+// app/routes/($lang)._index.tsx — smell
+export async function loader({ params }: LoaderFunctionArgs) {
+  const messages = await loadMessages(params.lang);   // undefined on /
+  return json(messages);
+}
+```
+
+**Why bad**: Optional segments are *optional* — `params.lang` is `string | undefined`. On `/` (no lang), it is `undefined`; on `/en`, it is `"en"`. Passing `undefined` downstream silently produces wrong data, a 500, or a redirect loop.
+
+**Fix**: Narrow before use — default, redirect, or 404.
+
+```tsx
+// app/routes/($lang)._index.tsx — correct
+export async function loader({ params }: LoaderFunctionArgs) {
+  const lang = params.lang ?? "en";
+  const messages = await loadMessages(lang);
+  return json(messages);
+}
 ```
 
 ---

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/v1-holdovers.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/v1-holdovers.md
@@ -35,8 +35,9 @@ Allowed exception: importing types like `Path` from `react-router-dom` is someti
 ```text
 app/routes/__auth/login.tsx          # v1 pathless layout shape
 app/routes/__auth/signup.tsx
-app/routes/__auth.tsx                # the layout module
 ```
+
+(v1 used `__auth/` as a *folder* name. A `.tsx` file literally named `__auth.tsx` at the routes root is a malformed mix of v1 and v2 grammar — it's neither a v1 pathless layout nor a v2 pathless layout. Treat it as a typo for `_auth.tsx`.)
 
 **Why bad**: v1's double-underscore-folder convention is not recognized by v2 flat-routes. The walker either ignores the folder or mounts files at wrong URLs.
 
@@ -104,7 +105,7 @@ export default {
 
 **Pattern**: Code uses `useTransition` (v1) instead of `useNavigation` (v2), or `useFetchers` semantics that assume v1 behavior.
 
-**Why bad**: `useTransition` was renamed `useNavigation` in v2 and its return shape changed (`state` is now `"idle" | "loading" | "submitting"`). Code copied from v1 docs or older blog posts will type-check against React's `useTransition` (different API entirely) or silently misbehave.
+**Why bad**: v2 renamed `useTransition` to `useNavigation` and removed the `type` and `submission` fields. The `state` values (`"idle" | "submitting" | "loading"`) are unchanged from v1. Code copied from v1 docs or older blog posts will type-check against React's `useTransition` (a different API entirely) or silently misbehave when it reaches for the removed `type`/`submission` properties.
 
 **Fix**:
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/v1-holdovers.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing-review/references/v1-holdovers.md
@@ -1,0 +1,153 @@
+# v1 Holdovers
+
+Remix v2 re-exports its router surface from `@remix-run/react`. Imports from `react-router-dom`, double-underscore folders, and v1 file shapes are nearly always migration leftovers that bypass Remix's loader/action wiring. The v1-convention adapter is legitimate when wired explicitly — flag it only when its presence is inconsistent with the rest of the tree.
+
+See [beagle-remix-v2:remix-v2-routing](../../remix-v2-routing/SKILL.md) for canonical v2 imports and filename grammar.
+
+---
+
+## Importing from `react-router-dom`
+
+**Pattern**: A route module or component imports `Outlet`, `Link`, `useLoaderData`, `useParams`, or any hook from `react-router-dom` in a Remix v2 project.
+
+```tsx
+// smell
+import { Outlet, Link, useParams } from "react-router-dom";
+```
+
+**Why bad**: Remix v2 wraps React Router with loader/action wiring, type inference for `useLoaderData<typeof loader>()`, and SSR-aware navigation. Importing the underlying `react-router-dom` package bypasses Remix's wiring — types break, loaders don't connect, and SSR hydration mismatches surface at runtime.
+
+**Fix**:
+
+```tsx
+import { Outlet, Link, useParams, useLoaderData } from "@remix-run/react";
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or /cloudflare, /deno
+```
+
+Allowed exception: importing types like `Path` from `react-router-dom` is sometimes necessary when `@remix-run/react` doesn't re-export them. Flag value imports; check type imports against the actual export surface before flagging.
+
+---
+
+## `__double` underscore folders left from v1
+
+**Pattern**: Folders under `app/routes/` named `__auth/`, `__app/`, `__marketing/`, with route files inside.
+
+```text
+app/routes/__auth/login.tsx          # v1 pathless layout shape
+app/routes/__auth/signup.tsx
+app/routes/__auth.tsx                # the layout module
+```
+
+**Why bad**: v1's double-underscore-folder convention is not recognized by v2 flat-routes. The walker either ignores the folder or mounts files at wrong URLs.
+
+**Fix**: Rename to single-underscore files.
+
+```text
+app/routes/_auth.tsx                 → pathless layout (no URL)
+app/routes/_auth.login.tsx           → /login
+app/routes/_auth.signup.tsx          → /signup
+```
+
+**Do NOT flag** when `@remix-run/v1-route-convention` is installed and wired (see below).
+
+---
+
+## `index.tsx` left from v1
+
+**Pattern**: Files named `index.tsx` (no leading `_`) under `app/routes/` or inside a v1-style folder.
+
+```text
+app/routes/index.tsx                 # v1 root index
+app/routes/dashboard/index.tsx       # v1 nested index
+```
+
+**Why bad**: v2 reads these as literal `/index` segments. The home page mysteriously moves from `/` to `/index` after the upgrade.
+
+**Fix**:
+
+```text
+app/routes/_index.tsx                → /
+app/routes/dashboard._index.tsx      → /dashboard
+```
+
+---
+
+## `@remix-run/v1-route-convention` as a deliberate-vs-accidental tell
+
+**Pattern**: The package appears in `package.json` and `remix.config.js` wires the v1 convention:
+
+```js
+// remix.config.js
+import { createRoutesFromFolders } from "@remix-run/v1-route-convention";
+
+/** @type {import('@remix-run/dev').AppConfig} */
+export default {
+  routes(defineRoutes) {
+    return createRoutesFromFolders(defineRoutes);
+  },
+};
+```
+
+**This is not automatically a smell.** It is the documented migration adapter — a team can legitimately keep a v1 nested-folder tree alive while shipping new v2 flat-routes alongside it.
+
+**Flag only when**:
+
+- The adapter is present **but no v1-style files exist** anywhere in `app/routes/` — the package is dead weight; remove it from `package.json` and `remix.config.js`.
+- The adapter is **absent** but v1-style files (`__auth/`, `index.tsx`) exist — those files won't route correctly; either delete them or install the adapter.
+- Mixed grammars *within the same feature folder* — e.g., `app/routes/__auth/login.tsx` (v1) alongside `app/routes/_auth.signup.tsx` (v2). Pick one per subtree.
+
+**Fix**: Either commit to v2 grammar (delete the adapter, rename files) or commit to v1 (keep the adapter, rename strays back to folders). Don't half-migrate.
+
+---
+
+## v1-style hooks and helpers
+
+**Pattern**: Code uses `useTransition` (v1) instead of `useNavigation` (v2), or `useFetchers` semantics that assume v1 behavior.
+
+**Why bad**: `useTransition` was renamed `useNavigation` in v2 and its return shape changed (`state` is now `"idle" | "loading" | "submitting"`). Code copied from v1 docs or older blog posts will type-check against React's `useTransition` (different API entirely) or silently misbehave.
+
+**Fix**:
+
+```tsx
+// v1
+import { useTransition } from "@remix-run/react";
+const transition = useTransition();
+if (transition.state === "submitting") { /* … */ }
+
+// v2
+import { useNavigation } from "@remix-run/react";
+const navigation = useNavigation();
+if (navigation.state === "submitting") { /* … */ }
+```
+
+Note: React's own `useTransition` from `react` is a different hook entirely — don't conflate.
+
+---
+
+## `json()` / `redirect()` imported from `@remix-run/react`
+
+**Pattern**: Server helpers imported from the React entry instead of the runtime entry.
+
+```tsx
+// smell
+import { json, redirect } from "@remix-run/react";
+```
+
+**Why bad**: `json` and `redirect` are server runtime helpers and live in the runtime package (`@remix-run/node`, `/cloudflare`, `/deno`). Importing them from `@remix-run/react` either fails to resolve or pulls server code into the client bundle.
+
+**Fix**: Match the runtime adapter the app uses.
+
+```tsx
+import { json, redirect } from "@remix-run/node";
+```
+
+---
+
+## Verification
+
+For each v1-holdover flag:
+
+1. Quote the offending import line or filename.
+2. Confirm the project is v2 (`@remix-run/react` ^2 in `package.json`).
+3. Check `remix.config.js` for `@remix-run/v1-route-convention` — if wired, v1 filenames are intentional.
+4. For import flags: confirm the symbol exists in the suggested replacement entry (`@remix-run/react` vs `@remix-run/node`).

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: remix-v2-routing
+description: Remix v2 routing patterns. Use when implementing flat-routes v2 conventions, route file naming, nested layouts, resource routes, or root.tsx scaffolding. Triggers on _layout.tsx, _index.tsx, $param, app/routes/, @remix-run/dev, defineRoutes, <Outlet /> in route modules.
+---
+
+# Remix v2 Routing
+
+## Quick Reference
+
+**Flat-routes v2 filename rules** (all files live in `app/routes/`):
+
+```text
+_index.tsx                 → /
+concerts.tsx               → /concerts                (layout module)
+concerts._index.tsx        → /concerts                (renders under layout)
+concerts.$city.tsx         → /concerts/:city          params.city
+concerts.trending.tsx      → /concerts/trending
+_auth.tsx + _auth.login.tsx → /login (pathless layout, no URL segment)
+files.$.tsx                → /files/*                 params["*"]
+($lang)._index.tsx         → / and /:lang             (optional segment)
+sitemap[.]xml.tsx          → /sitemap.xml             (escape literal)
+concerts_.mine.tsx         → /concerts/mine           (opts out of layout)
+dashboard/route.tsx        → /dashboard               (folder + route.tsx)
+reports.$id[.pdf].tsx      → /reports/:id.pdf         (no default export = resource)
+```
+
+**Imports — always use `@remix-run/react`, never `react-router-dom`**:
+
+```tsx
+import { Outlet, Link, useLoaderData, useParams } from "@remix-run/react";
+import type { LoaderFunctionArgs } from "@remix-run/node"; // or /cloudflare, /deno
+```
+
+## File Naming Conventions
+
+Dots in filenames create URL slashes and parent/child nesting. Underscore prefix marks pathless segments (`_auth.tsx`) and index routes (`_index.tsx`). Trailing underscore (`concerts_.mine.tsx`) opts out of layout nesting while keeping the URL nested. Brackets escape literal characters: `sitemap[.]xml.tsx`. Splat is the single dollar sign: `$.tsx` exposes the rest of the path under `params["*"]`. Optional segments are wrapped in parens: `($lang)`.
+
+See [references/conventions.md](references/conventions.md) for the full table and edge cases.
+
+## Nested Layouts
+
+A parent module (`concerts.tsx`) renders `<Outlet />`; child routes (`concerts.$city.tsx`, `concerts._index.tsx`) mount inside it automatically based on the dot-delimited filename.
+
+```tsx
+// app/routes/concerts.tsx
+import { Outlet } from "@remix-run/react";
+
+export default function ConcertsLayout() {
+  return (
+    <section>
+      <nav>{/* concerts subnav */}</nav>
+      <Outlet />
+    </section>
+  );
+}
+```
+
+```tsx
+// app/routes/concerts._index.tsx  (renders at exactly /concerts)
+export default function ConcertsIndex() {
+  return <h1>Browse concerts</h1>;
+}
+```
+
+For a layout with **no** URL contribution, prefix with a single underscore:
+
+```tsx
+// app/routes/_auth.tsx          → wraps /login, /signup; no URL segment
+// app/routes/_auth.login.tsx    → /login   (inherits _auth layout)
+// app/routes/_auth.signup.tsx   → /signup
+```
+
+## Dynamic Segments and Splats
+
+`$name` captures a single segment; `$.tsx` captures the rest of the path. Loader receives values via `params`:
+
+```tsx
+// app/routes/concerts.$city.tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  if (!params.city) throw new Response("Not found", { status: 404 });
+  return json({ city: params.city });
+}
+
+export default function City() {
+  const { city } = useLoaderData<typeof loader>();
+  return <h1>{city}</h1>;
+}
+```
+
+Splat values live under `"*"` — there is no `params.splat`:
+
+```tsx
+// app/routes/files.$.tsx
+export async function loader({ params }: LoaderFunctionArgs) {
+  const rest = params["*"]; // bracket access only
+  return new Response(await readBlob(rest), { headers: { "Content-Type": "application/octet-stream" } });
+}
+```
+
+## Root Module
+
+`app/root.tsx` is the only required route. It owns the document shell and must render `<Meta />`, `<Links />`, `<Outlet />`, `<ScrollRestoration />`, `<Scripts />`, and (during dev) `<LiveReload />`. See [references/root.md](references/root.md).
+
+## Resource Routes
+
+A route module without a `default` export is a **resource route** — it returns raw `Response` objects (PDF, JSON, RSS, webhooks). Parent loaders do **not** run, and `<Link>` must use `reloadDocument` (or be replaced with `<a>`) to trigger a real document request. See [references/resource-routes.md](references/resource-routes.md).
+
+## Gates (decision sequencing)
+
+Answer **in order**. **Pass** means the condition is true; pick the answer on the same line and **stop**.
+
+### Layout vs flat URL
+
+1. **Should this URL share UI (nav, breadcrumbs, sidebar) with a parent path**?
+   - **Pass →** Use dot-delimited nesting (`concerts.$city.tsx` under `concerts.tsx`). **Stop.**
+   - **Fail →** Step 2.
+2. **Does the URL just *happen* to be nested but should render standalone**?
+   - **Pass →** Trailing underscore (`concerts_.mine.tsx`). **Stop.**
+   - **Fail →** Step 3.
+3. **Need a wrapper layout but no parent URL segment**?
+   - **Pass →** Single-underscore pathless parent (`_auth.tsx` + `_auth.login.tsx`). **Stop.**
+
+### UI route vs resource route
+
+1. **Does this URL ever render HTML to a user**?
+   - **Pass →** Export a `default` component. UI route. **Stop.**
+   - **Fail →** Step 2.
+2. **Returns JSON, PDF, RSS, sitemap, webhook, or other raw `Response`**?
+   - **Pass →** Omit `default` export — module becomes a resource route. Use `reloadDocument` on any `<Link>` pointing to it. **Stop.**
+
+### `_index.tsx` vs `index.tsx`
+
+1. **On Remix v2 with flat-routes**?
+   - **Pass →** `_index.tsx` (leading underscore). **Stop.**
+   - **Fail →** Step 2 — you're on v1 (or using the v1 fallback adapter).
+2. **Need to keep a v1 nested-folder tree alive**?
+   - **Pass →** Install `@remix-run/v1-route-convention` and wire it in `remix.config.js`. See [references/v1-migration.md](references/v1-migration.md). **Stop.**
+
+## Additional Documentation
+
+- **Conventions**: See [references/conventions.md](references/conventions.md) for the full filename grammar (`_index`, `_layout`, `$param`, splat, optional, escape, folder + `route.tsx`, trailing underscore).
+- **Root module**: See [references/root.md](references/root.md) for the `root.tsx` scaffold and the required document elements.
+- **Resource routes**: See [references/resource-routes.md](references/resource-routes.md) for non-HTML responses, the no-`default`-export rule, parent-loader skipping, and `reloadDocument`.
+- **v1 → v2 migration**: See [references/v1-migration.md](references/v1-migration.md) for differences from v1 (`__double` underscore folders, `index.tsx`, `@remix-run/v1-route-convention`, `ignoredRouteFiles`).
+
+## v1 vs v2 Convention Comparison
+
+| Concern              | v1 (nested folders)              | v2 (flat routes)              |
+|----------------------|----------------------------------|-------------------------------|
+| Index route          | `index.tsx`                      | `_index.tsx`                  |
+| Pathless layout      | `__auth/` (double underscore)    | `_auth.tsx` (single)          |
+| Nested URL           | folder hierarchy                 | dot delimiter in filename     |
+| Dynamic segment      | `$param.tsx`                     | `$param.tsx` (unchanged)      |
+| Splat                | `$.tsx`                          | `$.tsx` (unchanged)           |
+| Escape literal       | n/a                              | `[.]`, `[]` brackets          |
+| Opt-out of layout    | move out of folder               | trailing `_` (`foo_.bar.tsx`) |
+| Co-location          | adjacent files in folder         | `feature/route.tsx` + siblings|
+| Fallback adapter     | n/a                              | `@remix-run/v1-route-convention` |

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remix-v2-routing
-description: Remix v2 routing patterns. Use when implementing flat-routes v2 conventions, route file naming, nested layouts, resource routes, or root.tsx scaffolding. Triggers on _layout.tsx, _index.tsx, $param, app/routes/, @remix-run/dev, defineRoutes, <Outlet /> in route modules.
+description: Remix v2 routing patterns. Use when implementing flat-routes v2 conventions, route file naming, nested layouts, resource routes, or root.tsx scaffolding. Triggers on _<name>.tsx (pathless layout), _index.tsx, $param, app/routes/, @remix-run/dev, defineRoutes, <Outlet /> in route modules.
 ---
 
 # Remix v2 Routing
@@ -11,13 +11,13 @@ description: Remix v2 routing patterns. Use when implementing flat-routes v2 con
 
 ```text
 _index.tsx                 → /
-concerts.tsx               → /concerts                (layout module)
+concerts.tsx               → /concerts                (acts as layout when dotted children exist; otherwise leaf for /concerts)
 concerts._index.tsx        → /concerts                (renders under layout)
 concerts.$city.tsx         → /concerts/:city          params.city
 concerts.trending.tsx      → /concerts/trending
 _auth.tsx + _auth.login.tsx → /login (pathless layout, no URL segment)
 files.$.tsx                → /files/*                 params["*"]
-($lang)._index.tsx         → / and /:lang             (optional segment)
+($lang)._index.tsx         → / and /en (or /fr etc.) — optional segment
 sitemap[.]xml.tsx          → /sitemap.xml             (escape literal)
 concerts_.mine.tsx         → /concerts/mine           (opts out of layout)
 dashboard/route.tsx        → /dashboard               (folder + route.tsx)
@@ -115,6 +115,9 @@ Answer **in order**. **Pass** means the condition is true; pick the answer on th
 
 ### Layout vs flat URL
 
+0. **Is there shared chrome at all (nav, breadcrumbs, sidebar) at this level**?
+   - **Fail →** Use plain dotted segments (`about.tsx`, `pricing.tsx`); no layout module needed. **Stop.**
+   - **Pass →** Step 1.
 1. **Should this URL share UI (nav, breadcrumbs, sidebar) with a parent path**?
    - **Pass →** Use dot-delimited nesting (`concerts.$city.tsx` under `concerts.tsx`). **Stop.**
    - **Fail →** Step 2.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/conventions.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/conventions.md
@@ -1,0 +1,158 @@
+# Flat-Routes v2 Conventions
+
+Remix v2 uses a **flat-file** routing convention. Every file under `app/routes/` becomes a route module; the filename itself encodes URL structure, nesting, and special behavior. Dots delimit URL segments, underscores mark pathless/index roles, dollar signs introduce dynamic segments, and brackets escape literal characters.
+
+## Convention Table
+
+| Convention            | Syntax                              | URL / Behavior                                     |
+|-----------------------|--------------------------------------|----------------------------------------------------|
+| Index route           | `_index.tsx`, `concerts._index.tsx` | Renders at the parent's exact URL                  |
+| Dot delimiter         | `concerts.trending.tsx`             | `/concerts/trending` (also creates parent nesting) |
+| Pathless layout       | `_auth.tsx`, `_auth.login.tsx`      | Shared layout with no URL segment                  |
+| Dynamic segment       | `concerts.$city.tsx`                | `params.city`                                      |
+| Splat (catch-all)     | `$.tsx`, `files.$.tsx`              | `params["*"]` (matches incl. slashes)              |
+| Optional segment      | `($lang)._index.tsx`                | Matches `/` and `/en`; `params.lang` may be undefined |
+| Escape literal        | `sitemap[.]xml.tsx`                 | `/sitemap.xml`                                     |
+| Folder route          | `dashboard/route.tsx`               | `/dashboard`; other files in the folder are inert  |
+| Opt-out of nesting    | `concerts_.mine.tsx`                | `/concerts/mine`, but does NOT inherit layout      |
+| Resource route        | no `default` export                 | Returns non-HTML `Response`                        |
+
+## Index Routes
+
+`_index.tsx` (with the leading underscore) is the v2 index marker. It renders at the **parent's** URL — not its own. So:
+
+```text
+app/routes/
+  _index.tsx              → /
+  concerts.tsx            → /concerts  (layout)
+  concerts._index.tsx     → /concerts  (inside the layout's <Outlet />)
+```
+
+A plain `index.tsx` (no underscore) in v2 is treated as a literal `/index` URL. Leftover `index.tsx` files post-upgrade silently produce wrong URLs.
+
+## Dot Delimiter and Nested Layouts
+
+Each dot in a filename creates both a URL slash and a parent/child relationship. The longest matching prefix wins as the parent layout:
+
+```text
+app/routes/
+  concerts.tsx            → /concerts        (parent — renders <Outlet />)
+  concerts._index.tsx     → /concerts        (child)
+  concerts.$city.tsx      → /concerts/:city  (child)
+  concerts.trending.tsx   → /concerts/trending
+```
+
+If a deeply dotted file has no parent module (e.g. `users.profile.settings.tsx` but no `users.tsx` or `users.profile.tsx`), the route still works — it just has no layout. That can confuse reviewers, so add the parent module or rename with trailing underscores to make the flat intent explicit.
+
+## Pathless Layouts (`_name`)
+
+A single leading underscore makes the segment **pathless** — it adds layout nesting without contributing to the URL:
+
+```text
+app/routes/
+  _auth.tsx               (no URL segment; renders <Outlet />)
+  _auth.login.tsx         → /login    (inherits _auth)
+  _auth.signup.tsx        → /signup   (inherits _auth)
+```
+
+```tsx
+// app/routes/_auth.tsx
+import { Outlet } from "@remix-run/react";
+
+export default function AuthLayout() {
+  return <div className="auth-shell"><Outlet /></div>;
+}
+```
+
+Watch out: `_auth._index.tsx` renders at `/` with the auth layout — almost never what was intended. Watch for accidental URL collisions when combining pathless parents with `_index`.
+
+## Dynamic Segments (`$name`)
+
+A segment beginning with `$` captures the URL value under that key in `params`:
+
+```tsx
+// app/routes/concerts.$city.tsx  →  /concerts/salt-lake-city
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  // params.city is `string | undefined` — narrow before use
+  if (!params.city) throw new Response("Not found", { status: 404 });
+  return { city: params.city };
+}
+```
+
+## Splat Route (`$.tsx`)
+
+A literal `$` (no name) catches the rest of the URL, including embedded slashes. The value lives under the `"*"` key, not under `splat` or `rest`:
+
+```tsx
+// app/routes/files.$.tsx   →  /files/anything/here/even/slashes
+export async function loader({ params }: LoaderFunctionArgs) {
+  const path = params["*"]; // bracket access only — there is no named splat
+  return new Response(await readBlob(path), {
+    headers: { "Content-Type": "application/octet-stream" },
+  });
+}
+```
+
+## Optional Segments (`(segment)`)
+
+Wrapping a segment in parentheses makes it optional:
+
+```text
+app/routes/($lang)._index.tsx   matches  /  and  /en
+```
+
+The key is always present in `params` — just possibly `undefined`. Don't assume it's omitted from the object. If zero-arg and one-arg behavior diverge significantly, prefer two explicit routes over one optional segment.
+
+## Escaping Literal Characters
+
+Only square brackets escape convention characters. Backslashes and quotes do **not** work:
+
+```text
+sitemap[.]xml.tsx           → /sitemap.xml
+reports.$id[.pdf].tsx       → /reports/:id.pdf
+```
+
+Without the brackets, the dot becomes a nesting delimiter, and `sitemap.xml.tsx` would produce `/sitemap/xml`.
+
+## Folder-Based Co-location
+
+You can promote a folder to a route by placing `route.tsx` inside it. Every other file in the folder is **not** a route — it is colocated source the route imports:
+
+```text
+app/routes/
+  dashboard/
+    route.tsx              ← becomes the route module (/dashboard)
+    queries.server.ts      ← NOT a route
+    Chart.tsx              ← NOT a route
+```
+
+Without a `route.tsx`, the folder is ignored entirely. This pattern keeps server helpers, components, and tests next to the route module without polluting the URL space.
+
+## Opt-Out of Layout Nesting (Trailing `_`)
+
+A trailing underscore on a segment keeps the URL nested but **skips** layout inheritance:
+
+```text
+app/routes/
+  concerts.tsx             → /concerts          (layout)
+  concerts._index.tsx      → /concerts          (uses layout)
+  concerts.$city.tsx       → /concerts/:city    (uses layout)
+  concerts_.mine.tsx       → /concerts/mine     (does NOT use layout)
+```
+
+Use sparingly: a trailing underscore signals to readers that you're escaping a parent layout that exists. Don't add it when there's no parent layout to escape — it just creates noise.
+
+## Resource Routes
+
+A route module with **no** `default` export becomes a resource route — it returns a raw `Response` (PDF, JSON, RSS, webhook target) rather than HTML. See [resource-routes.md](resource-routes.md) for full coverage.
+
+## Common Mistakes
+
+- Using v1 `__double` underscore folders or plain `index.tsx` — both silently break in v2.
+- Splat reader writing `params.splat` instead of `params["*"]`.
+- Escaping a dot with a backslash (`sitemap\.xml.tsx`) instead of brackets.
+- Trailing underscore on a route whose parent doesn't exist — pure noise.
+- Importing `Outlet`/`Link`/`useLoaderData` from `react-router-dom` instead of `@remix-run/react`.
+- Putting CSS, server helpers, or test files directly under `app/routes/` without folder convention — they get treated as routes. Either move into a `feature/` folder or add `ignoredRouteFiles` to `remix.config.js`.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/resource-routes.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/resource-routes.md
@@ -1,0 +1,119 @@
+# Resource Routes
+
+A **resource route** is a route module that returns a raw HTTP `Response` instead of HTML. PDFs, sitemaps, RSS feeds, JSON APIs, OAuth callbacks, webhooks, and file downloads are all resource routes.
+
+## The Defining Rule: No `default` Export
+
+A route becomes a resource route when its module has **no `default` export**. That single fact controls everything else about its behavior — there's no decorator, no config flag, no naming convention. The presence or absence of `export default function` is the switch.
+
+```tsx
+// app/routes/reports.$id[.pdf].tsx   →   /reports/42.pdf
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const pdf = await generateReportPDF(params.id!);
+  return new Response(pdf, {
+    status: 200,
+    headers: { "Content-Type": "application/pdf" },
+  });
+}
+
+// NOTE: no `export default` — this is what makes it a resource route.
+```
+
+If you add a default export — even an empty one — Remix treats this as a UI route and the resource-route fast path disappears.
+
+## What Changes When There's No Default Export
+
+| Behavior              | UI route (default export) | Resource route (no default) |
+|-----------------------|---------------------------|-----------------------------|
+| Response type         | HTML document             | Raw `Response`              |
+| Parent loaders run    | Yes                       | **No**                      |
+| `ErrorBoundary` mount | Yes                       | No (errors propagate)       |
+| `<Link>` navigation   | Client-side               | Requires `reloadDocument`   |
+| Meta / Links / Scripts| Injected                  | Not injected                |
+| Hydration             | Yes                       | N/A                         |
+
+The most important entry: **parent loaders are skipped**. A GET to a resource route does not invoke ancestor loaders. Auth checks that live in a `_layout.tsx` parent will not run. Re-check auth inside the resource route's own loader.
+
+## Linking to Resource Routes
+
+A normal `<Link>` tries to fetch the route the way it would fetch any other Remix route. For a resource route, that yields a parse error or a blank page because Remix is expecting a route-shaped response. Two valid options:
+
+```tsx
+import { Link } from "@remix-run/react";
+
+// 1. Force a full document request via Remix's Link
+<Link reloadDocument to="/reports/42.pdf">Download</Link>
+
+// 2. Or just use a plain anchor
+<a href="/reports/42.pdf">Download</a>
+```
+
+`reloadDocument` tells Remix: don't client-route this — let the browser do a regular navigation, which is what binary responses need.
+
+## Example: Sitemap
+
+```tsx
+// app/routes/sitemap[.]xml.tsx   →   /sitemap.xml
+import type { LoaderFunctionArgs } from "@remix-run/node";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const xml = await buildSitemap(url.origin);
+  return new Response(xml, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/xml",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}
+```
+
+Note the `[.]` bracket-escape on the filename so the dot is treated as a literal character, not a URL-segment delimiter.
+
+## Example: JSON API Endpoint
+
+```tsx
+// app/routes/api.users.$id.tsx
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+
+export async function loader({ params, request }: LoaderFunctionArgs) {
+  await requireApiKey(request);                // parent loaders DID NOT run
+  const user = await getUser(params.id!);
+  if (!user) throw new Response("Not found", { status: 404 });
+  return json(user);
+}
+```
+
+`json()` from `@remix-run/node` is a thin wrapper over `new Response(JSON.stringify(...), { headers: { "Content-Type": "application/json" } })` — use it freely in resource routes.
+
+## Example: Webhook Receiver (Action Only)
+
+A resource route can export only `action` if it's purely a write endpoint:
+
+```tsx
+// app/routes/webhooks.stripe.tsx
+import type { ActionFunctionArgs } from "@remix-run/node";
+
+export async function action({ request }: ActionFunctionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+  const event = await verifyStripeSignature(request);
+  await handleStripeEvent(event);
+  return new Response(null, { status: 204 });
+}
+```
+
+No `loader`, no `default` export — GETs will 405 from Remix's default method handling.
+
+## Common Mistakes
+
+- **Default export on a JSON/PDF/webhook route**: Turns it into a UI route. Parent loaders run, an `ErrorBoundary` mounts, Remix expects HTML. Delete the default export.
+- **`<Link to="/api/foo.pdf">`** without `reloadDocument`: Client navigation tries to parse the binary as a route module. Returns a parse error or blank page.
+- **Relying on auth in a parent layout's loader**: Parent loaders don't run for resource routes. Re-do the auth check inline.
+- **Forgetting the bracket escape on dotted URLs**: `sitemap.xml.tsx` produces `/sitemap/xml`, not `/sitemap.xml`. Use `sitemap[.]xml.tsx`.
+- **Returning a plain string or object**: Always return a `Response` (or `json(...)`). Returning a string yields `Content-Type: text/html` and a status the browser may not handle correctly for non-HTML payloads.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/resource-routes.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/resource-routes.md
@@ -9,9 +9,11 @@ A route becomes a resource route when its module has **no `default` export**. Th
 ```tsx
 // app/routes/reports.$id[.pdf].tsx   →   /reports/42.pdf
 import type { LoaderFunctionArgs } from "@remix-run/node";
+import invariant from "tiny-invariant";
 
 export async function loader({ params }: LoaderFunctionArgs) {
-  const pdf = await generateReportPDF(params.id!);
+  invariant(params.id, "id is required");
+  const pdf = await generateReportPDF(params.id);
   return new Response(pdf, {
     status: 200,
     headers: { "Content-Type": "application/pdf" },
@@ -79,10 +81,12 @@ Note the `[.]` bracket-escape on the filename so the dot is treated as a literal
 // app/routes/api.users.$id.tsx
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import { json } from "@remix-run/node";
+import invariant from "tiny-invariant";
 
 export async function loader({ params, request }: LoaderFunctionArgs) {
   await requireApiKey(request);                // parent loaders DID NOT run
-  const user = await getUser(params.id!);
+  invariant(params.id, "id is required");
+  const user = await getUser(params.id);
   if (!user) throw new Response("Not found", { status: 404 });
   return json(user);
 }

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/root.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/root.md
@@ -91,7 +91,15 @@ Like any other route module, `root.tsx` can export `loader`, `action`, `meta`, `
 // app/root.tsx
 import { json } from "@remix-run/node";
 import type { LoaderFunctionArgs } from "@remix-run/node";
-import { isRouteErrorResponse, useLoaderData, useRouteError } from "@remix-run/react";
+import {
+  isRouteErrorResponse,
+  Links,
+  LiveReload,
+  Meta,
+  Scripts,
+  ScrollRestoration,
+  useRouteError,
+} from "@remix-run/react";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   return json({ user: await getUser(request) });
@@ -110,7 +118,9 @@ export function ErrorBoundary() {
         {isRouteErrorResponse(error)
           ? <h1>{error.status} {error.statusText}</h1>
           : <h1>Application Error</h1>}
+        <ScrollRestoration />
         <Scripts />
+        <LiveReload />
       </body>
     </html>
   );

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/root.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/root.md
@@ -35,6 +35,8 @@ export default function App() {
 
 All six elements are load-bearing; omitting any of them breaks a documented Remix feature.
 
+> **Vite plugin (default for new v2 apps): omit `<LiveReload />`. Vite's own HMR handles dev reload.** This element is for the Classic Compiler only. The scaffold above shows the Classic Compiler shape; on Vite, delete the `LiveReload` import and the `<LiveReload />` element.
+
 ## The Six Required Elements
 
 ### `<Meta />`
@@ -78,6 +80,8 @@ Loads the Remix runtime and route module bundles. Without it, the app renders se
 ### `<LiveReload />`
 
 Connects to the dev server's reload socket. It **only does anything during development** — in production builds it no-ops, it does **not** throw. Ship it as-is; don't conditionally render it.
+
+> **Vite plugin (default for new v2 apps): omit `<LiveReload />`. Vite's own HMR handles dev reload.** This element is for the Classic Compiler only. If your project uses `@remix-run/dev/vite` in `vite.config.ts`, delete the import and element.
 
 ## Loader, Action, and ErrorBoundary
 
@@ -147,10 +151,61 @@ export function ErrorBoundary() {
 }
 ```
 
+> **Vite plugin (default for new v2 apps): omit `<LiveReload />` from `Document`.** Vite's own HMR handles dev reload; the element is Classic Compiler only.
+
+## `Layout` export (Remix v2 >= 2.4)
+
+Remix 2.4 added a framework-level `Layout` export that wraps `App`, `ErrorBoundary`, and `HydrateFallback` automatically. This is the canonical way to share the document shell — Remix calls `Layout(children)` for each of those three entry points, so you don't have to hand-roll a `Document` wrapper.
+
+```tsx
+// app/root.tsx
+import {
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  isRouteErrorResponse,
+  useRouteError,
+} from "@remix-run/react";
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        {children}
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+
+export default function App() {
+  return <Outlet />;
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return isRouteErrorResponse(error)
+    ? <h1>{error.status} {error.statusText}</h1>
+    : <h1>Application Error</h1>;
+}
+```
+
+`App`, `ErrorBoundary`, and `HydrateFallback` each render *inside* `Layout`, so none of them need their own `<html>`/`<head>`/`<body>`. This eliminates the duplication problem the hand-rolled `Document` wrapper above was solving.
+
+The hand-rolled `Document` pattern in the previous section is the pre-2.4 / explicit alternative — still valid, but on Remix >= 2.4 prefer the `Layout` export. Reference: https://remix.run/docs/en/main/file-conventions/root.
+
 ## Common Mistakes
 
 - **Missing `<Scripts />`**: App renders but never hydrates — feels like SSR-only.
 - **`<ScrollRestoration />` after `<Scripts />`**: Hydration order can clobber scroll restore. Put `<ScrollRestoration />` first.
-- **Conditionally rendering `<LiveReload />`**: Unnecessary — it no-ops in production. Just ship it.
+- **Conditionally rendering `<LiveReload />` (Classic Compiler)**: Unnecessary — it no-ops in production. Just ship it.
+- **Rendering `<LiveReload />` on Vite**: Wrong direction. **On Vite (default for new v2 apps), do NOT render `<LiveReload />`.** Vite's own HMR handles dev reload; the Remix element is Classic Compiler only and is dead weight (or worse, a runtime warning) under Vite.
 - **`ErrorBoundary` without the document shell**: Error page renders unstyled and unhydrated.
 - **Importing from `react-router-dom`**: Use `@remix-run/react` — the Remix re-export includes the loader/action wiring; the raw router package does not.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/root.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/root.md
@@ -1,0 +1,156 @@
+# Root Module (`app/root.tsx`)
+
+`app/root.tsx` is the **only required route** in a Remix v2 app. It owns the entire document shell — `<html>`, `<head>`, `<body>` — and is the rendering ancestor of every other route. Routes mount inside `<Outlet />`.
+
+## Canonical Scaffold
+
+```tsx
+// app/root.tsx
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+export default function App() {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+```
+
+All six elements are load-bearing; omitting any of them breaks a documented Remix feature.
+
+## The Six Required Elements
+
+### `<Meta />`
+
+Renders every `meta` export collected from the current route and all its ancestors. Place it in `<head>` so the browser sees `<title>`, `og:`, `twitter:`, and viewport tags before paint.
+
+```tsx
+// any route module
+export const meta = () => [
+  { title: "Concerts" },
+  { name: "description", content: "Browse upcoming concerts." },
+];
+```
+
+### `<Links />`
+
+Renders every `links` export from the route tree. Use it for stylesheets, preloads, and icons. Place it in `<head>` so CSS is applied before first paint.
+
+```tsx
+// app/root.tsx (or any route)
+import type { LinksFunction } from "@remix-run/node";
+import styles from "./styles/app.css";
+
+export const links: LinksFunction = () => [
+  { rel: "stylesheet", href: styles },
+];
+```
+
+### `<Outlet />`
+
+The mount point for child routes. The matched route — and any nested layouts — render here. Without `<Outlet />`, no route renders.
+
+### `<ScrollRestoration />`
+
+Restores scroll position on back/forward navigation and resets to top on new navigations. Place it as the **first** element in `<body>` after `<Outlet />` so the script runs before `<Scripts />` mounts.
+
+### `<Scripts />`
+
+Loads the Remix runtime and route module bundles. Without it, the app renders server HTML and never hydrates — links and forms still work via the browser, but loaders/actions never run client-side, prefetching is dead, and there is no SPA navigation.
+
+### `<LiveReload />`
+
+Connects to the dev server's reload socket. It **only does anything during development** — in production builds it no-ops, it does **not** throw. Ship it as-is; don't conditionally render it.
+
+## Loader, Action, and ErrorBoundary
+
+Like any other route module, `root.tsx` can export `loader`, `action`, `meta`, `links`, `headers`, and `ErrorBoundary`. The root `ErrorBoundary` is the last line of defense — it catches errors thrown anywhere below it when no descendant boundary handles them.
+
+```tsx
+// app/root.tsx
+import { json } from "@remix-run/node";
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { isRouteErrorResponse, useLoaderData, useRouteError } from "@remix-run/react";
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return json({ user: await getUser(request) });
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return (
+    <html lang="en">
+      <head>
+        <title>Oops</title>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        {isRouteErrorResponse(error)
+          ? <h1>{error.status} {error.statusText}</h1>
+          : <h1>Application Error</h1>}
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+```
+
+Because the root `ErrorBoundary` replaces the **entire** document (not just the `<Outlet />` slot), it must render its own `<html>`, `<head>`, `<body>`, and the document elements — otherwise the error page has no styles, no scripts, and no scroll restoration.
+
+## Layout Wrapper for `<head>` Reuse
+
+To avoid duplicating the `<html>` shell between `App` and `ErrorBoundary`, extract a `Layout` component:
+
+```tsx
+function Document({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        {children}
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default function App() {
+  return <Document><Outlet /></Document>;
+}
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  return <Document>{/* error UI */}</Document>;
+}
+```
+
+## Common Mistakes
+
+- **Missing `<Scripts />`**: App renders but never hydrates — feels like SSR-only.
+- **`<ScrollRestoration />` after `<Scripts />`**: Hydration order can clobber scroll restore. Put `<ScrollRestoration />` first.
+- **Conditionally rendering `<LiveReload />`**: Unnecessary — it no-ops in production. Just ship it.
+- **`ErrorBoundary` without the document shell**: Error page renders unstyled and unhydrated.
+- **Importing from `react-router-dom`**: Use `@remix-run/react` — the Remix re-export includes the loader/action wiring; the raw router package does not.

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/v1-migration.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/v1-migration.md
@@ -76,10 +76,10 @@ Wire it in `remix.config.js`:
 
 ```js
 // remix.config.js
-const { createRoutesFromFolders } = require("@remix-run/v1-route-convention");
+import { createRoutesFromFolders } from "@remix-run/v1-route-convention";
 
 /** @type {import('@remix-run/dev').AppConfig} */
-module.exports = {
+export default {
   ignoredRouteFiles: ["**/.*"],
   routes(defineRoutes) {
     return createRoutesFromFolders(defineRoutes, {
@@ -88,6 +88,8 @@ module.exports = {
   },
 };
 ```
+
+Vite-based v2 projects use `vite.config.ts` with the Remix Vite plugin instead of `remix.config.js`.
 
 The adapter preserves v1 nested-folder behavior — `index.tsx`, `__double` underscores, and folder-as-URL all keep working. Treat it as a migration aid, not a long-term answer: new code should adopt v2 conventions.
 
@@ -101,7 +103,8 @@ The flat structure means everything under `app/routes/` is a route candidate. CS
 
 ```js
 // remix.config.js
-module.exports = {
+/** @type {import('@remix-run/dev').AppConfig} */
+export default {
   ignoredRouteFiles: [
     "**/.*",                    // dotfiles
     "**/*.css",                 // stylesheets
@@ -111,6 +114,8 @@ module.exports = {
 };
 ```
 
+Vite-based v2 projects use `vite.config.ts` with the Remix Vite plugin instead of `remix.config.js`.
+
 Globs that match are skipped during route discovery.
 
 ## Manual `routes()` for Programmatic Definitions
@@ -119,7 +124,8 @@ You can also define routes programmatically. The callback receives `defineRoutes
 
 ```js
 // remix.config.js
-module.exports = {
+/** @type {import('@remix-run/dev').AppConfig} */
+export default {
   ignoredRouteFiles: ["**/*"],   // ignore filesystem entirely
   routes(defineRoutes) {
     return defineRoutes((route) => {
@@ -129,6 +135,8 @@ module.exports = {
   },
 };
 ```
+
+Vite-based v2 projects use `vite.config.ts` with the Remix Vite plugin instead of `remix.config.js`.
 
 ## Migration Checklist
 

--- a/plugins/beagle-remix-v2/skills/remix-v2-routing/references/v1-migration.md
+++ b/plugins/beagle-remix-v2/skills/remix-v2-routing/references/v1-migration.md
@@ -1,0 +1,140 @@
+# v1 → v2 Routing Migration
+
+Remix v1 used a **nested-folder** convention where directories created URL segments and double-underscore folder names marked pathless layouts. v2 replaces that with a **flat-file** convention where dots in filenames create URL slashes. The grammars are not compatible — leftover v1 files in a v2 project silently produce wrong URLs.
+
+## Side-by-Side Convention Map
+
+| Concept               | v1 (nested folders)            | v2 (flat routes)              |
+|-----------------------|--------------------------------|-------------------------------|
+| Index route           | `index.tsx`                    | `_index.tsx`                  |
+| Pathless layout       | `__auth/` (double underscore)  | `_auth.tsx` (single)          |
+| Nested URL            | folder hierarchy               | dot delimiter in filename     |
+| Dynamic segment       | `$param.tsx`                   | `$param.tsx` (unchanged)      |
+| Splat                 | `$.tsx`                        | `$.tsx` (unchanged)           |
+| Escape literal        | n/a                            | `[.]`, `[]` brackets          |
+| Opt-out of layout     | move out of folder             | trailing `_` (`foo_.bar.tsx`) |
+| Co-locate non-routes  | adjacent files in folder       | `feature/route.tsx` + siblings|
+
+## The Two Silent-Break Cases
+
+These are the most common upgrade failures because the file still compiles, the dev server still starts, and the URL still resolves — just to something other than what v1 produced.
+
+### 1. `index.tsx` → `_index.tsx`
+
+In v1, `index.tsx` rendered at the parent path. In v2, `index.tsx` is read as a literal segment and renders at `/index`. Rename every index file:
+
+```text
+v1                                  v2
+app/routes/index.tsx                app/routes/_index.tsx
+app/routes/concerts/index.tsx       app/routes/concerts._index.tsx
+app/routes/__auth/login.tsx         app/routes/_auth.login.tsx
+```
+
+### 2. `__double` underscore → `_single` underscore
+
+v1 pathless layouts used a **folder** named `__auth` (with the folder itself containing routes). v2 uses a **file** named `_auth.tsx` (the parent module) plus dot-delimited children:
+
+```text
+v1                                  v2
+app/routes/__auth/login.tsx         app/routes/_auth.tsx
+app/routes/__auth/signup.tsx        app/routes/_auth.login.tsx
+                                    app/routes/_auth.signup.tsx
+```
+
+A v1 `__auth` folder copied verbatim into v2 produces the literal URL `/__auth/login`.
+
+## Folder-Hierarchy → Dot-Delimited
+
+```text
+v1                                          v2
+app/routes/concerts/index.tsx               app/routes/concerts._index.tsx
+app/routes/concerts/$city.tsx               app/routes/concerts.$city.tsx
+app/routes/concerts/trending.tsx            app/routes/concerts.trending.tsx
+```
+
+If you prefer folders for organization, v2 supports them via the **folder + `route.tsx`** pattern. Only `route.tsx` becomes a route; siblings are colocated source:
+
+```text
+app/routes/
+  concerts/
+    route.tsx            ← becomes /concerts
+    queries.server.ts    ← NOT a route
+    Chart.tsx            ← NOT a route
+```
+
+Without a `route.tsx` inside, the folder is ignored entirely.
+
+## v1 Compatibility Adapter: `@remix-run/v1-route-convention`
+
+If a v1 route tree is large and you need to ship before migrating, install the official fallback adapter:
+
+```bash
+npm install -D @remix-run/v1-route-convention
+```
+
+Wire it in `remix.config.js`:
+
+```js
+// remix.config.js
+const { createRoutesFromFolders } = require("@remix-run/v1-route-convention");
+
+/** @type {import('@remix-run/dev').AppConfig} */
+module.exports = {
+  ignoredRouteFiles: ["**/.*"],
+  routes(defineRoutes) {
+    return createRoutesFromFolders(defineRoutes, {
+      ignoredFilePatterns: ["**/.*", "**/*.css"],
+    });
+  },
+};
+```
+
+The adapter preserves v1 nested-folder behavior — `index.tsx`, `__double` underscores, and folder-as-URL all keep working. Treat it as a migration aid, not a long-term answer: new code should adopt v2 conventions.
+
+## `ignoredRouteFiles` for Non-Route Files
+
+The flat structure means everything under `app/routes/` is a route candidate. CSS, server helpers, and test files dropped in there get treated as routes and surface as build warnings or 404-shaped routes. Two options:
+
+**Option 1 — Folder convention**: move helpers into a `feature/` folder; only `route.tsx` becomes a route, siblings are inert.
+
+**Option 2 — `ignoredRouteFiles`** in `remix.config.js`:
+
+```js
+// remix.config.js
+module.exports = {
+  ignoredRouteFiles: [
+    "**/.*",                    // dotfiles
+    "**/*.css",                 // stylesheets
+    "**/*.test.{ts,tsx}",       // test files
+    "**/*.server.{ts,tsx}",     // server-only modules
+  ],
+};
+```
+
+Globs that match are skipped during route discovery.
+
+## Manual `routes()` for Programmatic Definitions
+
+You can also define routes programmatically. The callback receives `defineRoutes` and runs **alongside** filesystem routes — it does not replace them. Use `ignoredRouteFiles` if you want the manual definitions to be authoritative:
+
+```js
+// remix.config.js
+module.exports = {
+  ignoredRouteFiles: ["**/*"],   // ignore filesystem entirely
+  routes(defineRoutes) {
+    return defineRoutes((route) => {
+      route("/", "home.tsx", { index: true });
+      route("/concerts/:city", "concerts/city.tsx");
+    });
+  },
+};
+```
+
+## Migration Checklist
+
+1. Rename every `index.tsx` → `_index.tsx` (in folders, also flatten with dots).
+2. Convert every `__name/` folder → `_name.tsx` parent + dotted children.
+3. Flatten folder hierarchies to dot-delimited filenames (or use folder + `route.tsx`).
+4. Audit imports: every `react-router-dom` import must become `@remix-run/react`.
+5. Add `ignoredRouteFiles` for any non-route files left under `app/routes/`.
+6. If you can't migrate everything at once, install `@remix-run/v1-route-convention` and wire it into `remix.config.js` as a temporary fallback.

--- a/plugins/beagle-remix-v2/skills/review-remix-v2/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/review-remix-v2/SKILL.md
@@ -1,0 +1,180 @@
+---
+description: Comprehensive Remix v2 code review with optional parallel agents. Detects Remix v2 in package.json, loads relevant review skills, runs verification protocol.
+name: review-remix-v2
+disable-model-invocation: true
+---
+
+# Remix v2 Code Review
+
+## Arguments
+
+- `--parallel`: Spawn specialized subagents per technology area
+- Path: Target directory (default: current working directory)
+
+## Step 1: Identify Changed Files
+
+```bash
+git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E '\.(tsx?|css)$'
+```
+
+If nothing is returned, ask the user for an explicit path list before continuing.
+
+## Step 2: Detect Remix v2 + Techs
+
+```bash
+# Detect Remix v2 in package.json (any official adapter)
+grep -E '"@remix-run/(react|node|cloudflare|deno|serve)"' package.json | head -3
+
+# Confirm app router layout
+ls app/routes/ 2>/dev/null | head -5
+
+# meta exports (route metadata)
+grep -rE 'export const meta|export function meta|export let meta' app/ --include="*.tsx" --include="*.ts" -l | head -3
+
+# Sessions / cookies / auth
+grep -rE 'createCookieSessionStorage|getSession\(|commitSession\(|destroySession\(' app/ --include="*.ts" --include="*.tsx" -l | head -3
+
+# Forms and progressive enhancement
+grep -rE 'useFetcher\(|<Form|useSubmit\(|useNavigation\(' app/ --include="*.tsx" -l | head -3
+
+# Error boundaries
+grep -rE 'export function ErrorBoundary|export const ErrorBoundary|useRouteError|isRouteErrorResponse' app/ --include="*.tsx" -l | head -3
+
+# Headers / streaming / server-only modules
+grep -rE 'export const headers|export function headers|defer\(' app/ --include="*.tsx" --include="*.ts" -l | head -3
+find app -type f \( -name '*.server.ts' -o -name '*.server.tsx' -o -name '*.client.ts' -o -name '*.client.tsx' \) | head -5
+
+# Loaders / actions (data flow)
+grep -rE 'export (async )?function (loader|action)|export const (loader|action)' app/ --include="*.tsx" --include="*.ts" -l | head -3
+```
+
+If the package.json check returns nothing, stop and tell the user: this skill expects a Remix v2 project.
+
+## Step 3: Load Verification Protocol
+
+Load `beagle-core:review-verification-protocol` before any substantive judgment on code. This is the canonical cross-plugin protocol; do not substitute a framework-specific copy.
+
+**Pass before Step 5:** The skill is loaded (or its checklist is open in context). Do not classify severity or write findings until this gate clears.
+
+## Step 4: Load Skills
+
+Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle-remix-v2:remix-v2-routing-review")`).
+
+**Always load** (a non-trivial Remix v2 app exercises all six areas):
+
+- `beagle-remix-v2:remix-v2-routing-review`
+- `beagle-remix-v2:remix-v2-data-flow-review`
+- `beagle-remix-v2:remix-v2-forms-review`
+- `beagle-remix-v2:remix-v2-error-boundaries-review`
+- `beagle-remix-v2:remix-v2-perf-ssr-review`
+- `beagle-remix-v2:remix-v2-meta-sessions-review`
+
+**Per-area triggers** (record which detection commands matched so coverage is auditable):
+
+| Condition | Skill |
+|-----------|-------|
+| `app/routes/` present | `remix-v2-routing-review` |
+| `loader` / `action` exports found | `remix-v2-data-flow-review` |
+| `<Form>` or `useFetcher` found | `remix-v2-forms-review` |
+| `ErrorBoundary` / `useRouteError` found | `remix-v2-error-boundaries-review` |
+| `headers` export, `defer(`, or `.server.ts` / `.client.ts` files | `remix-v2-perf-ssr-review` |
+| `meta` export or session/cookie helpers found | `remix-v2-meta-sessions-review` |
+
+If a detection row returns no matches, record that explicitly instead of silently skipping the skill.
+
+## Step 5: Review
+
+**Sequential (default):**
+1. Load applicable skills
+2. Review routing + nested route structure first
+3. Review loader/action data flow
+4. Review forms and progressive enhancement
+5. Review error boundaries
+6. Review meta, sessions, and headers/SSR
+7. Consolidate findings
+
+**Parallel (--parallel flag):**
+1. Detect all areas upfront
+2. Spawn one subagent per area with the `Task` tool
+3. Each agent loads its skill and reviews its domain only
+4. Wait for all agents
+5. Consolidate findings into a single output
+
+## Step 6: Verify Findings
+
+Before reporting any issue:
+1. Re-read the actual code (not just diff context)
+2. For "unused" claims — did you search all references, including route-file conventions?
+3. For "missing" claims — did you check parent routes, root.tsx, or framework defaults?
+4. For syntax issues — did you verify against Remix v2 docs (not v1, not React Router v7)?
+5. Remove findings that are style preferences, not actual issues
+
+**Pass before promoting to Critical/Major:** For that item, (2)–(4) are satisfied with a concrete artifact — opened file at `FILE:LINE`, grep output for references, or cited parent/framework code — not only diff context.
+
+## Step 7: Review Convergence
+
+- **Single-pass:** report ALL issues across routing, data flow, forms, errors, SSR/perf, meta/sessions, types, and security in one pass. Before submitting, ask whether your recommended fixes would themselves trigger new findings — if yes, include those now.
+- **Scope:** review only code in the diff and directly related existing code. Missing test coverage is ONE Minor issue, no implementation prescriptions. No new dependencies.
+- **Fix complexity:** real severity for fixes to existing code. Requests for net-new code (new modules, dependencies, test suites, extracted abstractions) are **Informational**, not blocking.
+- **Re-review:** verify previous fixes only — no new discovery, no re-flagging unfixed Minor/Nice-to-Have items.
+
+## Output Format
+
+```markdown
+## Review Summary
+[1-2 sentence overview]
+
+## Issues
+
+### Critical (Blocking)
+1. [FILE:LINE] ISSUE_TITLE
+   - Issue / Why / Fix
+
+### Major (Should Fix)
+2. [FILE:LINE] ISSUE_TITLE
+   - Issue / Why / Fix
+
+### Minor (Nice to Have)
+N. [FILE:LINE] ISSUE_TITLE
+   - Issue / Why / Fix
+
+### Informational (For Awareness)
+N. [FILE:LINE] SUGGESTION_TITLE
+   - Suggestion / Rationale
+
+## Good Patterns
+- [FILE:LINE] Pattern description (preserve this)
+
+## Verdict
+Ready: Yes | No | With fixes 1-N (Critical/Major only; Minor items are acceptable)
+Rationale: [1-2 sentences]
+```
+
+## Post-Fix Verification
+
+After fixes are applied, run:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+```
+
+All checks must pass before approval.
+
+## Gates
+
+Advance in order; do not skip a **pass condition** by restating it informally.
+
+1. **Scope recorded** — **Pass when:** You have the output of the Step 1 command (or an explicit substitute path list) naming what is in scope.
+2. **Protocol + always skills loaded** — **Pass when:** `beagle-core:review-verification-protocol` and all six `beagle-remix-v2:remix-v2-*-review` skills are loaded before the first severity judgment.
+3. **Conditional skills audited** — **Pass when:** For each Step 2 detection row you either confirmed a match or recorded that the command returned no results.
+4. **Critical/Major evidence** — **Pass when:** Each such finding cites a `FILE:LINE` that exists in the tree and meets the Step 6 pass rule for that finding type.
+5. **Single output** — **Pass when:** The Issues section uses one continuous numbering sequence and the deliverable satisfies Step 7 single-pass completeness.
+
+## Rules
+
+- Load skills BEFORE reviewing — not after.
+- Number every issue sequentially with `FILE:LINE` and clear Issue / Why / Fix.
+- This is Remix v2 — do not apply React Router v7, Remix v1, or Next.js (`"use client"`, server components) conventions.
+- Run the Post-Fix Verification block after fixes; Verdict ignores Minor and Informational items.

--- a/plugins/beagle-remix-v2/skills/review-remix-v2/SKILL.md
+++ b/plugins/beagle-remix-v2/skills/review-remix-v2/SKILL.md
@@ -14,7 +14,7 @@ disable-model-invocation: true
 ## Step 1: Identify Changed Files
 
 ```bash
-git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E '\.(tsx?|css)$'
+git diff --name-only $(git merge-base HEAD main)..HEAD | grep -E '\.(tsx?|jsx?|mjs|cjs|css)$|^(remix|vite)\.config\.'
 ```
 
 If nothing is returned, ask the user for an explicit path list before continuing.
@@ -34,8 +34,11 @@ grep -rE 'export const meta|export function meta|export let meta' app/ --include
 # Sessions / cookies / auth
 grep -rE 'createCookieSessionStorage|getSession\(|commitSession\(|destroySession\(' app/ --include="*.ts" --include="*.tsx" -l | head -3
 
-# Forms and progressive enhancement
+# Form primitives (forms-review)
 grep -rE 'useFetcher\(|<Form|useSubmit\(|useNavigation\(' app/ --include="*.tsx" -l | head -3
+
+# Form anti-patterns: native form / manual fetch (forms-review trigger even without Remix imports)
+grep -rE '(^|[^.])<form |fetch\(' app/ --include="*.tsx" -l | head -3
 
 # Error boundaries
 grep -rE 'export function ErrorBoundary|export const ErrorBoundary|useRouteError|isRouteErrorResponse' app/ --include="*.tsx" -l | head -3
@@ -43,6 +46,9 @@ grep -rE 'export function ErrorBoundary|export const ErrorBoundary|useRouteError
 # Headers / streaming / server-only modules
 grep -rE 'export const headers|export function headers|defer\(' app/ --include="*.tsx" --include="*.ts" -l | head -3
 find app -type f \( -name '*.server.ts' -o -name '*.server.tsx' -o -name '*.client.ts' -o -name '*.client.tsx' \) | head -5
+
+# Prefetch hygiene (perf-ssr-review)
+grep -rE 'prefetch=|<PrefetchPageLinks' app/ --include="*.tsx" -l | head -3
 
 # Loaders / actions (data flow)
 grep -rE 'export (async )?function (loader|action)|export const (loader|action)' app/ --include="*.tsx" --include="*.ts" -l | head -3
@@ -69,18 +75,18 @@ Use the `Skill` tool to load each applicable skill (e.g., `Skill(skill: "beagle-
 - `beagle-remix-v2:remix-v2-perf-ssr-review`
 - `beagle-remix-v2:remix-v2-meta-sessions-review`
 
-**Per-area triggers** (record which detection commands matched so coverage is auditable):
+**Detection telemetry** (records what each area review will actually find; does not gate loading — all six skills always load, but record matches/non-matches for the final report's coverage section):
 
 | Condition | Skill |
 |-----------|-------|
 | `app/routes/` present | `remix-v2-routing-review` |
 | `loader` / `action` exports found | `remix-v2-data-flow-review` |
-| `<Form>` or `useFetcher` found | `remix-v2-forms-review` |
+| `<Form>`, `useFetcher`, `useSubmit`, `useNavigation`, native `<form`, or manual `fetch(` found | `remix-v2-forms-review` |
 | `ErrorBoundary` / `useRouteError` found | `remix-v2-error-boundaries-review` |
-| `headers` export, `defer(`, or `.server.ts` / `.client.ts` files | `remix-v2-perf-ssr-review` |
+| `headers` export, `defer(`, or `.server.ts` / `.client.ts` files or `prefetch=`/`<PrefetchPageLinks` found | `remix-v2-perf-ssr-review` |
 | `meta` export or session/cookie helpers found | `remix-v2-meta-sessions-review` |
 
-If a detection row returns no matches, record that explicitly instead of silently skipping the skill.
+If a detection row returns no matches, record that explicitly in the report's coverage section — the skill still loads, but the reviewer should note the area had no surface to review.
 
 ## Step 5: Review
 


### PR DESCRIPTION
## Summary

Adds a new `beagle-remix-v2` plugin to the marketplace that covers Remix v2 (route modules + React Router v6) with 12 focused skills — 5 knowledge skills, 6 paired review skills, and 1 umbrella reviewer. Built on top of 6 cited research findings (~2,300 LOC of source material distilled into the plugin).

## Changes

### Added

- **`plugins/beagle-remix-v2/`** — new plugin scaffold (`.claude-plugin/plugin.json`, `README.md`, `skills/`)
- **5 knowledge skills** (auto-invoked when writing Remix v2 code):
  - `remix-v2-routing` — flat-routes v2, `_layout`/`_index`/`$param`, `root.tsx` scaffold, resource routes
  - `remix-v2-data-flow` — `loader`, `action`, `useLoaderData`, `defer`/`Await`, revalidation, `useNavigation`
  - `remix-v2-forms` — `<Form>`, `useFetcher`, `useSubmit`, optimistic UI, intent-based multi-action, uploads
  - `remix-v2-perf-ssr` — `headers` + SWR caching, streaming, `.server.ts`/`.client.ts`, hydration, prefetch
  - `remix-v2-meta-sessions` — v2 `meta` array API, `links`, `createCookieSessionStorage`, auth gates, CSRF
- **6 code-review skills** (loaded by the umbrella reviewer):
  - `remix-v2-routing-review` (22 anti-patterns)
  - `remix-v2-data-flow-review` (25)
  - `remix-v2-forms-review` (18)
  - `remix-v2-error-boundaries-review` (18 — review-only; v2 unified `ErrorBoundary` + v1 `CatchBoundary` holdovers)
  - `remix-v2-perf-ssr-review` (38)
  - `remix-v2-meta-sessions-review` (20)
- **1 umbrella reviewer** — `review-remix-v2` (`disable-model-invocation: true`); detects Remix v2 via `@remix-run/react`/`@remix-run/node`/`@remix-run/cloudflare` in `package.json` and `app/routes/` presence, then loads the relevant review skills and `beagle-core:review-verification-protocol`.
- **`.claude-plugin/marketplace.json`** — registers `beagle-remix-v2` under `category: frontend`.

**Stats**: 63 files, +10,895 LOC, 141 documented anti-patterns across 24 reference files.

## Motivation

The existing `beagle-react:react-router-v7` skill covers React Router v7 framework mode (which is the merged Remix v2 codebase under the React Router name), but does not target Remix v2 directly. Codebases still on `@remix-run/*` v2.x — and there are many — need a dedicated reviewer that flags v1-era holdovers (`CatchBoundary`, `useTransition`, `__pathless` folders, v1 `meta` object shape) and v2-specific anti-patterns (wrong `useNavigation`/`useFetcher` choice, unbounded multipart upload handlers, missing parent header merge, hydration mismatches).

## Testing

Beagle is a markdown plugin marketplace with no build system or automated test suite (see `CLAUDE.md`: "Validation is manual inspection of markdown syntax and YAML frontmatter").

- [ ] Manual testing performed: spot-check SKILL.md files for valid YAML frontmatter and reference-link integrity

### Manual Testing Steps

1. Install the plugin locally by pointing `~/.claude/settings.json` at this branch's `beagle/` path.
2. Open a Remix v2 codebase (`@remix-run/react` in `package.json`, `app/routes/` present).
3. Edit a route module — confirm the knowledge skills (e.g., `remix-v2-data-flow`) auto-invoke on relevant triggers (`loader`, `action`, `<Form>`).
4. Run `/beagle-remix-v2:review-remix-v2` against a branch with intentional anti-patterns (e.g., a v1 `CatchBoundary`, a `meta` object instead of array, a missing `httpOnly` cookie flag). Confirm the umbrella reviewer detects the techs, loads the relevant review skills, and flags the issues.

## Checklist

- [x] Code follows project style guidelines (markdown + YAML frontmatter conventions per `CLAUDE.md`)
- [x] Self-review completed (Wave A → spot-check gate → Wave B authoring)
- [ ] Manual installation + auto-invoke verification
- [ ] Documentation updated — plugin `README.md` lists all skills; marketplace `description` registered

---

Generated with [Claude Code](https://claude.com/claude-code)