### PR TITLE
fix(beagle-ai): add anti-confabulation gate 0 to code-review skills

### DIFF
--- a/plugins/beagle-ai/skills/deepagents-code-review/SKILL.md
+++ b/plugins/beagle-ai/skills/deepagents-code-review/SKILL.md
@@ -7,6 +7,17 @@ description: Reviews Deep Agents code for bugs, anti-patterns, and improvements.
 
 When reviewing Deep Agents code, check for these categories of issues.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** finding — flag a bug, anti-pattern, or improvement — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- The code finding: its `file:line` plus the cited code, read freshly now.
+- The agent code under review: the `create_deep_agent`, backend, subagent, or middleware snippet your finding depends on, quoted from the file you just read.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A finding issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the finding.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the gates below.
+
 ## Review gates (evidence-bound)
 
 Run these steps in order before and while you write findings. Skipping a step is a failed review.

--- a/plugins/beagle-ai/skills/langgraph-code-review/SKILL.md
+++ b/plugins/beagle-ai/skills/langgraph-code-review/SKILL.md
@@ -7,6 +7,17 @@ description: Reviews LangGraph code for bugs, anti-patterns, and improvements. U
 
 When reviewing LangGraph code, check for these categories of issues.
 
+## Anti-confabulation (gate 0 — runs before every other gate)
+
+Before issuing **any** finding — flag a bug, anti-pattern, or improvement — you MUST echo the exact artifact you are judging, quoted from a source you read in **this** turn:
+
+- The code finding: its `file:line` plus the cited code, read freshly now.
+- The graph/state code under review: the `StateGraph`, node, edge, or state-schema snippet your finding depends on, quoted from the file you just read.
+
+> The artifact is the only source of truth. **Never** infer what you are reviewing from the branch name, the working directory, surrounding files, or recollection. If your mental model differs from the freshly read source, **the source wins.** A finding issued without a same-turn echo of its target is invalid — emit the echo first, or do not emit the finding.
+
+This gate exists because an LLM under contextual priming will confidently flag code that is not in the file. It runs **before** the gates below.
+
 ## Review gates (sequenced)
 
 Complete in order. Each step has an objective pass condition before moving on.


### PR DESCRIPTION
## Summary

The anti-confabulation gate-0 rollout reached active review skills through each plugin's `review-verification-protocol`, but `beagle-ai` has no such protocol skill — so its two code-review skills (`langgraph-code-review`, `deepagents-code-review`) were left without the gate. This adds an inline gate-0 section to each, matching the pattern already used by `review-plan` and `review-structure`.

## Changes

### Added
- Inline **Anti-confabulation (gate 0)** section in `plugins/beagle-ai/skills/langgraph-code-review/SKILL.md` (domain bullet: `StateGraph`/node/edge/state-schema)
- Inline **Anti-confabulation (gate 0)** section in `plugins/beagle-ai/skills/deepagents-code-review/SKILL.md` (domain bullet: `create_deep_agent`/backend/subagent/middleware)

Each section requires the reviewer to echo a freshly read `file:line` artifact before emitting any finding, with the canonical source-of-truth blockquote and "this gate exists because..." rationale.

## Motivation

`beagle-ai` is deprecated (removed from the marketplace in v4.0.0, retained for backward compatibility), but its code-review skills are still loadable by existing users and could confabulate findings. Closing this gap makes gate-0 coverage consistent across every code-review skill in the marketplace. The fix mirrors the existing inline-gate-0 pattern rather than introducing a new protocol file, keeping frozen code minimal.

## Testing

This is a pure-markdown plugin marketplace with no build/lint/test system; validation is manual inspection.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed

### Manual Testing Steps

- Re-read both edited files: gate-0 section is well-formed Markdown, placed after the H1 intro and before each file's first review-gates section.
- Confirmed wording matches the canonical block in `beagle-core/skills/review-verification-protocol/SKILL.md` and the inline pattern in `review-plan`/`review-structure`.

## Related Issues

- Related to #119