### PR TITLE
chore(release): 4.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "4.1.0"
+    "version": "4.2.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-06-08
+
+### Changed
+- **beagle-core:subagent-prompt**: skill is now model-invocable (`disable-model-invocation: false`) so it can auto-trigger when relevant, instead of being user-invocation-only ([#132](https://github.com/existential-birds/beagle/pull/132))
+
 ## [4.1.0] - 2026-05-31
 
 ### Changed
@@ -504,7 +509,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v4.1.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v4.2.0...HEAD
+[4.2.0]: https://github.com/existential-birds/beagle/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/existential-birds/beagle/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/existential-birds/beagle/compare/v3.11.0...v4.0.0
 [3.11.0]: https://github.com/existential-birds/beagle/compare/v3.10.0...v3.11.0

--- a/plugins/beagle-core/.claude-plugin/plugin.json
+++ b/plugins/beagle-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-core",
   "description": "Shared code review workflows, verification protocol, git commands, and feedback handling. Recommended as a base for all beagle plugins.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 4.2.0
- Update CHANGELOG.md with changes since v4.1.0

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 4.2.0
- [x] `plugins/beagle-core/.claude-plugin/plugin.json` → 1.9.0

## Changes Since v4.1.0

- **beagle-core:subagent-prompt**: skill is now model-invocable so it can auto-trigger when relevant ([#132](https://github.com/existential-birds/beagle/pull/132))

## Post-merge Steps

After merging, run:
```
/release-tag 4.2.0
```

---

Generated with [Claude Code](https://claude.com/claude-code)