### PR TITLE
chore(release): 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-05-31
+
 ### Changed
 - **All active plugins (agent-agnostic skills):** Made every skill across the 10 active plugins (144 `SKILL.md` files) portable to non-Claude agents (Codex, opencode) and conformant to the [Agent Skills spec](https://agentskills.io/specification). Converted `<plugin>:<skill>` namespace tokens to relative `../<skill>/SKILL.md` links; replaced named harness tools (`Skill(skill:…)`, the Task/Skill/Edit/etc. tools, `AskUserQuestion`) and slash-command invocations with generic verbs; rewrote subagent fan-out in every review/orchestrator skill to a hedged-optional pattern ("if the agent supports subagents, dispatch in parallel; otherwise run sequentially with identical output"); neutralized "Claude Code"-as-agent and `CLAUDE.md` references; and made commit/PR attribution a generic optional footer. Removed wholly non-spec frontmatter keys (`autoContext`, `dependencies`, `triggers`) and split `agent-architecture-analysis` (558→130 lines) into `references/`. The Claude Code extensions `disable-model-invocation` and `user-invocable` are retained at top level as documented, accepted extensions (other agents ignore unknown keys). Added `scripts/check-portability.sh`, which gates all 493 skill `.md` files (entrypoints + references) against regressions ([#124](https://github.com/existential-birds/beagle/issues/124)).
 - **beagle-analysis:write-plan**: after writing the plan, prompts "Do you want a prompt to execute this plan in a new session?" and, on yes, invokes `beagle-core:subagent-prompt` to generate the handoff prompt in-session instead of only instructing the user to run it manually.
+- **beagle-analysis:write-plan**: skill is now model-invocable so it can auto-trigger when relevant, instead of being user-invocation-only ([#117](https://github.com/existential-birds/beagle/pull/117))
+
+### Fixed
+- **beagle-ai:** Add an anti-confabulation "gate 0" to the `beagle-ai` code-review skills so reviewers ground every finding in the actual diff before emitting it ([#127](https://github.com/existential-birds/beagle/pull/127))
+- **all review skills:** Propagate anti-confabulation gate 0 to the remaining review skills across the marketplace, blocking confabulated findings consistently ([#126](https://github.com/existential-birds/beagle/pull/126))
+- **beagle-core:** Harden the LLM-artifacts skills against confabulated findings ([#122](https://github.com/existential-birds/beagle/pull/122))
 
 ## [4.0.0] - 2026-05-27
 
@@ -496,7 +504,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v4.1.0...HEAD
+[4.1.0]: https://github.com/existential-birds/beagle/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/existential-birds/beagle/compare/v3.11.0...v4.0.0
 [3.11.0]: https://github.com/existential-birds/beagle/compare/v3.10.0...v3.11.0
 [3.10.0]: https://github.com/existential-birds/beagle/compare/v3.9.1...v3.10.0

--- a/plugins/beagle-ai/.claude-plugin/plugin.json
+++ b/plugins/beagle-ai/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-ai",
   "description": "Pydantic AI, LangGraph, DeepAgents, and Vercel AI SDK skills for building and reviewing AI applications.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-docs/.claude-plugin/plugin.json
+++ b/plugins/beagle-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-docs",
   "description": "Documentation quality, generation, and improvement using Diataxis principles. Pairs with beagle-core for full workflow.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-elixir/.claude-plugin/plugin.json
+++ b/plugins/beagle-elixir/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-elixir",
   "description": "Elixir, Phoenix, and LiveView code review and documentation skills",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-go/.claude-plugin/plugin.json
+++ b/plugins/beagle-go/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-go",
   "description": "Go code review and development skills covering architecture, middleware, data persistence, concurrency, and framework-specific patterns for BubbleTea, Wish SSH, and Prometheus.",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-ios/.claude-plugin/plugin.json
+++ b/plugins/beagle-ios/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-ios",
   "description": "Swift, SwiftUI, SwiftData, iOS animation design/implementation/review, and framework code review (HealthKit, CloudKit, WidgetKit, watchOS, App Intents). Pairs with beagle-core for full workflow.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-python/.claude-plugin/plugin.json
+++ b/plugins/beagle-python/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-python",
   "description": "Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review. Pairs with beagle-core for full workflow.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-react/.claude-plugin/plugin.json
+++ b/plugins/beagle-react/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-react",
   "description": "React, React Flow, React Router, Remix v2, shadcn/ui, Tailwind v4, Vitest, and Zustand code review. Pairs with beagle-core for full workflow.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-rust/.claude-plugin/plugin.json
+++ b/plugins/beagle-rust/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-rust",
   "description": "Rust code review and development skills covering ownership, lifetimes, error handling, async/tokio, serde, sqlx, axum, macros, FFI, unsafe, concurrency, and testing patterns.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-testing/.claude-plugin/plugin.json
+++ b/plugins/beagle-testing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-testing",
   "description": "Language-agnostic test plan generation and execution.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Release version 4.1.0 (changes since v4.0.0)
- Update CHANGELOG.md with the 4.1.0 section and footer compare links

## Changes Since v4.0.0

- **Changed** — all active plugins made agent-agnostic and conformant to the Agent Skills spec (#124, #125)
- **Changed** — beagle-analysis `write-plan` offers in-session execution handoff via `subagent-prompt` (#123)
- **Fixed** — anti-confabulation gate 0 added to beagle-ai code-review skills (#127) and propagated to remaining review skills (#126)
- **Fixed** — beagle-core LLM-artifacts skills hardened against confabulated findings (#122)

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 4.1.0 (already at target; unchanged)
- [x] `plugins/beagle-ai/.claude-plugin/plugin.json` → 1.2.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.8.0
- [x] `plugins/beagle-core/.claude-plugin/plugin.json` → 1.8.0
- [x] `plugins/beagle-docs/.claude-plugin/plugin.json` → 2.3.0
- [x] `plugins/beagle-elixir/.claude-plugin/plugin.json` → 1.5.0
- [x] `plugins/beagle-go/.claude-plugin/plugin.json` → 2.6.0
- [x] `plugins/beagle-ios/.claude-plugin/plugin.json` → 1.5.0
- [x] `plugins/beagle-python/.claude-plugin/plugin.json` → 1.4.0
- [x] `plugins/beagle-react/.claude-plugin/plugin.json` → 1.5.0
- [x] `plugins/beagle-rust/.claude-plugin/plugin.json` → 1.8.0
- [x] `plugins/beagle-testing/.claude-plugin/plugin.json` → 1.4.0

## Post-merge Steps

After merging, run:

```
/release-tag 4.1.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)