### PR TITLE
feat(beagle-core): skip resolved threads in fetch-pr-feedback

### DIFF
--- a/plugins/beagle-core/skills/fetch-pr-feedback/SKILL.md
+++ b/plugins/beagle-core/skills/fetch-pr-feedback/SKILL.md
@@ -141,7 +141,7 @@ def clean_body:
 [(add // []) | .[] | select(
   .user.login != $pr_author and
   .user.login != $current_user and
-  (($resolved_ids | index(.id)) | not)
+  (.id as $comment_id | ($resolved_ids | index($comment_id) | not))
 )] |
 map({
   id,

--- a/plugins/beagle-core/skills/fetch-pr-feedback/SKILL.md
+++ b/plugins/beagle-core/skills/fetch-pr-feedback/SKILL.md
@@ -1,22 +1,23 @@
 ---
 name: fetch-pr-feedback
-description: Fetch review comments from a PR and evaluate with receive-feedback skill
+description: Fetch unresolved review comments from a PR and evaluate with receive-feedback skill
 disable-model-invocation: true
 ---
 
 # Fetch PR Feedback
 
-Fetch review comments from all reviewers on the current PR, format them, and evaluate using the receive-feedback skill. Excludes the PR author and current user by default.
+Fetch review comments from all reviewers on the current PR, format them, and evaluate using the receive-feedback skill. Excludes the PR author and current user by default. Line-specific comments belonging to resolved review threads are also excluded by default.
 
 ## Usage
 
 ```bash
-/beagle-core:fetch-pr-feedback [--pr <number>] [--include-author]
+/beagle-core:fetch-pr-feedback [--pr <number>] [--include-author] [--include-resolved]
 ```
 
 **Flags:**
 - `--pr <number>` - PR number to target (default: current branch's PR)
 - `--include-author` - Include PR author's own comments (default: excluded)
+- `--include-resolved` - Include line-specific comments from resolved review threads (default: excluded)
 
 ## Instructions
 
@@ -25,8 +26,8 @@ Fetch review comments from all reviewers on the current PR, format them, and eva
 Advance only after each **Pass when** is satisfied.
 
 1. **PR context** — **Pass when:** `$PR_NUMBER` is set to a positive integer and `gh pr view` / `gh api` for that PR completed with exit code **0**, **or** you stop in **Get PR Context** with only the failure given there (“No PR found for current branch…”).
-2. **Fetch** — **Pass when:** both paginated `gh api … | jq -s -f …` runs (issue comments + review comments) exit **0** and parse as JSON (empty `[]` is valid). On non-zero exit or jq error, stop; surface command stderr—do not invent comments.
-3. **Formatted artifact** — **Pass when:** output is either (a) markdown matching **Format Feedback Document** (header `# PR #$PR_NUMBER Review Feedback`, per-reviewer `## Reviewer: …` with Summary / Line-Specific sections), **or** (b) exactly: `No review comments found on this PR (excluding PR author and current user).`
+2. **Fetch** — **Pass when:** the resolved-thread GraphQL call (skipped if `--include-resolved`) and both paginated `gh api … | jq -s -f …` runs (issue comments + review comments) exit **0** and parse as JSON (empty `[]` is valid). On non-zero exit or jq error, stop; surface command stderr—do not invent comments.
+3. **Formatted artifact** — **Pass when:** output is either (a) markdown matching **Format Feedback Document** (header `# PR #$PR_NUMBER Review Feedback`, per-reviewer `## Reviewer: …` with Summary / Line-Specific sections), **or** (b) exactly: `No review comments found on this PR (excluding PR author, current user, and resolved threads).`
 4. **Load receive-feedback** — **Pass when:** the Skill tool successfully loads `beagle-core:receive-feedback`; only then run that skill’s verify → evaluate → execute loop on that formatted document.
 
 ### 1. Parse Arguments
@@ -34,6 +35,7 @@ Advance only after each **Pass when** is satisfied.
 Extract flags from `$ARGUMENTS`:
 - `--pr <number>` or detect from current branch
 - `--include-author` flag (boolean, default false)
+- `--include-resolved` flag (boolean, default false)
 
 ### 2. Get PR Context
 
@@ -58,6 +60,35 @@ If no PR exists for current branch, fail with: "No PR found for current branch. 
 ### 3. Fetch Comments
 
 Fetch both types of comments, excluding `$PR_AUTHOR` and `$CURRENT_USER` (unless `--include-author` is set). Use `--paginate` with `jq -s` to combine paginated JSON arrays into one.
+
+Unless `--include-resolved` is set, first fetch the databaseIds of every review comment that belongs to a resolved review thread. Issue comments (summary/walkthrough) aren't part of review threads, so this only affects line-specific review comments.
+
+**Resolved-thread comment IDs** (skip this block entirely when `--include-resolved` is set; set `RESOLVED_IDS='[]'` instead):
+
+```bash
+RESOLVED_IDS=$(gh api graphql \
+  -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" \
+  -f query='
+    query($owner: String!, $repo: String!, $pr: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pr) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              comments(first: 100) { nodes { databaseId } }
+            }
+          }
+        }
+      }
+    }
+  ' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+         | select(.isResolved)
+         | .comments.nodes[].databaseId
+         | select(. != null)]')
+```
+
+The `first: 100` limits cover typical PRs. For very large PRs (>100 threads or >100 comments in a single thread), thread/comment-level pagination would need to be added; for now, that's a known limitation.
 
 Write jq filters to temp files using heredocs with single-quoted delimiters (prevents shell escaping issues with `!=`, regex patterns, and angle brackets):
 
@@ -109,7 +140,8 @@ def clean_body:
 ;
 [(add // []) | .[] | select(
   .user.login != $pr_author and
-  .user.login != $current_user
+  .user.login != $current_user and
+  (($resolved_ids | index(.id)) | not)
 )] |
 map({
   id,
@@ -127,10 +159,11 @@ JQEOF
 
 gh api --paginate "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments" | \
   jq -s --arg pr_author "$PR_AUTHOR" --arg current_user "$CURRENT_USER" \
+  --argjson resolved_ids "$RESOLVED_IDS" \
   -f /tmp/review_comments.jq
 ```
 
-If `--include-author` is set, omit the `--arg pr_author` parameter and the `.user.login != $pr_author` condition from both jq filter files. Keep the `$current_user` exclusion either way.
+If `--include-author` is set, omit the `--arg pr_author` parameter and the `.user.login != $pr_author` condition from both jq filter files. Keep the `$current_user` exclusion either way. The `$resolved_ids` filter naturally becomes a no-op when `RESOLVED_IDS='[]'` (the `--include-resolved` path), so leave it in place.
 
 ### 4. Format Feedback Document
 
@@ -163,7 +196,7 @@ If `--include-author` is set, omit the `--arg pr_author` parameter and the `.use
 ...
 ```
 
-If no comments found from any reviewer, output: "No review comments found on this PR (excluding PR author and current user)."
+If no comments found from any reviewer, output: "No review comments found on this PR (excluding PR author, current user, and resolved threads)."
 
 ### 5. Evaluate with receive-feedback
 
@@ -178,7 +211,7 @@ Then process the formatted feedback document:
 ## Example
 
 ```bash
-# Fetch all reviewer comments on current branch's PR (default)
+# Fetch unresolved reviewer comments on current branch's PR (default)
 /beagle-core:fetch-pr-feedback
 
 # Fetch from a specific PR
@@ -187,6 +220,9 @@ Then process the formatted feedback document:
 # Include PR author's own comments
 /beagle-core:fetch-pr-feedback --include-author
 
+# Include line-specific comments from resolved review threads
+/beagle-core:fetch-pr-feedback --include-resolved
+
 # Combined
-/beagle-core:fetch-pr-feedback --pr 456 --include-author
+/beagle-core:fetch-pr-feedback --pr 456 --include-author --include-resolved
 ```


### PR DESCRIPTION
## Summary
- Updates `beagle-core:fetch-pr-feedback` to exclude line-specific review comments that belong to resolved review threads by default.
- Adds a GraphQL query (`reviewThreads.isResolved`) to collect `databaseId`s of comments on resolved threads; review-comments jq filter excludes them via a new `--argjson resolved_ids`.
- Adds `--include-resolved` opt-in flag (mirrors `--include-author`). Issue comments (summary/walkthrough) are unaffected — they aren't part of review threads, so "resolved" doesn't apply.
- Updates gates, the "no comments" message, description, and examples.

Known limitation called out inline: `first: 100` threads × 100 comments per thread, fine for typical PRs; very large PRs would need cursor pagination.

## Test plan
- [ ] Run `/beagle-core:fetch-pr-feedback --pr <PR with mixed resolved/unresolved threads>` and confirm only unresolved line-specific comments appear, while all issue (summary) comments still appear.
- [ ] Re-run with `--include-resolved` and confirm comments from resolved threads come back.
- [ ] Run on a PR with no review threads and confirm the GraphQL call returns `[]` and the skill still completes (no-op filter).
- [ ] Run on a PR where every reviewer comment is resolved and confirm output is `No review comments found on this PR (excluding PR author, current user, and resolved threads).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)