### PR TITLE
feat(beagle-core): enable model invocation of subagent-prompt skill

### DIFF
--- a/plugins/beagle-core/skills/subagent-prompt/SKILL.md
+++ b/plugins/beagle-core/skills/subagent-prompt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent-prompt
 description: Produce a comprehensive prompt that hands off the current session's work to a fresh session for sub-agent-orchestrated execution. Use when the user wants to execute discussed/planned work in a new session, run a job to completion via sub-agents, or generate a portable handoff prompt with per-task verification. Assumes the target session supports sub-agents. Triggers on "subagent-prompt", "give me a prompt to run this in a new session", "hand this off to sub-agents", "execute this with sub-agents".
-disable-model-invocation: true
+disable-model-invocation: false
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

Flips `disable-model-invocation` from `true` to `false` for the `subagent-prompt` skill so Claude can auto-invoke it when relevant, in addition to manual `/beagle-core:subagent-prompt` use.

## Changes

### Changed
- `plugins/beagle-core/skills/subagent-prompt/SKILL.md`: `disable-model-invocation: true` → `false`

## Motivation

The subagent-prompt skill produces a portable handoff prompt for sub-agent-orchestrated execution. Previously it could only be triggered manually. Enabling model invocation lets Claude reach for it automatically when a user asks to hand off work to a new session or run a job to completion via sub-agents.

## Testing

- [ ] Manual testing performed

### Manual Testing Steps

- Trigger phrases like "hand this off to sub-agents" or "give me a prompt to run this in a new session" and confirm the skill is offered/invoked automatically.

## Checklist

- [ ] Self-review completed
- [ ] Documentation updated (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)