### PR TITLE
chore(release): 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [4.0.0] - 2026-05-27
 
+### Added
+- **beagle-core:** Add `review-skill` skill for automated skill PR review — validates structural validity, design quality, and marketplace consistency with reference checks for structure, design, and marketplace integration ([#111](https://github.com/existential-birds/beagle/pull/111))
+
 ### Changed
 - **BREAKING:** Merged beagle-meta into beagle-core — `skill-builder` and `review-skill` now live under beagle-core
 - **BREAKING:** Merged beagle-remix-v2 into beagle-react — all 12 Remix v2 skills now live under beagle-react

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-react/.claude-plugin/plugin.json
+++ b/plugins/beagle-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-react",
-  "description": "React, React Flow, React Router, shadcn/ui, Tailwind v4, Vitest, and Zustand code review. Pairs with beagle-core for full workflow.",
-  "version": "1.2.1",
+  "description": "React, React Flow, React Router, Remix v2, shadcn/ui, Tailwind v4, Vitest, and Zustand code review. Pairs with beagle-core for full workflow.",
+  "version": "1.3.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"
@@ -11,6 +11,8 @@
     "react",
     "react-flow",
     "react-router",
+    "remix",
+    "remix-v2",
     "shadcn",
     "tailwind",
     "vitest",


### PR DESCRIPTION
## Summary

- Bump plugin versions for 4.0.0 release
- Add missing `review-skill` entry to CHANGELOG.md
- Update beagle-react description and keywords for absorbed Remix v2 skills

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 4.0.0 (already bumped in #115)
- [x] `plugins/beagle-core/.claude-plugin/plugin.json` → 1.6.0
- [x] `plugins/beagle-react/.claude-plugin/plugin.json` → 1.3.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.6.1

## Post-merge Steps

After merging, run:
```
/release-tag 4.0.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)