### PR TITLE
fix(skills): propagate anti-confabulation gate 0 to remaining review skills

### DIFF
--- a/plugins/beagle-core/skills/review-plan/SKILL.md
+++ b/plugins/beagle-core/skills/review-plan/SKILL.md
@@ -12,6 +12,17 @@ Review implementation plans (such as those produced by a plan-writing skill) bef
 
 - Path: Plan file to review (e.g., `docs/plans/2025-01-15-auth-feature.md`)
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag a gap, raise an issue, or assign a verdict — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a plan finding: the **plan step or section text** under review, quoted from the plan file read freshly now (not recalled from earlier in the session) — cite the heading or step number it came from.
+- For a claim about the codebase the plan touches (a type, API, or file the plan references): the **file:line** plus cited code, read freshly now.
+
+> The artifact is the only source of truth. **Never** infer what the plan says from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag content that is not in the plan. It runs **before** the hard gates below.
+
 ## Hard gates (sequence)
 
 Do not skip ahead; each step **passes** only when the condition is objectively satisfied (artifact path, tool success, or labeled capture—not “I read it mentally”).

--- a/plugins/beagle-core/skills/review-structure/SKILL.md
+++ b/plugins/beagle-core/skills/review-structure/SKILL.md
@@ -12,6 +12,17 @@ Above all, this skill should push the reviewer to be **ambitious** about code st
 
 The structural lens is **repo-wide**: read and search any file in the codebase as needed to judge whether canonical helpers already exist, whether file-size budgets are honored, and whether the change makes the codebase easier or harder to live with.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, propose a restructuring, or assert a structural claim — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a structural claim ("no canonical helper exists", "file exceeds 1 000 lines"): the **search pattern + result** or **`wc -l`/read-based count** that backs it.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (sequence)
 
 Advance only when each **pass condition** is objectively satisfied (artifact path, tool output, or labeled capture — not "I checked it mentally"):

--- a/plugins/beagle-elixir/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-elixir/skills/review-verification-protocol/SKILL.md
@@ -10,6 +10,17 @@ This protocol MUST be followed before reporting any code review finding. Skippin
 
 For Elixir/OTP/Phoenix/LiveView files, apply the gates below first; the issue-type and cross-stack sections apply when the reviewed code uses those stacks or patterns.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, reject, or downgrade a finding — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (execute in order)
 
 Do not report a finding until each relevant gate passes for **that** finding. A gate passes only when the pass condition is objectively satisfied (tool output, cited path:line), not when it “feels” verified.

--- a/plugins/beagle-go/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-go/skills/review-verification-protocol/SKILL.md
@@ -8,6 +8,17 @@ user-invocable: false
 
 This protocol MUST be followed before reporting any code review finding. Skipping these steps leads to false positives that waste developer time and erode trust in reviews.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, reject, or downgrade a finding — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (sequenced)
 
 Run these **in order**. Do not move to the next gate until its **pass** condition is met (objective evidence, not internal certainty).

--- a/plugins/beagle-ios/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-ios/skills/review-verification-protocol/SKILL.md
@@ -8,6 +8,17 @@ user-invocable: false
 
 This protocol MUST be followed before reporting any code review finding. Skipping these steps leads to false positives that waste developer time and erode trust in reviews.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, reject, or downgrade a finding — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (sequenced)
 
 Run these **in order**. Do not move to the next gate until its **pass** condition is met (objective evidence, not internal certainty).

--- a/plugins/beagle-python/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-python/skills/review-verification-protocol/SKILL.md
@@ -8,6 +8,17 @@ user-invocable: false
 
 This protocol MUST be followed before reporting any code review finding. Skipping these steps leads to false positives that waste developer time and erode trust in reviews.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, reject, or downgrade a finding — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (sequence)
 
 Complete gates **in order** for each finding (or finding class). A gate **passes** only when the pass condition is objectively met—internal confidence is not enough.

--- a/plugins/beagle-react/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-react/skills/review-verification-protocol/SKILL.md
@@ -8,6 +8,17 @@ user-invocable: false
 
 This protocol MUST be followed before reporting any code review finding. Skipping these steps leads to false positives that waste developer time and erode trust in reviews.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, reject, or downgrade a finding — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (sequenced)
 
 Complete **in order** for each finding (or once per batch if every finding shares the same file/symbol). Do not advance while the prior gate fails.

--- a/plugins/beagle-rust/skills/review-verification-protocol/SKILL.md
+++ b/plugins/beagle-rust/skills/review-verification-protocol/SKILL.md
@@ -8,6 +8,17 @@ user-invocable: false
 
 This protocol MUST be followed before reporting any code review finding. Skipping these steps leads to false positives that waste developer time and erode trust in reviews.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** verdict — flag, reject, or downgrade a finding — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- For a code finding: the **file:line** plus the cited code, read freshly now (not recalled from earlier in the session).
+- For a diff review: the actual **diff hunk** under review.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A verdict issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the verdict.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the hard gates below.
+
 ## Hard gates (sequenced)
 
 Complete these **in order** before you add a finding. Skip a gate only when it clearly does not apply (e.g. skip the usages gate if the finding is not about dead code or “unused”).


### PR DESCRIPTION
## Summary

Follow-up to #122 (which closed #120 and hardened the LLM-artifacts review/verify chain against a real confabulation failure). PR #122 added a top-level **gate 0 (Anti-confabulation)** to `beagle-core:review-verification-protocol`, but the other review skills embed their **own copies** of that protocol rather than loading the shared one — so the gate-0 language did not propagate automatically. This PR completes that sweep.

**Gate 0:** before issuing any verdict, echo the exact artifact under review (file:line + cited code, the diff hunk, or quoted plan/structural-claim source) from a source read in *this* turn — never inferred from the branch name, working directory, surrounding files, or recollection.

## Changes (+88 lines, 8 files, no deletions)

- **6 embedded `review-verification-protocol` copies** — `beagle-{elixir,go,ios,python,react,rust}`. Because every per-language `*-code-review` skill *loads* its plugin's copy (relative `../review-verification-protocol/SKILL.md`), this covers the whole per-language review fleet transitively in one edit each.
- **`review-structure`** and **`review-plan`** (beagle-core) — referenced no protocol at all, so gate 0 is added inline and adapted to each skill's artifact (structural claims / plan-step text).

### Already covered (no change needed)
- **`review-skill`** loads the canonical beagle-core copy (already has gate 0).
- **`review-ai-writing`** and **`review-feedback-schema`** reference the canonical copy cross-plugin → inherit the gate.

## Why embed-copies and not a shared load?

The embedded copies have intentionally drifted per-language (different hard-gate wording, 226–368 lines), so this matches the established pattern rather than refactoring them to load a shared skill. The gate-0 block itself is kept consistent across copies; the canonical's beagle-core-specific cross-references are dropped since those sibling skills don't exist in language plugins. Converting the embeds to load the shared canonical skill would be a larger refactor, out of scope here.

## Testing

No build/test system exists (pure markdown plugin marketplace). Verified by grep that exactly one gate-0 section landed in each of the 8 files, that all six per-language review entrypoints still reference their now-updated copy, and that `review-skill`/`review-ai-writing`/`review-feedback-schema` inherit the canonical gate.

## Related issues

- Closes #121
- Completes the "Scope note" remainder of #119 (its core changes A–F shipped in #122)

🤖 Generated with [Claude Code](https://claude.com/claude-code)