### PR TITLE
fix(beagle-core): forbid deferral in receive-feedback; dispatch fixes via parallel subagents

### DIFF
--- a/plugins/beagle-core/skills/receive-feedback/EVALUATION.md
+++ b/plugins/beagle-core/skills/receive-feedback/EVALUATION.md
@@ -1,40 +1,53 @@
 # Evaluation Rules
 
-## Decision Matrix
+## Binary Classification
 
-| Condition | Action | Response |
-|-----------|--------|----------|
-| **Correct & In Scope** | Implement immediately | "Fixed in [file:line]" |
-| **Correct but Out of Scope** | Defer | "Valid point. Out of scope; added to backlog." |
-| **Technically Incorrect** | Reject with evidence | "Verified: [evidence]. Maintaining current implementation." |
-| **Ambiguous / Unclear** | STOP and ask | "Clarification needed: [specific question]" |
-| **Violates YAGNI** | Reject | "Not currently used by any consumer. Skipping (YAGNI)." |
-| **Conflicts with codebase patterns** | Flag for discussion | "Conflicts with established pattern in [location]. Discuss?" |
+Every feedback item is exactly one of:
+
+| Classification | Meaning | Action |
+|----------------|---------|--------|
+| **VALID** | Verification confirmed the claim holds and the suggested change (or a clear equivalent) is implementable | Add to the `launch fixes for ...` confirmation prompt. On confirm, spawn a dedicated subagent. |
+| **INVALID** | Verification disproved the claim — the code is correct, the symbol is used, the bug does not reproduce | Reject with cited verification evidence. |
+| **NEEDS CLARIFICATION** | The feedback is genuinely unparseable (e.g., "fix the auth flow" with no further detail) | Ask one specific clarifying question. Do not use this bucket to dodge a fix. |
+
+There is no fourth bucket. There is no "Deferred". There is no "Out of scope". There is no "Pre-existing".
+
+## Prohibited Reasoning
+
+The following are NOT valid reasons to downgrade a VALID item or move it out of the fix queue:
+
+- "This is pre-existing." — If the reviewer found it on this PR, it is in scope.
+- "This is out of scope for the PR." — If the bug exists on this branch, the PR owns it.
+- "We can fix this in a follow-up." — No. Fix it now.
+- "This is minor / cosmetic / an edge case." — Irrelevant. A valid bug is a valid bug.
+- "This would be too much churn." — Irrelevant.
+- "The reviewer lacks context." — If you can prove that with a verification artifact, the item is INVALID. If you cannot, it is VALID.
+- "YAGNI." — Only applies when verification proves the code or feature has zero consumers; then the item is INVALID with evidence, not deferred.
+
+If you find yourself reasoning toward any of the above, stop and ask: *did verification actually disprove the claim?* If no, the item is VALID and must be dispatched to a subagent.
 
 ## Evaluation Order
 
-Process feedback items in this order:
+Within the verification pass, work top-to-bottom through the feedback list. Do not reorder by perceived priority — the user sees the same numbering the reviewer used.
 
-1. **Clarify** - Resolve all ambiguous items first
-2. **Critical** - Security issues, breaking bugs
-3. **Simple** - Typos, imports, formatting
-4. **Complex** - Refactoring, logic changes, architecture
+## When To Reject (INVALID)
 
-## When To Push Back
+Reject only with a concrete verification artifact:
 
-Push back when:
-- Suggestion breaks existing functionality
-- Reviewer lacks full context
-- Violates YAGNI (unused feature)
-- Technically incorrect for this stack
-- Conflicts with established codebase patterns
-- Legacy/compatibility reasons exist
+- Suggestion targets code that does not exist on this branch (cite path).
+- Symbol the reviewer wants removed is referenced (cite `Grep` hit at file:line).
+- Bug the reviewer reports does not reproduce (cite the test or script output).
+- Suggestion contradicts an established codebase pattern documented in a beagle skill (cite the skill and the existing usage).
+
+A rejection without an artifact is not a rejection — it is deferral in disguise. Treat it as VALID.
 
 ## Anti-Patterns
 
 | Forbidden | Why | Instead |
 |-----------|-----|---------|
-| "You're absolutely right!" | Performative, adds no value | State the fix or push back |
-| "Great catch!" | Social noise | Just fix it |
-| Implementing without verifying | May introduce bugs | Verify first |
-| Batch implementing | Hard to isolate regressions | One at a time, test each |
+| "You're absolutely right!" | Performative, adds no value | State the fix or push back with evidence |
+| "Great catch!" | Social noise | Just dispatch the subagent |
+| Implementing without verifying | May introduce bugs or miss the real issue | Verify first, then dispatch |
+| Orchestrator editing files directly | Violates the dispatch model | Spawn one subagent per valid item |
+| Asking "which of these would you like to fix?" | Implies deferral is on the table | Ask only `launch fixes for <numbers>?` |
+| Inventing a "Deferred" bucket in the response | There is no deferred bucket | Implemented or Rejected, nothing else |

--- a/plugins/beagle-core/skills/receive-feedback/RESPONSE.md
+++ b/plugins/beagle-core/skills/receive-feedback/RESPONSE.md
@@ -21,7 +21,18 @@ Print invalid items with evidence, then valid items numbered, then the single pr
 launch fixes for 1,3,4?
 ```
 
-The confirmation line is the entire prompt. Do not append "or let me know which ones to skip" or similar — that re-opens deferral.
+The confirmation line is the entire prompt and must list **every** valid item's number. Do not pre-narrow the set, and do not append "or let me know which ones to skip" or similar — that re-opens deferral.
+
+### Accepted user replies
+
+| User reply | Meaning |
+|------------|---------|
+| `y` / `yes` / `go` / `ok` / `lgtm` / ↵ | Dispatch the full proposed set. |
+| Comma- or space-separated numbers (e.g. `1,3` or `1 3 4`) | Dispatch only those numbers. Must be a subset of the proposed set. |
+| `no` / `cancel` / `stop` | Halt without dispatching. |
+| Anything else | Re-print the prompt once. Do not invent a disposition. |
+
+A subset reply is a user override, not an agent narrowing. Items the user omits are **not** deferred — they are simply not run this round. Surface them only on the line described below.
 
 ## Post-Dispatch Summary (after subagents return)
 
@@ -42,7 +53,11 @@ Exactly two sections. No third bucket.
 |---|------|--------|----------|
 | 2 | Remove `validate_user` | Function is used | Called at `middleware.py:45` |
 | 5 | Add generator | Input is tiny and read once | `config.py:12`, <1KB at startup |
+
+Not run this round: 4 (user-excluded)
 ```
+
+The trailing `Not run this round` line is the **only** place user-excluded valid items appear. Omit the line entirely if the user accepted the full set. Never reword this as "deferred", "skipped for now", or "follow-up".
 
 ## Response Guidelines
 

--- a/plugins/beagle-core/skills/receive-feedback/RESPONSE.md
+++ b/plugins/beagle-core/skills/receive-feedback/RESPONSE.md
@@ -1,49 +1,65 @@
 # Response Format
 
-## Structured Output Template
+## Pre-Dispatch Summary (before the confirmation prompt)
 
-After processing all feedback items, produce this summary:
+Print invalid items with evidence, then valid items numbered, then the single prompt.
+
+```markdown
+### Invalid (rejected with evidence)
+| # | Item | Evidence |
+|---|------|----------|
+| 2 | Remove `validate_user` | Called at `middleware.py:45` |
+| 5 | Switch to generator | Input is <1KB read once at startup (`config.py:12`) |
+
+### Valid (will be fixed by subagents)
+| # | Item | Target |
+|---|------|--------|
+| 1 | Null check on session | `src/auth.py:42` |
+| 3 | Rename `data` → `user_data` | `src/utils.py:15` |
+| 4 | Typo `usr` → `user` | `src/models.py:88` |
+
+launch fixes for 1,3,4?
+```
+
+The confirmation line is the entire prompt. Do not append "or let me know which ones to skip" or similar — that re-opens deferral.
+
+## Post-Dispatch Summary (after subagents return)
+
+Exactly two sections. No third bucket.
 
 ```markdown
 ## Feedback Response
 
 ### Implemented
-| # | Item | Location | Notes |
-|---|------|----------|-------|
-| 1 | Fixed null check | `src/auth.py:42` | Added validation |
-| 3 | Renamed variable | `src/utils.py:15` | `data` → `user_data` |
+| # | Item | Location | Subagent Notes |
+|---|------|----------|----------------|
+| 1 | Null check on session | `src/auth.py:42` | Added guard + test |
+| 3 | Rename variable | `src/utils.py:15` | `data` → `user_data`, 4 callsites updated |
+| 4 | Fix typo | `src/models.py:88` | `usr` → `user` |
 
 ### Rejected
 | # | Item | Reason | Evidence |
 |---|------|--------|----------|
-| 2 | Remove validate_user | Function is used | Called in `middleware.py:45` |
-| 5 | Add generator | Premature optimization | Processes <1KB once at startup |
-
-### Deferred
-| # | Item | Reason |
-|---|------|--------|
-| 4 | Add caching layer | Out of scope for this PR |
-
-### Needs Clarification
-| # | Item | Question |
-|---|------|----------|
-| 6 | "Fix the auth flow" | Which specific aspect? Token refresh? Session handling? |
+| 2 | Remove `validate_user` | Function is used | Called at `middleware.py:45` |
+| 5 | Add generator | Input is tiny and read once | `config.py:12`, <1KB at startup |
 ```
 
 ## Response Guidelines
 
-- **Be terse** - No filler words, no apologies
-- **Be specific** - Include file:line references
-- **Be evidenced** - Rejections must cite verification results
-- **Be actionable** - Clarification questions should be specific
+- **Be terse** — No filler words, no apologies.
+- **Be specific** — Include file:line references.
+- **Be evidenced** — Rejections must cite verification results.
+- **No Deferred section.** If you typed "Deferred", delete it and dispatch a subagent.
+- **No "out of scope" / "pre-existing" / "follow-up" language anywhere in the response.**
 
 ## Single-Item Responses
 
-For quick acknowledgments during implementation:
+For quick acknowledgments during a one-item flow:
 
 | Outcome | Response Format |
 |---------|-----------------|
-| Implemented | "Fixed in `file:line`" |
+| Implemented (by subagent) | "Fixed in `file:line` (subagent <id>)" |
 | Rejected | "Verified: [evidence]. Keeping current implementation." |
-| Deferred | "Valid. Out of scope for this task." |
-| Unclear | "Need clarification: [specific question]" |
+| Needs clarification | "Need clarification: [specific question]" |
+
+There is no single-item "deferred" response.

--- a/plugins/beagle-core/skills/receive-feedback/SKILL.md
+++ b/plugins/beagle-core/skills/receive-feedback/SKILL.md
@@ -44,15 +44,20 @@ If a bug is valid, a subagent fixes it. Full stop. No deferral, no excuses.
 2. **Classify** each item as **VALID** (must fix) or **INVALID** (reject with evidence).
    - Truly unparseable items get one clarification question. That is the only escape.
 3. **Print** a short summary: invalid items with evidence, valid items numbered.
-4. **Ask exactly one prompt**: `launch fixes for 1,2,3?` (list the valid items' numbers).
-5. **On confirmation**, spawn **one subagent per valid item, all in a single message** so they run in parallel. The orchestrator MUST NOT call Edit / Write / NotebookEdit for any fix.
-6. **Collect** subagent results and emit the final response table.
+4. **Ask exactly one prompt**: `launch fixes for 1,2,3?` (list every valid item's number — the default proposal is always the full valid set).
+5. **Resolve the user's reply**:
+   - Confirmation (`y`, `yes`, `go`, `ok`, `do it`, `lgtm`, or just ↵) → dispatch the full proposed set.
+   - A comma/space-separated list of numbers (e.g. `1,3` or `1 3 4`) → dispatch only those numbers. They must be a subset of the proposed valid set. Items the user omits are NOT marked deferred — they are simply not run this round.
+   - `no` / `cancel` / `stop` → halt without dispatching.
+   - Anything else → re-print the prompt once; do not invent a new disposition.
+6. **Spawn one subagent per chosen item, all in a single message** so they run in parallel. The orchestrator MUST NOT call Edit / Write / NotebookEdit for any fix.
+7. **Collect** subagent results and emit the final response table.
 
 ## Forbidden Behaviors
 
 These are non-negotiable. The orchestrator may **not**:
 
-- Ask the user *which* items to fix. The only question allowed is `launch fixes for <numbers>?`.
+- Ask the user *which* items to fix. The only question allowed is `launch fixes for <numbers>?`, where `<numbers>` defaults to the full valid set. (The user may override by replying with their own subset of numbers — that is a user override, not an agent question.)
 - Claim an issue is **pre-existing**. If a reviewer found it on this PR, it is in scope.
 - Claim an issue is **out of scope** for the PR. If the bug exists on this branch, the PR owns it.
 - **Defer** a valid item to "later", a "backlog", a "follow-up PR", or a "future ticket".
@@ -77,23 +82,25 @@ Do not advance to the next gate until its **pass condition** is true. Details li
 **Gate 2 — Single batch confirmation**
 
 1. Print the invalid items (with rejection evidence) and the valid items (numbered).
-2. Ask the **single** prompt: `launch fixes for <comma-separated numbers>?`
+2. Ask the **single** prompt: `launch fixes for <comma-separated numbers>?` — `<numbers>` MUST be the full valid set. Do not pre-narrow it.
+3. Accept the user's reply per the Workflow resolution rules: confirmation → full set; subset of numbers → that subset only; refusal → halt.
 
-**Pass when:** The user confirms. **Fail (stop):** Asking the user to pick a subset, asking whether to fix at all, or proposing to defer any valid item.
+**Pass when:** The user confirms or supplies a subset of the proposed numbers, and the chosen set is locked in writing before Gate 3. **Fail (stop):** Proposing a narrowed default, asking "which would you like to fix?", or proposing to defer any valid item.
 
 **Gate 3 — Parallel subagent dispatch**
 
-1. In a single tool-use block, spawn one `Agent` per valid item. Each subagent gets: the original feedback text, the verification artifact, the file/line target, and instructions to make the fix and report the resulting diff.
+1. In a single tool-use block, spawn one `Agent` per item in the user-chosen set. Each subagent gets: the original feedback text, the verification artifact, the file/line target, and the Fix-Quality Contract.
 2. The orchestrator does not call `Edit`, `Write`, or `NotebookEdit` during this gate.
 
-**Pass when:** Every valid item has a corresponding subagent invocation in the same message. **Fail (stop):** Fixing inline, serializing the subagents, or skipping any valid item.
+**Pass when:** Every item in the user-chosen set has a corresponding subagent invocation in the same message. **Fail (stop):** Fixing inline, serializing the subagents, or skipping any item the user actually chose.
 
 **Gate 4 — Response artifact (batch)**
 
 1. After subagents return, fill the structured template in `RESPONSE.md`.
 2. The response has exactly two sections: **Implemented** and **Rejected**. There is no Deferred section.
+3. Valid items the user explicitly excluded from this round get a single line under the table — `Not run this round: <numbers> (user-excluded)` — and nothing else. Do not label them deferred or out of scope.
 
-**Pass when:** Every item appears in Implemented or Rejected with file:line citations. **Fail (stop):** Shipping a summary that omits an item, lacks evidence on a rejection, or invents a "Deferred" bucket.
+**Pass when:** Every item appears in Implemented or Rejected with file:line citations, and any user-excluded valid items are listed verbatim under the table. **Fail (stop):** Shipping a summary that omits an item, lacks evidence on a rejection, or invents a "Deferred" bucket.
 
 ## Command Workflow
 

--- a/plugins/beagle-core/skills/receive-feedback/SKILL.md
+++ b/plugins/beagle-core/skills/receive-feedback/SKILL.md
@@ -11,20 +11,25 @@ disable-model-invocation: false
 Process code review feedback with verification-first discipline.
 No performative agreement. Technical correctness over social comfort.
 
+The orchestrator **verifies** and **dispatches**. It never edits files itself.
+Every valid item is fixed by a dedicated subagent spawned in parallel.
+
 ## Quick Reference
 
 ```
-┌─────────────┐     ┌──────────────┐     ┌─────────────┐
-│   VERIFY    │ ──▶ │   EVALUATE   │ ──▶ │   EXECUTE   │
-│ (tool-based)│     │ (decision    │     │ (implement/ │
-│             │     │  matrix)     │     │  reject/    │
-└─────────────┘     └──────────────┘     │  defer)     │
-                                         └─────────────┘
+┌─────────────┐     ┌──────────────┐     ┌──────────────────────┐
+│   VERIFY    │ ──▶ │   CONFIRM    │ ──▶ │   DISPATCH FIXES     │
+│ (tool-based)│     │ ("launch     │     │ (one subagent per    │
+│             │     │  fixes for   │     │  valid item, run in  │
+│             │     │  1,2,3?")    │     │  parallel)           │
+└─────────────┘     └──────────────┘     └──────────────────────┘
 ```
 
 ## Core Principle
 
-**Verify before implementing. Ask before assuming.**
+**Verify, confirm once, then dispatch subagents. The orchestrator does not fix.**
+
+If a bug is valid, a subagent fixes it. Full stop. No deferral, no excuses.
 
 ## When To Use
 
@@ -35,36 +40,60 @@ No performative agreement. Technical correctness over social comfort.
 
 ## Workflow
 
-For each feedback item:
+1. **Verify every item** against the current codebase (tools, not memory).
+2. **Classify** each item as **VALID** (must fix) or **INVALID** (reject with evidence).
+   - Truly unparseable items get one clarification question. That is the only escape.
+3. **Print** a short summary: invalid items with evidence, valid items numbered.
+4. **Ask exactly one prompt**: `launch fixes for 1,2,3?` (list the valid items' numbers).
+5. **On confirmation**, spawn **one subagent per valid item, all in a single message** so they run in parallel. The orchestrator MUST NOT call Edit / Write / NotebookEdit for any fix.
+6. **Collect** subagent results and emit the final response table.
 
-1. **Verify** - Use tools to check if feedback is technically valid
-2. **Evaluate** - Apply decision matrix to determine action
-3. **Execute** - Implement, reject with evidence, or defer
+## Forbidden Behaviors
 
-## Hard gates
+These are non-negotiable. The orchestrator may **not**:
+
+- Ask the user *which* items to fix. The only question allowed is `launch fixes for <numbers>?`.
+- Claim an issue is **pre-existing**. If a reviewer found it on this PR, it is in scope.
+- Claim an issue is **out of scope** for the PR. If the bug exists on this branch, the PR owns it.
+- **Defer** a valid item to "later", a "backlog", a "follow-up PR", or a "future ticket".
+- Use any reasoning — risk, complexity, time, churn, "minor", "cosmetic", "edge case" — to avoid fixing a valid item.
+- **Edit code directly.** Every fix is performed by a spawned subagent.
+- Bundle multiple fixes into one subagent. One valid item = one subagent.
+
+A valid bug raised by a code or security reviewer **must** be fixed by a subagent. There is no other option.
+
+## Hard Gates
 
 Do not advance to the next gate until its **pass condition** is true. Details live in `VERIFICATION.md`, `EVALUATION.md`, and `RESPONSE.md`.
 
 **Gate 1 — Verification evidence (per item)**
 
-1. Locate the referenced code or behavior (`Read`, `Grep`, tests, or another check from `VERIFICATION.md` that fits the claim).
-2. Record the outcome: claim **holds**, **fails**, or **unclear**, with an artifact (file path and line range, command/test result, or short quoted tool output—not paraphrase alone).
+1. Locate the referenced code or behavior (`Read`, `Grep`, tests, or another check from `VERIFICATION.md`).
+2. Record the outcome: **VALID** (claim holds and is actionable) or **INVALID** (claim fails), with an artifact (file path and line range, command/test result, or short quoted tool output — not paraphrase alone).
+3. If unparseable, mark **NEEDS CLARIFICATION** with the specific question. Do not invent a disposition.
 
-**Pass when:** That record exists before you choose implement / reject / defer / clarify. **Fail (stop):** Proceeding with only a verbal “I verified” without an artifact.
+**Pass when:** Every item has VALID / INVALID / NEEDS CLARIFICATION plus an artifact. **Fail (stop):** Proceeding without an artifact, or downgrading a VALID item to "skip" / "defer" / "pre-existing" / "out of scope".
 
-**Gate 2 — Disposition locked (per item)**
+**Gate 2 — Single batch confirmation**
 
-1. Apply the decision matrix in `EVALUATION.md` to the verified facts.
-2. Choose exactly one primary outcome: implement, reject with evidence, defer, or ask for clarification.
+1. Print the invalid items (with rejection evidence) and the valid items (numbered).
+2. Ask the **single** prompt: `launch fixes for <comma-separated numbers>?`
 
-**Pass when:** Outcome is explicit. **Fail (stop):** Implementing while the item is still ambiguous—resolve or clarify first per `EVALUATION.md`.
+**Pass when:** The user confirms. **Fail (stop):** Asking the user to pick a subset, asking whether to fix at all, or proposing to defer any valid item.
 
-**Gate 3 — Response artifact (batch)**
+**Gate 3 — Parallel subagent dispatch**
 
-1. After every item has passed Gates 1–2, fill the structured template in `RESPONSE.md`.
-2. Ensure rejections include verification evidence and implemented rows cite locations.
+1. In a single tool-use block, spawn one `Agent` per valid item. Each subagent gets: the original feedback text, the verification artifact, the file/line target, and instructions to make the fix and report the resulting diff.
+2. The orchestrator does not call `Edit`, `Write`, or `NotebookEdit` during this gate.
 
-**Pass when:** Each feedback item appears in the correct section of the response template with required columns satisfied. **Fail (stop):** Shipping a summary that omits an item or lacks evidence on a rejection.
+**Pass when:** Every valid item has a corresponding subagent invocation in the same message. **Fail (stop):** Fixing inline, serializing the subagents, or skipping any valid item.
+
+**Gate 4 — Response artifact (batch)**
+
+1. After subagents return, fill the structured template in `RESPONSE.md`.
+2. The response has exactly two sections: **Implemented** and **Rejected**. There is no Deferred section.
+
+**Pass when:** Every item appears in Implemented or Rejected with file:line citations. **Fail (stop):** Shipping a summary that omits an item, lacks evidence on a rejection, or invents a "Deferred" bucket.
 
 ## Command Workflow
 
@@ -72,13 +101,12 @@ Use this skill from the `/receive-feedback` command or by invoking it directly w
 
 1. **Read** the feedback file at `$ARGUMENTS`
 2. **Parse** individual feedback items, whether numbered, bulleted, or freeform
-3. **Load** this skill: `Skill(skill: "beagle-core:receive-feedback")`
-4. **Process** each item through verify → evaluate → execute
-5. **Produce** the structured response summary defined in `RESPONSE.md`
+3. **Verify** each item per `VERIFICATION.md`
+4. **Confirm** via single `launch fixes for <numbers>?` prompt
+5. **Dispatch** one subagent per valid item in a single message
+6. **Produce** the response summary defined in `RESPONSE.md`
 
 ## Expected Feedback File Format
-
-The feedback file may contain numbered or bulleted items:
 
 ```markdown
 1. Remove unused import on line 15
@@ -89,17 +117,60 @@ The feedback file may contain numbered or bulleted items:
 
 Freeform prose is also acceptable; extract actionable items from the text.
 
+## Subagent Dispatch Template
+
+When spawning a fix subagent, the prompt MUST include:
+
+- The original feedback text (verbatim).
+- The verification artifact: file path, line range, and what was confirmed.
+- The exact change required, or "implement the reviewer's suggestion as written" if the reviewer specified one.
+- The fix-quality contract below, copied verbatim into every subagent prompt.
+
+### Fix-Quality Contract (paste into every subagent prompt)
+
+```
+You are fixing one code review finding. Hard requirements:
+
+1. Make the fix. Do not defer. Do not declare anything out of scope.
+   Do not call anything pre-existing. If you discover the fix needs to
+   touch adjacent code to be correct, touch it.
+
+2. The fix must be clean and architectural — idiomatic for the language
+   and the file's surrounding patterns. Read enough of the
+   surrounding module to match its conventions before editing.
+   No inline hacks, no band-aids, no "minimum to make it green".
+
+3. Do NOT over-engineer. No new abstractions, no speculative
+   generality, no helper layers, no config knobs. Solve the actual
+   reported problem. If three lines are right, write three lines.
+
+4. Write NO comments unless a future reader would be genuinely
+   confused without one (a non-obvious invariant, a workaround for a
+   specific upstream bug, a hidden constraint). Never write comments
+   that restate what the code does. Never write headers, banners,
+   "fix:" markers, or "// added for review feedback" notes.
+   Excessive comments are a defect — do not produce them.
+
+5. Run the project's typecheck / lint for the file you touched if a
+   command is obvious from the repo. Report what you ran.
+
+6. Report back: the resulting diff, the file:line of the change, and
+   one sentence on what you changed and why.
+```
+
+Use `subagent_type: "general-purpose"` unless a domain-specific agent is clearly better.
+
 ## Example
 
 ```bash
 /receive-feedback reviews/pr-123-feedback.md
 ```
 
-Reads the file, processes each item with technical verification, and outputs a structured response table.
+Reads the file, verifies each item, prints invalid/valid summary, asks `launch fixes for 1,3,4?`, and on confirmation spawns three subagents in parallel to fix items 1, 3, and 4.
 
 ## Files
 
 - `VERIFICATION.md` - Tool-based verification workflow
-- `EVALUATION.md` - Decision matrix and rules
+- `EVALUATION.md` - Classification rules (VALID / INVALID only)
 - `RESPONSE.md` - Structured output format
 - `references/skill-integration.md` - Using with code-review skills

--- a/plugins/beagle-core/skills/receive-feedback/SKILL.md
+++ b/plugins/beagle-core/skills/receive-feedback/SKILL.md
@@ -16,7 +16,7 @@ Every valid item is fixed by a dedicated subagent spawned in parallel.
 
 ## Quick Reference
 
-```
+```text
 ┌─────────────┐     ┌──────────────┐     ┌──────────────────────┐
 │   VERIFY    │ ──▶ │   CONFIRM    │ ──▶ │   DISPATCH FIXES     │
 │ (tool-based)│     │ ("launch     │     │ (one subagent per    │
@@ -135,7 +135,7 @@ When spawning a fix subagent, the prompt MUST include:
 
 ### Fix-Quality Contract (paste into every subagent prompt)
 
-```
+```text
 You are fixing one code review finding. Hard requirements:
 
 1. Make the fix. Do not defer. Do not declare anything out of scope.
@@ -178,6 +178,6 @@ Reads the file, verifies each item, prints invalid/valid summary, asks `launch f
 ## Files
 
 - `VERIFICATION.md` - Tool-based verification workflow
-- `EVALUATION.md` - Classification rules (VALID / INVALID only)
+- `EVALUATION.md` - Classification rules (VALID / INVALID / NEEDS CLARIFICATION)
 - `RESPONSE.md` - Structured output format
 - `references/skill-integration.md` - Using with code-review skills

--- a/plugins/beagle-core/skills/receive-feedback/VERIFICATION.md
+++ b/plugins/beagle-core/skills/receive-feedback/VERIFICATION.md
@@ -22,7 +22,10 @@ For EACH feedback item:
 1. **Locate**: Find the referenced code (`Read` tool)
 2. **Context**: Understand why it exists (`Grep` for usage, git blame)
 3. **Validate**: Test the claim (run tests, reproduce issue)
-4. **Document**: Note verification result before proceeding
+4. **Classify**: VALID (claim holds) or INVALID (claim disproved by an artifact). If genuinely unparseable, NEEDS CLARIFICATION — but never use this to dodge a fixable item.
+5. **Document**: Record the artifact (path:line, command output, grep hit) before proceeding.
+
+A claim is INVALID only when verification produced a concrete artifact disproving it. "I don't think this matters" is not verification — it is deferral, which is forbidden.
 
 ## Using Code-Review Skills for Verification
 
@@ -48,5 +51,13 @@ Feedback: "Remove unused `validate_user` function"
 Verification:
 1. `Grep` for "validate_user" across codebase
 2. Found: Called in `auth/middleware.py:45`
-3. Result: **Feedback incorrect** - function is used
-4. Action: Push back with evidence
+3. Classification: **INVALID** — function is used
+4. Action: Reject with evidence in the pre-dispatch summary
+
+Contrast — feedback: "Null check missing on `session` at `auth.py:42`"
+
+Verification:
+1. `Read` `auth.py` around line 42
+2. Confirmed: `session.user_id` is dereferenced with no prior `if session is None` guard
+3. Classification: **VALID**
+4. Action: Add to the `launch fixes for ...` prompt; on confirm, spawn a subagent to add the guard. Do not edit `auth.py` from the orchestrator.


### PR DESCRIPTION
## Summary

Rewrites the `receive-feedback` skill so it stops asking which items to fix and stops using "pre-existing" / "out of scope" / "deferred" as escape hatches for valid reviewer findings. The orchestrator verifies, asks one batch confirmation, and dispatches one parallel subagent per valid item to do the fix. The confirmation still defaults to the full valid set, but the user may override with a subset of numbers — excluded items are labeled "Not run this round (user-excluded)", never deferred.

## Changes

### Changed
- `SKILL.md`: new `verify → confirm → dispatch` workflow with four hard gates. Orchestrator is explicitly forbidden from calling `Edit` / `Write` / `NotebookEdit` for fixes; every chosen item gets its own subagent spawned in a single tool-use block. The default proposal is always the full valid set; the user may reply with a subset of numbers as an override (not an agent-asked narrowing). MD040 fences tagged as ```text` to satisfy markdownlint; Files-section blurb aligned with the three-bucket classification.
- `EVALUATION.md`: collapsed the decision matrix to a binary classification (VALID / INVALID, plus NEEDS CLARIFICATION as a tight escape valve). Adds a Prohibited Reasoning section calling out "pre-existing", "out of scope", "follow-up PR", "minor / cosmetic", "too much churn", "reviewer lacks context", and YAGNI-as-deferral.
- `RESPONSE.md`: new pre-dispatch summary format ending in the single `launch fixes for ...?` confirmation. Post-dispatch summary has exactly two sections — Implemented and Rejected. User-excluded items get one trailing line ("Not run this round: <numbers> (user-excluded)"); the Deferred bucket is removed entirely.
- `VERIFICATION.md`: adds an explicit Classify step and a contrasting VALID example demonstrating that the orchestrator must dispatch rather than edit inline.

### Added
- Fix-Quality Contract in `SKILL.md` that gets pasted verbatim into every subagent prompt: idiomatic clean fixes, match surrounding patterns, no inline hacks, no over-engineering, no excessive comments.
- User subset-override path on the single confirmation prompt: `y`/`yes`/`go`/↵ runs the full proposed set; a comma- or space-separated list of numbers runs that subset; `no`/`cancel` halts. Items the user omits are not marked deferred — they are simply not run this round.

## Motivation

The previous skill kept asking the user which items to fix and would routinely shelve valid bugs as "pre-existing", "out of scope for this PR", or "follow-up". That defeats the purpose of receiving review feedback — if a bug exists on the branch, the PR owns it. The rewrite removes every avenue the agent had to reason its way out of fixing a valid finding, and makes the fix mechanism (parallel subagents) structurally enforced rather than advisory. The subset override gives the user a deliberate, explicit exit hatch without re-introducing the deferral pattern as an agent decision.

## Testing

Markdown-only skill change; this repo has no build or test suite. Verified by re-reading each modified file end-to-end after each commit.

- [ ] Unit tests added/updated *(N/A — markdown only)*
- [ ] Integration tests added/updated *(N/A — markdown only)*
- [x] Manual testing performed

### Manual Testing Steps

1. Run `/receive-feedback <some-feedback-file.md>` against a real review.
2. Confirm the agent prints an Invalid table + Valid table + a single `launch fixes for <all valid numbers>?` prompt and nothing else.
3. Reply `yes` and confirm one subagent is spawned per valid item in a single message; the post-dispatch summary has only Implemented and Rejected sections.
4. Re-run, this time reply with a subset (e.g. `1,3`). Confirm only those subagents spawn, and the response table lists the omitted item under "Not run this round: <n> (user-excluded)" — never as deferred.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Linting passes *(markdownlint MD040 resolved)*
- [x] Documentation updated *(this PR is the documentation)*

---

Generated with [Claude Code](https://claude.com/claude-code)