### PR TITLE
chore(release): 3.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "3.6.0"
+    "version": "3.7.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-05-15
+
 ### Added
-- **beagle-core:** Add `subagent-prompt` skill — produces a self-contained orchestration prompt that hands the current session's work off to a fresh session for sub-agent execution, with explicit per-task verification commands and a final integration check before reporting success. User-invocable, `disable-model-invocation: true`
-- **beagle-analysis:** Add `write-plan` skill — turns a finalized `brainstorm-beagle` spec at `.beagle/concepts/<slug>/spec.md` into a bite-sized, TDD-driven implementation plan at `.beagle/concepts/<slug>/plan.md`. Reads the spec, scans `CLAUDE.md` conventions, designs file structure, decomposes work into 2-5 minute steps with exact paths/commands, self-reviews against the spec, gets user approval, then writes. References `references/plan-template.md` and `references/plan-reviewer.md` for the document skeleton and the optional reviewer-subagent prompt
+- **beagle-core:** Add `subagent-prompt` skill — produces a self-contained orchestration prompt that hands the current session's work off to a fresh session for sub-agent execution, with explicit per-task verification commands and a final integration check before reporting success. User-invocable, `disable-model-invocation: true` ([#104](https://github.com/existential-birds/beagle/pull/104))
+- **beagle-analysis:** Add `write-plan` skill — turns a finalized `brainstorm-beagle` spec at `.beagle/concepts/<slug>/spec.md` into a bite-sized, TDD-driven implementation plan at `.beagle/concepts/<slug>/plan.md`. Reads the spec, scans `CLAUDE.md` conventions, designs file structure, decomposes work into 2-5 minute steps with exact paths/commands, self-reviews against the spec, gets user approval, then writes. References `references/plan-template.md` and `references/plan-reviewer.md` for the document skeleton and the optional reviewer-subagent prompt ([#104](https://github.com/existential-birds/beagle/pull/104))
+
+### Fixed
+- **beagle-react:** `review-frontend` now routes to `review-remix-v2` when Remix v2 is detected, ensuring Remix projects get the dedicated review skill instead of generic React review ([#104](https://github.com/existential-birds/beagle/pull/104))
 
 ## [3.6.0] - 2026-05-15
 
@@ -416,7 +421,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.6.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v3.7.0...HEAD
+[3.7.0]: https://github.com/existential-birds/beagle/compare/v3.6.0...v3.7.0
 [3.6.0]: https://github.com/existential-birds/beagle/compare/v3.5.0...v3.6.0
 [3.5.0]: https://github.com/existential-birds/beagle/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/existential-birds/beagle/compare/v3.3.0...v3.4.0

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-react/.claude-plugin/plugin.json
+++ b/plugins/beagle-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-react",
   "description": "React, React Flow, React Router, shadcn/ui, Tailwind v4, Vitest, and Zustand code review. Pairs with beagle-core for full workflow.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 3.7.0
- Update CHANGELOG.md with changes since v3.6.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 3.7.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.5.0 (new `write-plan` skill)
- [x] `plugins/beagle-core/.claude-plugin/plugin.json` → 1.3.0 (new `subagent-prompt` skill)
- [x] `plugins/beagle-react/.claude-plugin/plugin.json` → 1.2.1 (`review-frontend` routing fix)

## Post-merge Steps

After merging, run:
```
/release-tag 3.7.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)