### PR TITLE
feat(beagle-core): add review-structure skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+### Added
+- **beagle-core:** Add the `review-structure` skill — a repo-wide structural-maintainability review (`/beagle-core:review-structure`) focused on implementation quality, abstraction quality, and codebase health. Pushes for "code-judo" restructurings that preserve behavior while simplifying, guards against pushing files past 1k lines, flags anti-spaghetti branching, enforces canonical-layer reuse, calls out magic/wrapper abstractions, and demands explicit type/boundary contracts. Ships `disable-model-invocation` (user-invoked only) with a severity-categorized output format and an explicit approval bar
+
 ## [3.10.0] - 2026-05-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Beagle-specific:
 | beagle-rust | `review-rust` | Rust/tokio/axum/sqlx/serde code review |
 | beagle-remix-v2 | `review-remix-v2` | Remix v2 code review (loaders, actions, forms, sessions, perf/SSR) |
 | beagle-core | `review-plan` | Review implementation plans before execution |
-| beagle-core | `review-structure` | Repo-wide structural-maintainability review (code-judo restructurings, 1k-line guard, anti-spaghetti branching) |
+| beagle-core | `review-structure` | Repo-wide structural-maintainability review (code-judo restructurings, 1k-line file guard, anti-spaghetti branching, canonical-layer enforcement, anti-magic abstractions, explicit type/boundary contracts) |
 | beagle-core | `commit-push` | Commit with Conventional Commits format |
 | beagle-core | `create-pr` | Create PR with structured template |
 | beagle-core | `gen-release-notes` | Generate changelog from git history |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 12 focused plugins with 145 skills.
+Beagle is a Claude Code plugin marketplace providing framework-aware code review skills and verification workflows for pre-push reviews and GitHub bot feedback handling. It contains 12 focused plugins with 146 skills.
 
 ## Marketplace Architecture
 
@@ -13,7 +13,7 @@ beagle/
 ├── .claude-plugin/
 │   └── marketplace.json         # Marketplace manifest (12 plugins)
 └── plugins/
-    ├── beagle-core/             # Shared workflows, verification, git workflows (20 skills)
+    ├── beagle-core/             # Shared workflows, verification, git workflows (21 skills)
     ├── beagle-python/           # Python, FastAPI, SQLAlchemy, PostgreSQL, pytest (7 skills)
     ├── beagle-go/               # Go, BubbleTea, Wish SSH, Prometheus (13 skills)
     ├── beagle-elixir/           # Elixir, Phoenix, LiveView, ExUnit, ExDoc (11 skills)
@@ -77,6 +77,7 @@ Beagle-specific:
 | beagle-rust | `review-rust` | Rust/tokio/axum/sqlx/serde code review |
 | beagle-remix-v2 | `review-remix-v2` | Remix v2 code review (loaders, actions, forms, sessions, perf/SSR) |
 | beagle-core | `review-plan` | Review implementation plans before execution |
+| beagle-core | `review-structure` | Repo-wide structural-maintainability review (code-judo restructurings, 1k-line guard, anti-spaghetti branching) |
 | beagle-core | `commit-push` | Commit with Conventional Commits format |
 | beagle-core | `create-pr` | Create PR with structured template |
 | beagle-core | `gen-release-notes` | Generate changelog from git history |

--- a/plugins/beagle-core/skills/review-structure/SKILL.md
+++ b/plugins/beagle-core/skills/review-structure/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: review-structure
+description: Repo-wide structural-maintainability review — code-judo restructurings, 1k-line file guard, anti-spaghetti branching, canonical-layer enforcement, anti-magic abstractions, explicit type/boundary contracts.
+disable-model-invocation: true
+---
+
+# Structural-Maintainability Review
+
+Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
+
+Above all, this skill should push the reviewer to be **ambitious** about code structure. Do not merely identify local cleanup opportunities. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant.
+
+The structural lens is **repo-wide**: read any file in the codebase as needed (Read/Grep/Bash) to judge whether canonical helpers already exist, whether file-size budgets are honored, and whether the change makes the codebase easier or harder to live with.
+
+## Core Prompt
+
+Start from this baseline:
+
+> Perform a deep structural review of the current branch's changes.
+> Rethink how to structure / implement the changes to meaningfully improve code quality without impacting behavior.
+> Work to improve abstractions, modularity, reduce spaghetti code, improve succinctness and legibility.
+> Be ambitious — if there is a clear path to improving the implementation that involves restructuring some of the codebase, go for it.
+> Be extremely thorough and rigorous. Measure twice, cut once.
+
+## Non-Negotiable Additional Standards
+
+Apply the baseline prompt above, plus these explicit review rules:
+
+0. **Be ambitious about structural simplification.**
+   - Do not stop at "this could be a bit cleaner."
+   - Look for opportunities to reframe the change so that whole branches, helpers, modes, conditionals, or layers disappear entirely.
+   - Prefer the solution that makes the code feel inevitable in hindsight.
+   - Assume there is often a "code judo" move available: a re-organization that uses the existing architecture more effectively and makes the change dramatically simpler and more elegant.
+   - If you see a path to delete complexity rather than rearrange it, push hard for that path.
+
+1. **Do not let a PR push a file from under 1k lines to over 1k lines without a very strong reason.**
+   - Treat this as a strong code-quality smell by default.
+   - Prefer extracting helpers, subcomponents, modules, or local abstractions instead of letting a file sprawl past 1000 lines.
+   - If the diff crosses that threshold, explicitly ask whether the code should be decomposed first.
+   - Only waive this if there is a compelling structural reason and the resulting file is still clearly organized.
+
+2. **Do not allow random spaghetti growth in existing code.**
+   - Be highly suspicious of new ad-hoc conditionals, scattered special cases, or one-off branches inserted into unrelated flows.
+   - If a change adds "weird if statements in random places", treat that as a design problem, not a stylistic nit.
+   - Prefer pushing the logic into a dedicated abstraction, helper, state machine, policy object, or separate module instead of tangling an existing path.
+   - Call out changes that make the surrounding code harder to reason about, even if they technically work.
+
+3. **Bias toward cleaning the design, not just accepting working code.**
+   - If behavior can stay the same while the structure becomes meaningfully cleaner, push for the cleaner version.
+   - Do not rubber-stamp "it works" implementations that leave the codebase messier.
+   - Strongly prefer simplifications that remove moving pieces altogether over refactors that merely spread the same complexity around.
+
+4. **Prefer direct, boring, maintainable code over hacky or magical code.**
+   - Treat brittle, ad-hoc, or "magic" behavior as a code-quality problem.
+   - Be skeptical of generic mechanisms that hide simple data-shape assumptions.
+   - Flag thin abstractions, identity wrappers, or pass-through helpers that add indirection without buying clarity.
+
+5. **Push hard on type and boundary cleanliness when they affect maintainability.**
+   - Question unnecessary optionality, `unknown`, `any`, or cast-heavy code when a clearer type boundary could exist.
+   - Prefer explicit typed models or shared contracts over loosely-shaped ad-hoc objects.
+   - If a branch relies on silent fallback to paper over an unclear invariant, ask whether the boundary should be made explicit instead.
+
+6. **Keep logic in the canonical layer and reuse existing helpers.**
+   - Call out feature logic leaking into shared paths or implementation details leaking through APIs.
+   - Prefer existing canonical utilities/helpers over bespoke one-offs.
+   - Push code toward the right package, service, or module instead of normalizing architectural drift.
+
+7. **Treat unnecessary sequential orchestration and non-atomic updates as design smells when the cleaner structure is obvious.**
+   - If independent work is serialized for no good reason, ask whether the flow should run in parallel instead.
+   - If related updates can leave state half-applied, push for a more atomic structure.
+   - Do not over-index on micro-optimizations, but do flag avoidable orchestration complexity that makes the implementation more brittle.
+
+## Primary Review Questions
+
+For every meaningful change, ask:
+
+- Is there a "code judo" move that would make this dramatically simpler?
+- Can this change be reframed so fewer concepts, branches, or helper layers are needed?
+- Does this improve or worsen the local architecture?
+- Did the diff add branching complexity where a better abstraction should exist?
+- Did a previously cohesive module become more coupled, more stateful, or harder to scan?
+- Is this logic living in the right file and layer?
+- Did this change enlarge a file or component past a healthy size boundary?
+- Are there repeated conditionals that signal a missing model or missing helper?
+- Is the implementation direct and legible, or does it rely on special cases and incidental control flow?
+- Is this abstraction actually earning its keep, or is it just a wrapper?
+- Did the diff introduce casts, optionality, or ad-hoc object shapes that obscure the real invariant?
+- Is this logic living in the canonical layer, or did the diff leak details across a boundary?
+- Is this orchestration more sequential or less atomic than it needs to be?
+
+## What to Flag Aggressively
+
+Escalate findings when you see:
+
+- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
+- Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
+- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
+- New conditionals bolted onto unrelated code paths.
+- One-off booleans, nullable modes, or flags that complicate existing control flow.
+- Feature-specific logic leaking into general-purpose modules.
+- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
+- Thin wrappers or identity abstractions that add indirection without simplifying anything.
+- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
+- Copy-pasted logic instead of extracted helpers.
+- Narrow edge-case handling implemented in the middle of an already busy function.
+- Refactors that technically pass tests but make the code less modular or less readable.
+- "Temporary" branching that is likely to become permanent debt.
+- Bespoke helpers where the codebase already has a canonical utility for the job.
+- Logic added in the wrong layer/package when it should live somewhere more central.
+- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
+- Partial-update logic that leaves state less atomic than necessary.
+
+## Preferred Remedies
+
+When you identify a code-quality problem, prefer suggestions like:
+
+- Delete a whole layer of indirection rather than polishing it.
+- Reframe the state model so conditionals disappear instead of getting centralized.
+- Change the ownership boundary so the feature becomes a natural extension of an existing abstraction.
+- Turn special-case logic into a simpler default flow with fewer exceptions.
+- Extract a helper or pure function.
+- Split a large file into smaller focused modules.
+- Move feature-specific logic behind a dedicated abstraction.
+- Replace condition chains with a typed model or explicit dispatcher.
+- Separate orchestration from business logic.
+- Collapse duplicate branches into a single clearer flow.
+- Delete wrappers that do not meaningfully clarify the API.
+- Reuse the existing canonical helper instead of introducing a near-duplicate.
+- Make type boundaries more explicit so the control flow gets simpler.
+- Move the logic to the package/module/layer that already owns the concept.
+- Parallelize independent work when that also simplifies the orchestration.
+- Restructure related updates into a more atomic flow when partial state would be harder to reason about.
+
+Do not be satisfied with "maybe rename this" feedback when the real issue is structural.
+Do not be satisfied with a merely cleaner version of the same messy idea if there is a plausible path to a much simpler idea.
+
+## Review Tone
+
+Be direct, serious, and demanding about quality.
+Do not be rude, but do not soften major maintainability issues into mild suggestions.
+If the code is making the codebase messier, say so clearly.
+If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
+
+Good phrases:
+
+- `this pushes the file past 1k lines. can we decompose this first?`
+- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
+- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
+- `this feels like feature logic leaking into a shared path. can we isolate it?`
+- `this abstraction seems unnecessary. can we just keep the direct flow?`
+- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
+- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
+- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
+- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
+
+## Output Expectations
+
+Prioritize findings in this order:
+
+1. Structural code-quality regressions
+2. Missed opportunities for dramatic simplification / code-judo restructuring
+3. Spaghetti / branching complexity increases
+4. Boundary / abstraction / type-contract problems that make the code harder to reason about
+5. File-size and decomposition concerns
+6. Modularity and abstraction issues
+7. Legibility and maintainability concerns
+
+Do not flood the review with low-value nits if there are larger structural issues.
+Prefer a smaller number of high-conviction comments over a long list of cosmetic notes.
+
+## Approval Bar
+
+Do not approve merely because behavior seems correct.
+The bar for approval is:
+
+- no clear structural regression
+- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
+- no unjustified file-size explosion
+- no obvious spaghetti-growth from special-case branching
+- no obviously hacky or magical abstraction that makes the code harder to reason about
+- no unnecessary wrapper/cast/optionality churn obscuring the real design
+- no clear architecture-boundary leak or avoidable canonical-helper duplication
+- no missed opportunity for an obvious decomposition that would materially improve maintainability
+
+Treat these as presumptive blockers unless the author can justify them clearly:
+
+- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
+- the PR pushes a file from below 1000 lines to above 1000 lines
+- the PR adds ad-hoc branching that makes an existing flow more tangled
+- the PR solves a local problem by scattering feature checks across shared code
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
+- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+
+If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.
+
+## Step 1: Identify Changed Files
+
+Capture the command output (or equivalent) as your authoritative changed-file set before reviewing. The structural lens applies to changes in any language — do not filter by extension.
+
+```bash
+git diff --name-only $(git merge-base HEAD main)..HEAD
+```
+
+If the list is empty, state that explicitly and do not invent structural findings.
+
+## Output Format
+
+```markdown
+## Review Summary
+
+[1-2 sentence overview of structural findings]
+
+## Issues
+
+### Critical (Blocking)
+
+1. [FILE:LINE] ISSUE_TITLE
+   - Issue: Description of the structural problem
+   - Why: Why this matters (maintainability, spaghetti growth, missed code-judo move)
+   - Fix: Specific recommended restructuring
+
+### Major (Should Fix)
+
+2. [FILE:LINE] ISSUE_TITLE
+   - Issue: ...
+   - Why: ...
+   - Fix: ...
+
+### Minor (Nice to Have)
+
+N. [FILE:LINE] ISSUE_TITLE
+   - Issue: ...
+   - Why: ...
+   - Fix: ...
+
+### Informational (For Awareness)
+
+N. [FILE:LINE] SUGGESTION_TITLE
+   - Suggestion: ...
+   - Rationale: ...
+
+## Good Patterns
+
+- [FILE:LINE] Pattern description (preserve this)
+
+## Verdict
+
+Ready: Yes | No | With fixes 1-N (Critical/Major only; Minor items are acceptable)
+Rationale: [1-2 sentences]
+```
+
+## Rules
+
+- Read repo-wide (Read/Grep/Bash) before claiming a canonical helper does not exist
+- Number every issue sequentially (1, 2, 3...)
+- Include FILE:LINE for each issue
+- Separate Issue/Why/Fix clearly
+- Categorize by actual severity
+- Prefer fewer high-conviction structural findings over many cosmetic notes
+- The Verdict ignores Minor and Informational items — only Critical and Major block approval

--- a/plugins/beagle-core/skills/review-structure/SKILL.md
+++ b/plugins/beagle-core/skills/review-structure/SKILL.md
@@ -12,6 +12,16 @@ Above all, this skill should push the reviewer to be **ambitious** about code st
 
 The structural lens is **repo-wide**: read any file in the codebase as needed (Read/Grep/Bash) to judge whether canonical helpers already exist, whether file-size budgets are honored, and whether the change makes the codebase easier or harder to live with.
 
+## Hard gates (sequence)
+
+Advance only when each **pass condition** is objectively satisfied (artifact path, tool output, or labeled capture — not "I checked it mentally"):
+
+| Gate | Pass condition |
+|------|----------------|
+| **G1 — Changed-file list** | `git diff --name-only` (or equivalent) returns a non-empty list *or* you exit with an explicit "no changed files" message; the list is recorded before any review step begins. |
+| **G2 — Full file reads** | Every file in scope has been opened with `Read`; for each file you record the path and line count (e.g. `src/foo.ts — 342 lines`). Do **not** proceed to findings until all reads are logged. |
+| **G3 — Canonical-helper and 1k-line claims verified** | Any finding that asserts "no canonical helper exists" must cite a `Grep` artifact showing the search pattern and result. Any finding that asserts a file exceeds 1 000 lines must cite a `wc -l` or `Read` line-count artifact. Findings lacking these artifacts are **blocked** from the report. |
+
 ## Core Prompt
 
 Start from this baseline:
@@ -90,25 +100,13 @@ For every meaningful change, ask:
 
 ## What to Flag Aggressively
 
-Escalate findings when you see:
+Apply rules 0–7 above, and escalate especially when you see:
 
-- A complicated implementation where a cleaner reframing could delete whole categories of complexity.
 - Refactors that move code around but fail to reduce the number of concepts a reader must hold in their head.
-- A file crossing 1000 lines due to the PR, especially if the new code could be split out.
-- New conditionals bolted onto unrelated code paths.
-- One-off booleans, nullable modes, or flags that complicate existing control flow.
-- Feature-specific logic leaking into general-purpose modules.
-- Generic "magic" handling that hides simple structure and makes the code harder to reason about.
-- Thin wrappers or identity abstractions that add indirection without simplifying anything.
-- Unnecessary casts, `any`, `unknown`, or optional params that muddy the real contract.
 - Copy-pasted logic instead of extracted helpers.
 - Narrow edge-case handling implemented in the middle of an already busy function.
 - Refactors that technically pass tests but make the code less modular or less readable.
 - "Temporary" branching that is likely to become permanent debt.
-- Bespoke helpers where the codebase already has a canonical utility for the job.
-- Logic added in the wrong layer/package when it should live somewhere more central.
-- Sequential async flow where obviously independent work could stay simpler and clearer with parallel execution.
-- Partial-update logic that leaves state less atomic than necessary.
 
 ## Preferred Remedies
 
@@ -141,18 +139,6 @@ Do not be rude, but do not soften major maintainability issues into mild suggest
 If the code is making the codebase messier, say so clearly.
 If the implementation missed an opportunity for a dramatic simplification, say that clearly too.
 
-Good phrases:
-
-- `this pushes the file past 1k lines. can we decompose this first?`
-- `this adds another special-case branch into an already busy flow. can we move this behind its own abstraction?`
-- `this works, but it makes the surrounding code more spaghetti. let's keep the behavior and restructure the implementation.`
-- `this feels like feature logic leaking into a shared path. can we isolate it?`
-- `this abstraction seems unnecessary. can we just keep the direct flow?`
-- `why does this need a cast / optional here? can we make the boundary more explicit instead?`
-- `this looks like a bespoke helper for something we already have elsewhere. can we reuse the canonical one?`
-- `i think there's a code-judo move here that makes this much simpler. can we reframe this so these branches disappear?`
-- `this refactor moves complexity around, but doesn't really delete it. is there a way to make the model itself simpler?`
-
 ## Output Expectations
 
 Prioritize findings in this order:
@@ -170,26 +156,15 @@ Prefer a smaller number of high-conviction comments over a long list of cosmetic
 
 ## Approval Bar
 
-Do not approve merely because behavior seems correct.
-The bar for approval is:
+Do not approve merely because behavior seems correct. The bar is: no violation of rules 0–7 above, and no clear structural regression.
 
-- no clear structural regression
-- no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
-- no unjustified file-size explosion
-- no obvious spaghetti-growth from special-case branching
-- no obviously hacky or magical abstraction that makes the code harder to reason about
-- no unnecessary wrapper/cast/optionality churn obscuring the real design
-- no clear architecture-boundary leak or avoidable canonical-helper duplication
-- no missed opportunity for an obvious decomposition that would materially improve maintainability
+Treat as presumptive blockers unless the author can justify them clearly:
 
-Treat these as presumptive blockers unless the author can justify them clearly:
-
-- the PR preserves a lot of incidental complexity when there is a plausible code-judo move that would delete it
-- the PR pushes a file from below 1000 lines to above 1000 lines
-- the PR adds ad-hoc branching that makes an existing flow more tangled
-- the PR solves a local problem by scattering feature checks across shared code
-- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
-- the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
+- the PR preserves incidental complexity when a plausible code-judo move would delete it (rule 0)
+- the PR pushes a file from below 1000 lines to above 1000 lines (rule 1)
+- the PR adds ad-hoc branching that makes an existing flow more tangled (rule 2)
+- the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract (rules 4–5)
+- the PR duplicates an existing helper or puts logic in the wrong layer (rule 6)
 
 If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.
 
@@ -198,7 +173,18 @@ If those conditions are not met, leave explicit, actionable feedback and push fo
 Capture the command output (or equivalent) as your authoritative changed-file set before reviewing. The structural lens applies to changes in any language — do not filter by extension.
 
 ```bash
-git diff --name-only $(git merge-base HEAD main)..HEAD
+BASE=$(for ref in main origin/main master origin/master; do
+         git rev-parse --verify "$ref" >/dev/null 2>&1 && { echo "$ref"; break; }
+       done)
+if [ -z "$BASE" ]; then
+  echo "error: no main/master ref found (checked main, origin/main, master, origin/master)." >&2
+  exit 1
+fi
+MERGE_BASE=$(git merge-base HEAD "$BASE") || {
+  echo "error: git merge-base HEAD $BASE failed." >&2
+  exit 1
+}
+git diff --name-only "$MERGE_BASE..HEAD"
 ```
 
 If the list is empty, state that explicitly and do not invent structural findings.


### PR DESCRIPTION
## Summary

Adds a `review-structure` skill: a repo-wide structural-maintainability code review focused on implementation quality, abstraction quality, and codebase health. It pushes reviewers to be ambitious about "code-judo" restructurings (preserve behavior, dramatically simplify) rather than settling for working-but-messy code.

It lives in **beagle-core** — alongside the other language-agnostic review workflows (`review-plan`, `review-llm-artifacts`) — rather than as a standalone single-skill plugin.

## Changes

### Added
- **beagle-core:** `review-structure` skill (`/beagle-core:review-structure`). User-invoked only (`disable-model-invocation`). Covers code-judo simplification, a 1k-line file-size guard, anti-spaghetti branching, canonical-layer reuse, anti-magic/anti-wrapper abstractions, and explicit type/boundary contracts. Ships a severity-categorized output format and an explicit approval bar.
- CHANGELOG entry under `[Unreleased]`.
- CLAUDE.md skill counts (145→146, beagle-core 20→21) and a new Key Skills row.

> Version bumps (marketplace + beagle-core `plugin.json`) are intentionally **deferred to the dedicated release PR**, matching this repo's `chore(release)` flow.

## Motivation

Existing review skills are framework-specific (`review-go`, `review-python`, …) or artifact-specific (`review-llm-artifacts`). None take a repo-wide structural lens that asks "is there a restructuring that deletes whole categories of complexity?" This fills that gap. It belongs in beagle-core because it is language-agnostic, like the workflows already there — a dedicated one-skill plugin would be packaging overhead the content doesn't justify.

## Testing

This is a pure-markdown plugin marketplace (no build/test system). Validation performed:

- [x] Touched JSON parses; marketplace still lists 12 plugins.
- [x] Zero lingering references to the discarded standalone plugin anywhere in the repo.
- [x] Moved SKILL.md has no hardcoded plugin name (portable).
- [x] Net diff vs `main` is exactly 3 files: SKILL.md, CHANGELOG, CLAUDE.md (no version-file changes).

## Checklist

- [x] Follows project conventions (Conventional Commits, semver, Keep a Changelog)
- [x] Self-review completed
- [x] JSON validates / no stray references
- [x] CHANGELOG updated (under `[Unreleased]`)
- [x] CLAUDE.md updated

---

Generated with [Claude Code](https://claude.com/claude-code)