### PR TITLE
docs: add privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,27 @@
+# Privacy Policy
+
+_Last updated: May 26, 2026_
+
+Beagle is a [Claude Code](https://claude.com/claude-code) plugin marketplace distributed as Markdown skill files (plus one local helper script for numbering ADRs). It runs entirely inside your local Claude Code session.
+
+## What we collect
+
+Nothing. Beagle does not collect, store, transmit, or sell any personal data. It contains no telemetry, analytics, tracking, or "phone-home" code, and it has no backend servers.
+
+## How Beagle works
+
+The plugins are static Markdown instructions that Claude Code reads locally. Beagle makes no network requests of its own.
+
+Some skills instruct Claude Code to use its own built-in tools — for example web search, `git`, or the GitHub CLI (`gh`) — but only when you invoke those skills. Any such activity is performed by Claude Code and the tools you have configured, under your control. That activity is governed by the privacy policies of those tools and services (for example [Anthropic](https://www.anthropic.com/legal/privacy) and [GitHub](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement)), not by Beagle.
+
+## Your data
+
+Anything Beagle's skills read or write — your source code, documentation, and review output — stays on your machine or within the services you already use. Beagle never receives a copy.
+
+## Changes
+
+This policy may be updated over time. Changes are tracked in this file's git history.
+
+## Contact
+
+Questions: legal@existentialbirds.com


### PR DESCRIPTION
Adds `PRIVACY.md` so the claude-community marketplace submission has a hostable privacy-policy URL.

Beagle is a pure-Markdown plugin marketplace: no telemetry, no analytics, no backend servers, and no network requests of its own (verified — no `hooks.json`, no `.mcp.json`, no `bin/` executables; the single script `next_adr_number.py` only does local file numbering). Any tool use (web search, `git`, `gh`) is Claude Code's, under the user's control. The policy states this plainly.

Contact email: legal@existentialbirds.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)