### PR TITLE
chore(release): 3.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "3.5.0"
+    "version": "3.6.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-05-15
+
+### Added
+- **beagle-remix-v2:** New plugin (v0.1.0) with 12 skills covering Remix v2 code review and best practices — `review-remix-v2` orchestrator plus paired build/review skills for routing, data flow (loaders/actions/defer/revalidation), forms (Form/fetcher/optimistic UI/uploads), meta + sessions (meta v2, links, sessions, auth/CSRF), error boundaries (root + nested, throw Response, v1 holdovers), and performance/SSR (hydration, headers/caching, prefetch/streaming, server-client split) ([#102](https://github.com/existential-birds/beagle/pull/102))
+
 ## [3.5.0] - 2026-05-03
 
 ### Added
@@ -407,7 +412,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/existential-birds/beagle/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/existential-birds/beagle/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/existential-birds/beagle/compare/v3.3.0...v3.4.0
 [3.3.0]: https://github.com/existential-birds/beagle/compare/v3.2.0...v3.3.0


### PR DESCRIPTION
## Summary

- Bump version to 3.6.0
- Update CHANGELOG.md with changes since v3.5.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 3.6.0
- [x] `plugins/beagle-remix-v2/.claude-plugin/plugin.json` → 0.1.0 (initial release of new plugin, version unchanged)

## What's in this release

- **beagle-remix-v2** (new plugin, v0.1.0): 12 skills covering Remix v2 code review and best practices — `review-remix-v2` orchestrator plus paired build/review skills for routing, data flow, forms, meta + sessions, error boundaries, and performance/SSR (#102)

## Post-merge Steps

After merging, run:

```
/release-tag 3.6.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)