### PR TITLE
fix(beagle-core): harden LLM-artifacts skills against confabulated findings

### DIFF
--- a/plugins/beagle-core/skills/fix-llm-artifacts/SKILL.md
+++ b/plugins/beagle-core/skills/fix-llm-artifacts/SKILL.md
@@ -27,6 +27,8 @@ Sequence matters. Do not apply fixes until each **pass condition** is satisfied 
 
 1. **Working tree** — `git status --porcelain` is empty **or** a stash was created with message `beagle-core: pre-fix-llm-artifacts backup` and `git stash list` shows it. If the user refuses stash/backup, **stop** or document explicit acceptance of risk in the report before edits.
 2. **Review artifact on disk** — `.beagle/llm-artifacts-review.json` exists, **or** `--all` completed a `review-llm-artifacts` run that wrote that file. Otherwise **stop** (no fixes from memory or guesses).
+2a. **Echo + ID lock (anti-confabulation)** — After loading the review (Section 3), echo the finding table (`id | category | file:line | description`) from the **parsed JSON** and record the exact id set as the **locked id set**. You fix only findings in this set; never fix a finding inferred from the branch name, directory, or memory. Every fix you apply or skip maps 1:1 to a locked id. See `beagle-core:review-verification-protocol` → Anti-confabulation (gate 0).
+2b. **Per-fix existence precondition** — Before editing for any finding, confirm (i) its `id` is in the locked set, and (ii) the cited `file` exists and the cited code is actually present at `file:line` (read it now). If the file or code is absent, **do not edit** — the finding is stale or confabulated; mark it skipped with a reason and move on. Never create or rewrite a file to match a finding.
 3. **Stale review** — If `jq -r '.git_head' .beagle/llm-artifacts-review.json` ≠ `git rev-parse HEAD`, prompt to re-run review. **`y`** → re-run review, then continue. **`n`** → **abort** the fix pass (do not apply fixes against stale findings).
 4. **Verification overlay** — If `.beagle/llm-artifacts-verification.json` exists, it must **parse**; build exclude/inconclusive sets **before** partitioning (Section 4). On parse failure, **stop** and report the error.
 5. **Risky fixes** — No `code_removal`, `logic_change`, `mock_boundary`, `abstraction_change`, or `test_refactor` work without the interactive choice in Section 6 (or `s` to skip all remaining risky items).
@@ -68,6 +70,24 @@ cat .beagle/llm-artifacts-review.json 2>/dev/null
 **If file missing:**
 - If `--all` flag: Run `review-llm-artifacts --all` first to produce a full-project review
 - Otherwise: Fail with: "No review results found. Run `/beagle-core:review-llm-artifacts` first."
+
+**Echo + lock ids (gate 2a):** Once the file is present, print every finding from the parsed JSON and lock the id set before partitioning:
+
+```bash
+python3 - <<'PY'
+import json
+r = json.load(open('.beagle/llm-artifacts-review.json'))
+f = r['findings']
+print("| id | category | file:line | description |")
+print("|----|----------|-----------|-------------|")
+for x in f:
+    desc = (x.get('description') or '').replace('|', '\\|')[:80]
+    print(f"| {x['id']} | {x.get('category')} | {x.get('file')}:{x.get('line')} | {desc} |")
+print("Locked ids: {" + ", ".join(str(x['id']) for x in f) + "}")
+PY
+```
+
+Adjudicate and fix only the ids above. If your sense of what to fix differs from this table, the table wins.
 
 **Optional verification overlay** — if `.beagle/llm-artifacts-verification.json` exists:
 - Build a set of finding ids with `status: false_positive` → **exclude** these from all fix lists.
@@ -134,7 +154,10 @@ Otherwise, spawn parallel agents per category with `Task` tool:
 ```
 Task: Apply safe fixes for category "{category}"
 Files: [list of files with findings in this category]
-Instructions: Apply each fix, preserving surrounding code. Report success/failure per fix.
+Instructions: For EACH finding, first confirm it is in the locked id set and that the
+cited code exists at file:line (read it). If the file or code is absent, skip the finding
+with a reason — do NOT create or rewrite a file to match the finding. Then apply each
+confirmed fix, preserving surrounding code. Report success/failure/skip per fix by id.
 ```
 
 Categories to parallelize:

--- a/plugins/beagle-core/skills/fix-llm-artifacts/SKILL.md
+++ b/plugins/beagle-core/skills/fix-llm-artifacts/SKILL.md
@@ -78,12 +78,19 @@ python3 - <<'PY'
 import json
 r = json.load(open('.beagle/llm-artifacts-review.json'))
 f = r['findings']
+if not isinstance(f, list) or not f:
+    raise SystemExit("No findings to lock; aborting.")
+ids = [x.get('id') for x in f]
+if any(not isinstance(i, int) for i in ids):
+    raise SystemExit("All finding ids must be integers; aborting.")
+if len(set(ids)) != len(ids):
+    raise SystemExit("Duplicate finding ids detected; aborting.")
 print("| id | category | file:line | description |")
 print("|----|----------|-----------|-------------|")
 for x in f:
     desc = (x.get('description') or '').replace('|', '\\|')[:80]
     print(f"| {x['id']} | {x.get('category')} | {x.get('file')}:{x.get('line')} | {desc} |")
-print("Locked ids: {" + ", ".join(str(x['id']) for x in f) + "}")
+print("Locked ids: {" + ", ".join(str(i) for i in sorted(set(ids))) + "}")
 PY
 ```
 

--- a/plugins/beagle-core/skills/llm-artifacts-detection/SKILL.md
+++ b/plugins/beagle-core/skills/llm-artifacts-detection/SKILL.md
@@ -126,7 +126,7 @@ For each issue found, report: [FILE:LINE] ISSUE_TITLE
 
 ## Gates (reporting)
 
-Run these in order so findings are evidence-bound, not inferred:
+Run these in order so findings are evidence-bound, not inferred. This is the detection-side instance of the **Anti-confabulation gate** in `beagle-core:review-verification-protocol`: every `[FILE:LINE]` must be echoed from a freshly read buffer in this turn, never inferred from the branch name, directory, or memory.
 
 1. **Anchor** — Set `FILE` and `LINE` from an opened buffer, `read_file`, or equivalent; do not rely only on stale search snippets. **Pass:** `LINE` is in range for `FILE`, and the described issue is visible on that line or its immediate neighbors.
 2. **Title** — `ISSUE_TITLE` states the defect in plain language (about one short sentence), not a proposed fix. **Pass:** someone opening `FILE` at `LINE` can see why the title applies.

--- a/plugins/beagle-core/skills/review-llm-artifacts/SKILL.md
+++ b/plugins/beagle-core/skills/review-llm-artifacts/SKILL.md
@@ -160,6 +160,10 @@ Wait for all subagents to complete, then:
 2. Assign unique IDs (1, 2, 3...)
 3. Group by category for display
 
+**Echo before write (anti-confabulation):** Every finding written to JSON MUST come from a subagent's returned `[FILE:LINE] ISSUE_TITLE` output, not from the branch name, directory, or your own inference. After assigning ids, echo the consolidated table — `id | category | file:line | description` — and confirm each row traces to a specific subagent result. Do not add findings that no subagent reported.
+
+**ID lock:** Ids are contiguous `1..N` with no gaps or duplicates. This `1..N` set is the **locked id set** that downstream skills (`verify-llm-artifacts`, `fix-llm-artifacts`) bind to 1:1. `summary.total` MUST equal `N`, and `summary.by_category` counts MUST sum to `N`. State the id set before writing JSON.
+
 ## Step 5: Write JSON Report
 
 Create `.beagle` directory if it doesn't exist:
@@ -244,9 +248,20 @@ Before completing, verify the review executed correctly:
 2. **Subagent success:** All 4 subagents completed without errors
 3. **Git HEAD captured:** The `git_head` field is non-empty in the report
 4. **Staleness check:** If a previous report exists, compare stored `git_head` to current HEAD and warn if different
+5. **ID + count integrity:** Finding ids are contiguous `1..N`; `summary.total == N`; `summary.by_category` sums to `N`. A mismatch means a finding was added, dropped, or duplicated — fix before completing.
 
 ```bash
 python3 -c "import json; json.load(open('.beagle/llm-artifacts-review.json'))" 2>/dev/null && echo "✓ Valid JSON" || echo "✗ Invalid JSON"
+
+python3 - <<'PY'
+import json
+r = json.load(open('.beagle/llm-artifacts-review.json'))
+ids = [x['id'] for x in r['findings']]
+n = len(ids)
+ok = ids == list(range(1, n + 1)) and r['summary']['total'] == n \
+     and sum(r['summary']['by_category'].values()) == n
+print("✓ ids 1..N and counts consistent" if ok else f"✗ id/count mismatch: ids={ids} total={r['summary']['total']}")
+PY
 
 STORED_HEAD=$(jq -r '.git_head' .beagle/llm-artifacts-review.json 2>/dev/null)
 CURRENT_HEAD=$(git rev-parse --short HEAD)
@@ -270,6 +285,7 @@ If any verification fails, report the error and do not proceed.
 ## Rules
 
 - Follow **Hard gates** order; do not skip **G3** (JSON before Step 6).
+- **Anti-confabulation:** every finding must trace to a subagent's `[FILE:LINE]` output (Step 4 echo); never invent findings from the branch name, directory, or inference. See `beagle-core:review-verification-protocol` → Anti-confabulation (gate 0).
 - Always load the `beagle-core:llm-artifacts-detection` skill first
 - Use `Task` tool for parallel subagents when >= 4 files
 - Every finding MUST have file:line reference

--- a/plugins/beagle-core/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-core/skills/review-verification-protocol/SKILL.md
@@ -8,6 +8,18 @@ user-invocable: false
 
 This protocol MUST be followed before reporting any code review finding. Skipping these steps leads to false positives that waste developer time and erode trust in reviews.
 
+## Anti-confabulation (gate 0 — applies to ALL review/verify skills)
+
+Before issuing **any** verdict — confirm, reject, sever, fix, or adjudicate — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+- For a structured report (e.g. `verify-llm-artifacts` adjudicating `findings[]`): the finding's id + file + line + description, printed from the **parsed source file**, not from memory.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently adjudicate things that are not in the file. It runs **before** the per-finding hard gates below. Skills that consume this protocol implement it concretely: `verify-llm-artifacts` (Load + ECHO + ID-lock gate), `review-llm-artifacts` (echo finding before writing JSON), `llm-artifacts-detection` (anchor `FILE:LINE` from an opened buffer).
+
 ## Hard gates (sequence)
 
 Apply **once per finding** before it may appear in the review. If a gate fails, **omit** the finding, **downgrade** to Informational (per [Severity Calibration](#severity-calibration)), or **rephrase** as a question—do not ship soft accusations.
@@ -215,6 +227,7 @@ Flag missing try/catch **ONLY IF**:
 ## Before Submitting Review
 
 Final verification:
+0. Each finding passed [Anti-confabulation (gate 0)](#anti-confabulation-gate-0--applies-to-all-reviewverify-skills) — its target was echoed from a source read in this turn, not recalled or inferred.
 1. Each finding passed [Hard gates (sequence)](#hard-gates-sequence) (anchor, evidence with artifacts, severity, format).
 2. Re-read each finding and ask: "Did I verify this is actually an issue?"
 3. For each finding, can you point to the specific line that proves the issue exists?

--- a/plugins/beagle-core/skills/verify-llm-artifacts/SKILL.md
+++ b/plugins/beagle-core/skills/verify-llm-artifacts/SKILL.md
@@ -23,7 +23,7 @@ If the review file is missing, exit with: `Run /beagle-core:review-llm-artifacts
 
 ## Prerequisite skills
 
-1. Load `Skill(skill: "beagle-core:review-verification-protocol")` — general anti–false-positive discipline.
+1. Load `Skill(skill: "beagle-core:review-verification-protocol")` — general anti–false-positive discipline, including the **Anti-confabulation gate** (echo the artifact from a freshly read source before any verdict). The Load + ECHO gate in step 1 is this skill's concrete instance of that rule.
 2. Load `Skill(skill: "beagle-core:llm-artifacts-detection")` — category criteria for what counts as a real issue.
 
 ## Instructions
@@ -33,18 +33,45 @@ If the review file is missing, exit with: `Run /beagle-core:review-llm-artifacts
 Objective pass conditions before you claim verification is done:
 
 1. **Input parse:** The JSON load command in step 1 exits 0 (no traceback). **Pass:** valid JSON on disk at `.beagle/llm-artifacts-review.json`.
-2. **Evidence before verdict:** For each finding you adjudicate, you have applied [references/verification-checklist.md](references/verification-checklist.md) for its `category` (or documented why the category is N/A) and recorded matching strings in `checks_performed`. **Pass:** no `status` without at least one checklist-backed check or an explicit N/A note in `notes`.
-3. **Output contract:** After writing `.beagle/llm-artifacts-verification.json`, the validate command in step 4 exits 0; `summary` counts equal the number of `results` entries by `status`; every `id` matches the source report. **Pass:** schema-valid JSON and consistent ids/counts.
+2. **Echo before adjudicate:** Step 1 has printed the full finding table (one row per `findings[]` entry: id, file, line, category, description) sourced from the parsed JSON in **this** turn. **Pass:** the table exists in your output and its row count equals `len(findings)` — you have not begun any verdict before it.
+3. **ID lock:** Step 1 has recorded the exact id set from `findings[]` and stated it explicitly. Every `results` entry maps 1:1 to a locked id — none added, none dropped. **Pass:** the locked id list is printed; if at any point an apparent finding has no matching locked id, you STOP (see step 1, ID lock).
+4. **Evidence before verdict:** For each finding you adjudicate, you have applied [references/verification-checklist.md](references/verification-checklist.md) for its `category` (or documented why the category is N/A) and recorded matching strings in `checks_performed`. **Pass:** no `status` without at least one checklist-backed check or an explicit N/A note in `notes`.
+5. **Output contract:** After writing `.beagle/llm-artifacts-verification.json`, the validate command in step 4 exits 0; `summary` counts equal the number of `results` entries by `status`; the `results` id set equals the **locked id set** from gate 3 exactly. **Pass:** schema-valid JSON and `results` ids == locked ids == source `findings[]` ids.
 
-### 1. Load and validate JSON
+### 1. Load, ECHO, and lock ids
+
+This is a two-part gate. **Parsing is not loading** — a `json.load` that exits 0 only proves the file is well-formed, not that you have the findings in context. You must echo the actual content before any adjudication.
+
+**1a. Parse and echo the finding table.**
+
+Print every finding from the parsed `findings[]` array — not from memory, not from the branch name, not from surrounding files:
 
 ```bash
-python3 -c "import json; json.load(open('.beagle/llm-artifacts-review.json'))"
+python3 - <<'PY'
+import json
+r = json.load(open('.beagle/llm-artifacts-review.json'))
+f = r['findings']
+print(f"git_head={r.get('git_head')} scope={r.get('scope')} count={len(f)}")
+print("| id | file | line | category | description |")
+print("|----|------|------|----------|-------------|")
+for x in f:
+    desc = (x.get('description') or '').replace('|', '\\|')[:80]
+    print(f"| {x['id']} | {x.get('file')} | {x.get('line')} | {x.get('category')} | {desc} |")
+print("ids=" + ",".join(str(x['id']) for x in f))
+PY
 ```
 
-**Pass:** command exits 0.
+**Pass:** the command exits 0 and the table (one row per finding) appears in your output.
 
-Record `git_head` and `scope` from the report. If the working tree no longer matches (optional strict mode: compare to `git rev-parse HEAD`), warn that line numbers may drift.
+> **The only source of findings is the parsed `findings[]` array.** Do not infer findings from the branch name, the working directory, or surrounding files. If your mental model of the findings differs from the echoed table, **the table wins** — discard the mental model and adjudicate only the rows above.
+
+**1b. ID lock (hard gate, before any adjudication).**
+
+Record the exact set of ids from the `ids=` line above and state it now, e.g. `Locked ids: {1, 2, 3, 4, 5, 6, 7}`. This is the **locked id set**. Every result you write in step 4 must map 1:1 to this set: no id added, none dropped. The output id-check in step 4 references this locked set, not a re-derived one.
+
+If, while verifying, you find yourself about to adjudicate a finding whose id is **not** in the locked set — or about to write a result for a file that does not appear in any locked row — **STOP**. That is an agent error (you are reasoning from memory or context, not the report). Re-read `findings[]` via the echo command above and restart adjudication. Do **not** record such a finding as `false_positive` (see step 3, Status discipline).
+
+Record `git_head` and `scope` from the report (already printed by 1a). If the working tree no longer matches (optional strict mode: compare to `git rev-parse HEAD`), warn that line numbers may drift.
 
 ### 2. Order findings
 
@@ -57,24 +84,27 @@ With `--priority-only`, stop after processing category `dead_code` and all `fix_
 
 ### 3. Verify each finding
 
-For each finding, follow [references/verification-checklist.md](references/verification-checklist.md).
+For each finding, follow [references/verification-checklist.md](references/verification-checklist.md). Its **first** check for every category is the existence precondition: confirm the cited `file` exists at `source_git_head` before running any symbol/usage check.
 
 **Minimum evidence per finding:**
 
+- **Existence first:** Confirm `file` exists at `source_git_head` (`git cat-file -e <head>:<file>` or `test -f`). A nonexistent cited file is **not** routine — it is either a deleted-file finding (note it) or a sign you are not looking at the real report. A **wall** of missing-file results means STOP and re-read `findings[]` (step 1a). Do not absorb missing files silently.
 - Read the **file** at the cited location and enough context to judge (parent symbol, imports).
 - For unused/dead claims: **search** the repo (symbols, exports, string hooks) unless the issue is purely stylistic with no removal.
 
-**Pass:** `checks_performed` lists only checks you actually ran (e.g. `read_symbol`, `ripgrep_symbol`); `notes` cite the decisive observation.
+**Pass:** `checks_performed` lists only checks you actually ran (e.g. `file_exists`, `read_symbol`, `ripgrep_symbol`); `notes` cite the decisive observation.
 
 Assign one status:
 
 | `status` | Meaning |
 |----------|---------|
-| `confirmed_issue` | The finding is valid; acting on it is appropriate. |
-| `false_positive` | The finding should be discarded; do not auto-fix. |
+| `confirmed_issue` | The finding in the report is valid; acting on it is appropriate. |
+| `false_positive` | The finding **in the report** is invalid (factually wrong, or harmful if "fixed"); do not auto-fix. |
 | `inconclusive` | Needs human or product context; treat like risky in `fix-llm-artifacts`. |
 
 Set `confidence`: `high` | `medium` | `low` based on how direct the evidence was.
+
+**Status discipline (hard rule):** `false_positive` means *"the finding present in the report is invalid."* It never means *"this finding is not in the report."* If you encounter an apparent finding that cannot be matched to an entry in the locked id set (step 1b), that is **agent error, not a false positive** — STOP, re-read `findings[]` via the step-1a echo command, and restart adjudication. Writing a `false_positive` (or any status) for an id outside the locked set is forbidden.
 
 ### 4. Write output
 
@@ -92,7 +122,7 @@ Create `.beagle` if needed. Write **`.beagle/llm-artifacts-verification.json`**:
       "id": 1,
       "status": "confirmed_issue|false_positive|inconclusive",
       "confidence": "high|medium|low",
-      "checks_performed": ["read_symbol", "ripgrep_symbol", "export_trace"],
+      "checks_performed": ["file_exists", "read_symbol", "ripgrep_symbol", "export_trace"],
       "notes": "1-3 sentences of evidence"
     }
   ],
@@ -110,7 +140,7 @@ Validate the file you wrote:
 python3 -c "import json; json.load(open('.beagle/llm-artifacts-verification.json'))"
 ```
 
-**Pass:** command exits 0; re-open the file and confirm `summary` matches `results` (count each `status`).
+**Pass:** command exits 0; re-open the file and confirm (a) `summary` matches `results` (count each `status`), and (b) the set of `results` ids equals the **locked id set** from step 1b exactly — no id added, none dropped. If the id sets differ, the pass is broken: do not ship; re-read `findings[]` (step 1a) and reconcile.
 
 ### 5. Summarize for the user
 

--- a/plugins/beagle-core/skills/verify-llm-artifacts/references/verification-checklist.md
+++ b/plugins/beagle-core/skills/verify-llm-artifacts/references/verification-checklist.md
@@ -2,6 +2,21 @@
 
 Use this **before** marking a review finding as `confirmed_issue`. Skipping steps causes false positives (especially for dead code and “verbose” style).
 
+## Existence precondition (FIRST check, every category)
+
+Run this **before** any symbol/usage check, for **every** finding regardless of category:
+
+- [ ] **Cited file exists at `source_git_head`.** Confirm with `git cat-file -e <source_git_head>:<file>` (or `test -f <file>` when verifying the working tree). Record `file_exists` in `checks_performed`.
+
+Branch on the result:
+
+- **Exists** → proceed to the category checks below.
+- **Does not exist** → **do not** proceed to symbol/usage checks. It is one of:
+  - A finding about a **deleted file** — note it explicitly in `notes` and adjudicate accordingly (often `false_positive` if the cited issue no longer exists, or `inconclusive`).
+  - A sign the report is **corrupt or you are not looking at the real report** — **STOP**, re-read `findings[]` (verify-llm-artifacts step 1a echo), and confirm the file path came from the parsed JSON, not from memory or the branch name.
+
+> A **wall of missing-file results** (most or all findings citing nonexistent files) is an explicit **stop-and-reload trigger**, not routine evidence. It almost always means you are adjudicating confabulated findings rather than the report's `findings[]`. Stop, re-echo the finding table, and restart — do not keep writing `false_positive` rows.
+
 ## Universal
 
 - [ ] Opened the **full** surrounding context (function/class/module), not only the cited line.
@@ -35,8 +50,11 @@ Use this **before** marking a review finding as `confirmed_issue`. Skipping step
 
 | Situation | `status` |
 |-----------|----------|
-| Finding is factually wrong or harmful if “fixed” | `false_positive` |
-| Finding is valid and fix is appropriate | `confirmed_issue` |
+| Finding in the report is factually wrong or harmful if “fixed” | `false_positive` |
+| Finding in the report is valid and fix is appropriate | `confirmed_issue` |
 | Cannot decide without domain/product context | `inconclusive` |
+| Apparent finding has **no matching id in the locked set** (not in the report) | **none — STOP, re-read `findings[]`, restart** |
 
 Prefer `inconclusive` over guessing when evidence is mixed.
+
+`false_positive` means *"the finding in the report is invalid."* It never means *"this finding isn't in the report."* A finding you cannot trace back to a locked id is agent error, not a false positive — do not give it a status.


### PR DESCRIPTION
## Summary

Hardens the LLM-artifacts review/verify chain against a real failure where an agent running `verify-llm-artifacts` fabricated an entire set of findings (inferred from the working dir's branch name and surrounding files) instead of reading `.beagle/llm-artifacts-review.json`, then wrote a schema-valid verification adjudicating findings that did not exist. Only a downstream id-count mismatch caught it — had the counts matched, the bogus report would have shipped.

## Changes

### Changed
- **`verify-llm-artifacts/SKILL.md`** — replaced the step-1 parse with a **Load + ECHO + ID-lock** gate: a Python snippet prints every finding (id, file, line, category, description) from the parsed JSON, the id set is locked before any verdict, and the output contract now requires `results` ids == locked ids == source ids (moved from a late post-write check to a tripwire after load). Added an existence-first evidence rule and **status discipline**: `false_positive` means "the finding in the report is invalid," never "this finding isn't in the report." Hard gates expanded 3 → 5.
- **`verify-llm-artifacts/references/verification-checklist.md`** — added an **existence precondition** as the FIRST check for every category (`git cat-file -e`/`test -f`); a wall of missing-file results is an explicit stop-and-reload trigger.
- **`review-verification-protocol/SKILL.md`** — added a top-level **gate 0 (Anti-confabulation)** applying to all review/verify skills: echo the artifact under review from a source read in *this* turn before any verdict. Cross-referenced from the chain.
- **`review-llm-artifacts/SKILL.md`** (producer) — echo-before-write and 1:1 ID-lock (`1..N` contiguous, summary counts must equal N); Step 7 integrity check validates ids/counts.
- **`fix-llm-artifacts/SKILL.md`** (fixer) — same echo + ID-lock discipline; confirms the finding is in the report AND the cited code exists before editing (never creates/rewrites a file to match a finding).
- **`llm-artifacts-detection/SKILL.md`** — framed its anchor gates as the detection-side instance of gate 0.

## Motivation

The skill optimized for precision of adjudication but had no integrity check that the things being adjudicated are the things in the file. It trusted the agent to have loaded the report faithfully — exactly what an LLM under contextual priming will violate. These gates force the report content into context (echo), bind every verdict to a locked id set, and treat nonexistent cited files and unmatched ids as loud stop signals rather than routine evidence.

## Testing

- [x] Manual testing performed

### Manual Testing Steps

Ran all three embedded Python snippets (verify echo/id-lock, review id+count integrity, fix echo) against a sample `findings[]` fixture — all execute cleanly and produce correct output, with pipe-escaping so finding descriptions don't break the markdown tables. Grep-confirmed the anti-confabulation cross-reference is present in all five SKILL.md files and the locked-id discipline in all three chain skills.

## Compatibility

No JSON schema fields added (`file_exists` is a new value in the existing `checks_performed` array). `summary` counts still equal results-by-status. Not user-facing breaking.

## Related Issues

- Closes #120
- Follow-up: #121 (propagate gate 0 to the remaining review skills with embedded protocol copies)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Markdown/snippet validation performed
- [x] Documentation updated (these skills are the documentation)

---

Generated with [Claude Code](https://claude.com/claude-code)