### PR TITLE
feat(beagle-analysis): enable model invocation for brainstorm and write-plan skills

### DIFF
--- a/plugins/beagle-analysis/skills/write-plan/SKILL.md
+++ b/plugins/beagle-analysis/skills/write-plan/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: write-plan
 description: "Use when you have a finalized `beagle-analysis:brainstorm-beagle` spec at `.beagle/concepts/<slug>/spec.md` and need a bite-sized, TDD-driven implementation plan before any code is written. Triggers on: \"write a plan\", \"plan this spec\", \"turn the spec into a plan\", \"now plan the implementation\", \"/write-plan\". Reads the spec, designs the file structure, decomposes work into 2-5 minute TDD steps with exact paths and commands, self-reviews against the spec, gets user approval, then writes to `.beagle/concepts/<slug>/plan.md`. Does NOT brainstorm specs, write code, or execute the plan — produces the plan document only."
-disable-model-invocation: true
 ---
 
 # Write Plan: Spec Into Implementation Plan


### PR DESCRIPTION
## Summary

Enable `brainstorm-beagle` and `write-plan` skills to be invoked via the Skill tool by removing the `disable-model-invocation: true` frontmatter flag from `write-plan`. `brainstorm-beagle` was already model-invocable (no flag present).

## Changes

### Changed
- Removed `disable-model-invocation: true` from `write-plan/SKILL.md` frontmatter

## Motivation

Both skills should be callable by the model via the Skill tool so they can be chained programmatically (e.g., brainstorm producing a spec, then write-plan consuming it) without requiring the user to manually invoke each one.

## Testing

- [ ] Manual testing: verified `write-plan` no longer appears with `disable-model-invocation` in frontmatter
- [ ] No build system — validation is frontmatter inspection

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No build/tests to run (pure markdown plugin)

---

Generated with [Claude Code](https://claude.com/claude-code)