### PR TITLE
feat(beagle-docs): make full Diataxis doc suite spec-compliant

### DIFF
--- a/plugins/beagle-docs/skills/docs-style/SKILL.md
+++ b/plugins/beagle-docs/skills/docs-style/SKILL.md
@@ -8,6 +8,21 @@ user-invocable: false
 
 Apply these principles when writing or reviewing documentation to ensure clarity, consistency, and accessibility for both human readers and LLMs.
 
+## Choose the Right Documentation Type First
+
+Style serves a purpose, and the purpose depends on which of the four Diataxis types you are writing. Before applying the conventions below, decide whether the document is a **Tutorial** (learning), **How-To guide** (a task), **Reference** (looking up), or **Explanation** (understanding) — these are not interchangeable, and mixing them in one document weakens all of them.
+
+To choose, ask the two compass questions: *action or cognition? acquisition or application?*
+
+| The reader's stance | Type |
+|---|---|
+| "I'm learning — guide my hands" | **Tutorial** |
+| "I have a goal — help me reach it" | **How-To** |
+| "I'm working — let me look something up" | **Reference** |
+| "I'm reflecting — help me understand why" | **Explanation** |
+
+For the full decision procedure, the 2×2 map, the two distinctions that resolve most ambiguity (Tutorial vs. How-To, Reference vs. Explanation), and the quality model, see [references/diataxis-compass.md](references/diataxis-compass.md). The type-specific skills (`tutorial-docs`, `howto-docs`, `reference-docs`, `explanation-docs`) build on the principles in this guide once the type is chosen.
+
 ## Voice and Tone
 
 ### Use Second Person
@@ -308,10 +323,20 @@ This will blow your mind.
 Let's dive in!
 ```
 
+## Two Kinds of Quality
+
+Good documentation has two layers of quality, and the second depends on the first:
+
+- **Functional quality** — objective and measurable: accuracy, completeness, consistency, usefulness, precision. This is the prerequisite. The principles in this guide and the type-specific skills target functional quality.
+- **Deep quality** — subjective and human-centred: it feels good to use, anticipates the reader, and fits how people actually work. You cannot reach it without functional quality first; choosing the right type (above) and writing it cleanly lays the conditions for it.
+
+See [references/diataxis-compass.md](references/diataxis-compass.md) for the full quality model and the "work by improvement" approach (improve one real piece at a time; never build empty section skeletons).
+
 ## Quick Reference Checklist
 
 When writing documentation, verify:
 
+- [ ] The document is one clear Diataxis type, not a mix (see [the compass](references/diataxis-compass.md))
 - [ ] Using "you" instead of "the user"
 - [ ] Active voice throughout
 - [ ] No unnecessary words

--- a/plugins/beagle-docs/skills/docs-style/references/diataxis-compass.md
+++ b/plugins/beagle-docs/skills/docs-style/references/diataxis-compass.md
@@ -1,0 +1,108 @@
+# The Diataxis Compass, Map, and Quality Model
+
+The canonical reference for choosing a documentation type and judging its quality, drawn from the [Diataxis framework](https://diataxis.fr/). This file is **self-contained**: every Beagle documentation skill links here, but it carries no dependency on the others, so it remains usable even when a single skill is installed on its own.
+
+Use it to answer three questions:
+
+1. **Which type should I write?** → The Compass.
+2. **How do the four types relate?** → The Map.
+3. **Is what I wrote any good?** → The Quality model.
+
+## The two axes
+
+Diataxis observes that all documentation serves a craft, and a craft is learned and practised along two axes:
+
+- **Action ↔ Cognition** — practical knowledge (*knowing how*, doing) versus theoretical knowledge (*knowing that*, thinking).
+- **Acquisition ↔ Application** — *studying* to acquire skill versus *working* to apply it.
+
+> "These two axes don't just cover the entire territory, they define it. This is why there are necessarily four quarters to it, and there could not be three, or five."
+
+## The Map (2×2)
+
+| | **Action** (informs *doing*) | **Cognition** (informs *thinking*) |
+|---|---|---|
+| **Acquisition** (study / learning) | **Tutorial** | **Explanation** |
+| **Application** (work / a goal) | **How-To guide** | **Reference** |
+
+One-line identity of each type:
+
+- **Tutorial** — *learning-oriented.* A lesson under the guidance of a teacher. Builds competence and confidence through a guaranteed-to-succeed, hands-on experience.
+- **How-To guide** — *task-oriented.* Directs an already-competent user through the steps to reach a real-world goal.
+- **Reference** — *information-oriented.* Austere, authoritative description of the machinery, consulted while working.
+- **Explanation** — *understanding-oriented.* Discursive discussion of *why* — context, alternatives, trade-offs — read away from the keyboard.
+
+## The Compass: choosing a type
+
+> "To use the compass, just two questions need to be asked: *action or cognition? acquisition or application?*"
+
+| If the content… | …and serves the user's… | …it is a… |
+|---|---|---|
+| informs **action** | **acquisition** (study) | **Tutorial** |
+| informs **action** | **application** (work) | **How-To guide** |
+| informs **cognition** | **application** (work) | **Reference** |
+| informs **cognition** | **acquisition** (study) | **Explanation** |
+
+A faster phrasing for a single document or request:
+
+| The reader's stance | Type |
+|---|---|
+| "I'm learning — guide my hands" | **Tutorial** |
+| "I have a goal — help me reach it" | **How-To** |
+| "I'm working — let me look something up" | **Reference** |
+| "I'm reflecting — help me understand why" | **Explanation** |
+
+## The two distinctions that resolve most ambiguity
+
+**Tutorial vs. How-To** — both are action-oriented sequences, so they are easily confused. The split is **study vs. work**, not difficulty:
+
+- A *tutorial* is a lesson; the teacher owns the agenda, eliminates the unexpected, and is responsible if the learner fails.
+- A *how-to guide* is a recipe; the user owns the agenda, brings their own real-world context, and the guide must prepare for branching and the unexpected.
+- Analogy: teaching a child to cook (tutorial) vs. a recipe for someone who already cooks (how-to).
+
+**Reference vs. Explanation** — both are cognition-oriented, so they too blur together. The split is **work vs. study**:
+
+- *Reference* is **bounded by the product/machinery**: neutral, austere facts you consult while working. "Describe, and only describe."
+- *Explanation* is **bounded by a topic**: discursive prose you read while reflecting. It discusses, weighs, and connects.
+- Litmus test: would the reader consult this *while actively working*, or only *after stepping away to reflect*?
+
+## Why not mix types
+
+Each type meets a distinct user need; blending them dilutes all of them. Explanation inside a tutorial gets in the way of doing. Reference interrupted by digressions stops being scannable. Instruction smuggled into explanation stops it from developing its own argument. When a document tries to do two jobs, **split it** and link the halves together.
+
+## Quality: two dimensions
+
+Diataxis distinguishes two kinds of quality, and the second depends on the first.
+
+**Functional quality** — objective, measurable against the world. A document either has these or it does not:
+
+- **accuracy** — it is correct
+- **completeness** — nothing required is missing
+- **consistency** — terms, structure, and format match across the docs
+- **usefulness** — it serves a real user need
+- **precision** — it says exactly what it means
+
+Functional quality is a prerequisite. It takes discipline and attention to detail, and Diataxis alone cannot supply it — but the framework *exposes* functional gaps by forcing each type to do one job well.
+
+**Deep quality** — subjective, human-centred, and recognisable rather than measurable. It is *conditional on functional quality* — you cannot reach it without the foundation:
+
+- feels good to use; has flow
+- anticipates the user's needs
+- fits the way people actually work
+- is, in a word, beautiful
+
+Organising documentation around genuine user needs (which is what the Compass enforces) is what lays the conditions for deep quality.
+
+## How to apply Diataxis: work by improvement
+
+Diataxis is **not** a set of four empty boxes to fill in up front. It "discourages planning and top-down workflows, preferring instead small, responsive iterations."
+
+The working cycle:
+
+1. **Choose** one thing — however small — that you can improve now.
+2. **Assess** it against Diataxis: Does it serve a single, clear user need? Is it the right type? Is the language right for that type?
+3. **Decide** a single next action.
+4. **Do it** and publish.
+
+Don't build skeleton trees of empty sections. "Diataxis changes the structure of your documentation from the inside." Documentation is never finished, yet at each step it stays complete.
+
+Scaling note: for large doc sets, group by type behind landing pages; "seven items seems to be a comfortable general limit" for any one list.

--- a/plugins/beagle-docs/skills/draft-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/draft-docs/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Draft Docs
 
-Generate Reference, How-To, or Explanation documentation drafts to `docs/drafts/` for review before publishing.
+Generate Tutorial, How-To, Reference, or Explanation documentation drafts to `docs/drafts/` for review before publishing. These are the four [Diataxis](https://diataxis.fr/) types — see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md) for the full type-selection procedure.
 
 ## Arguments
 
@@ -50,16 +50,17 @@ Extract from the prompt:
 
 | Keywords | Type | Skill |
 |----------|------|-------|
+| "tutorial", "learn", "getting started", "first", "onboarding", "introduction", "build a/your" | Tutorial | [tutorial-docs](../tutorial-docs/SKILL.md) |
 | "how to", "guide", "steps", "configure", "set up" | How-To | [howto-docs](../howto-docs/SKILL.md) |
 | "API", "reference", "parameters", "function", "endpoint" | Reference | [reference-docs](../reference-docs/SKILL.md) |
 | "why", "how does it work", "concept", "background", "rationale", "design decision", "architecture", "trade-offs" | Explanation | [explanation-docs](../explanation-docs/SKILL.md) |
 
-These three types map to three quadrants of the [Diátaxis](https://diataxis.fr/) framework — Reference (information), How-To (task), and Explanation (understanding). Two distinctions resolve most ambiguity:
+These four types are the quadrants of the [Diátaxis](https://diataxis.fr/) framework — Tutorial (learning), How-To (task), Reference (information), and Explanation (understanding). Decide with the two compass questions — *action or cognition? acquisition or application?* — detailed in [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md). Two distinctions resolve most ambiguity:
 
+- **Tutorial vs. How-To** both give action steps, but a Tutorial teaches a beginner through a guaranteed-to-succeed lesson (study), while a How-To directs a competent user toward a real goal (work). If the reader is learning the product for the first time, it's a Tutorial; if they already know it and want to get a task done, it's a How-To.
 - **Reference vs. Explanation** both serve theoretical knowledge, but Reference *states* neutral facts to consult at the keyboard, while Explanation *discusses* reasoning and context to read away from it. If the request wants opinions, history, or trade-offs, it's Explanation; if it wants an authoritative spec, it's Reference.
-- **How-To vs. Explanation** split on practice vs. theory: How-To answers "how do I accomplish this task?" and is followed at the keyboard; Explanation answers "why does this work this way?" and builds a mental model.
 
-If ambiguous, ask: "Should this be a Reference doc (technical lookup), a How-To guide (task completion), or an Explanation (understanding the why behind a concept)?"
+If ambiguous, ask: "Should this be a Tutorial (learning by doing), a How-To guide (task completion), a Reference doc (technical lookup), or an Explanation (understanding the why behind a concept)?"
 
 ### Step 2: Load Skills
 
@@ -67,8 +68,9 @@ Always load both:
 
 1. [docs-style](../docs-style/SKILL.md) - Core writing principles
 2. Detected type skill:
-   - [reference-docs](../reference-docs/SKILL.md) for Reference
+   - [tutorial-docs](../tutorial-docs/SKILL.md) for Tutorial
    - [howto-docs](../howto-docs/SKILL.md) for How-To
+   - [reference-docs](../reference-docs/SKILL.md) for Reference
    - [explanation-docs](../explanation-docs/SKILL.md) for Explanation
 
 ### Step 3: Analyze Code
@@ -88,6 +90,14 @@ Gather:
 ### Step 4: Generate Draft
 
 Apply the loaded skills to generate documentation:
+
+**For Tutorial docs:**
+- Follow `tutorial-docs` template structure
+- Title names what the reader will build ("Build your first X"), not what they'll learn
+- Use first-person plural — "In this tutorial, we will…" — to keep the teacher/learner narrative
+- Give one clear path with no choices or alternatives
+- After every step, state what the reader should see ("You should see…")
+- Ruthlessly minimize explanation; link out to Explanation docs for the "why"
 
 **For Reference docs:**
 - Follow `reference-docs` template structure
@@ -128,7 +138,7 @@ Apply the loaded skills to generate documentation:
    ## Draft Created
 
    **File:** `docs/drafts/{slug}.md`
-   **Type:** Reference | How-To | Explanation
+   **Type:** Tutorial | How-To | Reference | Explanation
    **Based on:** [list of analyzed symbols/files]
 
    ### Next Steps
@@ -156,8 +166,9 @@ markdownlint docs/drafts/{slug}.md 2>/dev/null || echo "markdownlint not availab
 **Verification Checklist:**
 - [ ] Draft file created at `docs/drafts/{slug}.md`
 - [ ] Frontmatter includes `title` and `description`
-- [ ] Content type matches detected type (Reference, How-To, or Explanation)
-- [ ] Code examples are complete and runnable (Reference/How-To); concepts grounded in real design decisions (Explanation)
+- [ ] Content type matches detected type (Tutorial, How-To, Reference, or Explanation)
+- [ ] Code examples are complete and runnable (Tutorial/How-To/Reference); concepts grounded in real design decisions (Explanation)
+- [ ] Tutorial drafts give a single path with observable "You should see…" outcomes at each step
 - [ ] All analyzed symbols referenced in draft
 
 If any verification fails, report the specific issue and offer to regenerate.
@@ -179,11 +190,12 @@ Ask user which section:
 ```markdown
 Where should this document go?
 
-1. **API Reference** → `docs/api/{slug}.md`
-2. **Guides** → `docs/guides/{slug}.md`
-3. **How-To** → `docs/how-to/{slug}.md`
-4. **Concepts / Explanation** → `docs/concepts/{slug}.md`
-5. **Other** → Specify path
+1. **Tutorials** → `docs/tutorials/{slug}.md`
+2. **API Reference** → `docs/api/{slug}.md`
+3. **Guides** → `docs/guides/{slug}.md`
+4. **How-To** → `docs/how-to/{slug}.md`
+5. **Concepts / Explanation** → `docs/concepts/{slug}.md`
+6. **Other** → Specify path
 ```
 
 ### Step 3: Move File
@@ -257,6 +269,12 @@ If any verification fails, report the specific issue and offer remediation steps
 
 ## Content Type Detection
 
+### Tutorial Indicators
+
+- Prompt mentions: tutorial, learn, getting started, first, onboarding, introduction, "build a/your"
+- Target is a beginner's first successful experience with the product
+- User wants a guided, learn-by-doing lesson, not a task or a lookup
+
 ### Reference Indicators
 
 - Prompt mentions: API, endpoint, function, method, class, type, parameters, returns
@@ -292,8 +310,8 @@ Do not skip ahead: each **Pass** must be true before the next step. Use commands
 ### Generate draft (Mode 1)
 
 1. **Context gate — Pass:** Step 0 commands ran (or equivalent) and you recorded at least one concrete outcome: e.g. `docs/` listing snippet, or explicit note that `docs/` is missing and will be created.
-2. **Type gate — Pass:** Reference vs How-To vs Explanation is decided using the keyword table **or** the user’s explicit answer (quote or paraphrase with “user chose …”). Do not start **Step 3: Analyze Code** until this is locked.
-3. **Skills gate — Pass:** Before analysis, both are in play: [docs-style](../docs-style/SKILL.md) and the type skill ([reference-docs](../reference-docs/SKILL.md), [howto-docs](../howto-docs/SKILL.md), or [explanation-docs](../explanation-docs/SKILL.md)). In your run, name the two skills loaded (paths)—not “I reviewed writing guidelines.”
+2. **Type gate — Pass:** Tutorial vs How-To vs Reference vs Explanation is decided using the keyword table and the two compass questions **or** the user’s explicit answer (quote or paraphrase with “user chose …”). Do not start **Step 3: Analyze Code** until this is locked.
+3. **Skills gate — Pass:** Before analysis, both are in play: [docs-style](../docs-style/SKILL.md) and the type skill ([tutorial-docs](../tutorial-docs/SKILL.md), [howto-docs](../howto-docs/SKILL.md), [reference-docs](../reference-docs/SKILL.md), or [explanation-docs](../explanation-docs/SKILL.md)). In your run, name the two skills loaded (paths)—not “I reviewed writing guidelines.”
 4. **Write gate — Pass:** After writing the draft, `test -f docs/drafts/{slug}.md` succeeds (or `ls` shows the file). Only then emit the **Draft Created** block.
 
 ### Publish draft (Mode 2)

--- a/plugins/beagle-docs/skills/draft-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/draft-docs/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 
 # Draft Docs
 
-Generate Reference or How-To documentation drafts to `docs/drafts/` for review before publishing.
+Generate Reference, How-To, or Explanation documentation drafts to `docs/drafts/` for review before publishing.
 
 ## Arguments
 
@@ -52,8 +52,14 @@ Extract from the prompt:
 |----------|------|-------|
 | "how to", "guide", "steps", "configure", "set up" | How-To | [howto-docs](../howto-docs/SKILL.md) |
 | "API", "reference", "parameters", "function", "endpoint" | Reference | [reference-docs](../reference-docs/SKILL.md) |
+| "why", "how does it work", "concept", "background", "rationale", "design decision", "architecture", "trade-offs" | Explanation | [explanation-docs](../explanation-docs/SKILL.md) |
 
-If ambiguous, ask: "Should this be a Reference doc (technical lookup) or How-To guide (task completion)?"
+These three types map to three quadrants of the [Diátaxis](https://diataxis.fr/) framework — Reference (information), How-To (task), and Explanation (understanding). Two distinctions resolve most ambiguity:
+
+- **Reference vs. Explanation** both serve theoretical knowledge, but Reference *states* neutral facts to consult at the keyboard, while Explanation *discusses* reasoning and context to read away from it. If the request wants opinions, history, or trade-offs, it's Explanation; if it wants an authoritative spec, it's Reference.
+- **How-To vs. Explanation** split on practice vs. theory: How-To answers "how do I accomplish this task?" and is followed at the keyboard; Explanation answers "why does this work this way?" and builds a mental model.
+
+If ambiguous, ask: "Should this be a Reference doc (technical lookup), a How-To guide (task completion), or an Explanation (understanding the why behind a concept)?"
 
 ### Step 2: Load Skills
 
@@ -63,6 +69,7 @@ Always load both:
 2. Detected type skill:
    - [reference-docs](../reference-docs/SKILL.md) for Reference
    - [howto-docs](../howto-docs/SKILL.md) for How-To
+   - [explanation-docs](../explanation-docs/SKILL.md) for Explanation
 
 ### Step 3: Analyze Code
 
@@ -95,6 +102,14 @@ Apply the loaded skills to generate documentation:
 - Break into single-action steps
 - Include verification section
 
+**For Explanation docs:**
+- Follow `explanation-docs` template structure
+- Frame the title around understanding a concept ("Understanding X"), not a task
+- Open by stating what the reader will understand after reading
+- Explain the *why* behind design decisions, not just what exists
+- Discuss trade-offs honestly and acknowledge alternatives that were considered
+- Write flowing prose for reading away from the keyboard — no steps to follow
+
 ### Step 5: Write Draft
 
 1. **Create output path:**
@@ -113,7 +128,7 @@ Apply the loaded skills to generate documentation:
    ## Draft Created
 
    **File:** `docs/drafts/{slug}.md`
-   **Type:** Reference | How-To
+   **Type:** Reference | How-To | Explanation
    **Based on:** [list of analyzed symbols/files]
 
    ### Next Steps
@@ -141,8 +156,8 @@ markdownlint docs/drafts/{slug}.md 2>/dev/null || echo "markdownlint not availab
 **Verification Checklist:**
 - [ ] Draft file created at `docs/drafts/{slug}.md`
 - [ ] Frontmatter includes `title` and `description`
-- [ ] Content type matches detected type (Reference or How-To)
-- [ ] Code examples are complete and runnable
+- [ ] Content type matches detected type (Reference, How-To, or Explanation)
+- [ ] Code examples are complete and runnable (Reference/How-To); concepts grounded in real design decisions (Explanation)
 - [ ] All analyzed symbols referenced in draft
 
 If any verification fails, report the specific issue and offer to regenerate.
@@ -167,7 +182,8 @@ Where should this document go?
 1. **API Reference** → `docs/api/{slug}.md`
 2. **Guides** → `docs/guides/{slug}.md`
 3. **How-To** → `docs/how-to/{slug}.md`
-4. **Other** → Specify path
+4. **Concepts / Explanation** → `docs/concepts/{slug}.md`
+5. **Other** → Specify path
 ```
 
 ### Step 3: Move File
@@ -253,6 +269,12 @@ If any verification fails, report the specific issue and offer remediation steps
 - Target is a task or workflow
 - User wants procedural instructions
 
+### Explanation Indicators
+
+- Prompt mentions: why, how it works, concept, background, rationale, design decision, architecture, trade-offs
+- Target is a concept or system the reader wants to understand, not operate
+- User wants context and reasoning to read away from the keyboard, not steps to follow
+
 ## Rules
 
 - Always load `docs-style` skill for every draft
@@ -270,8 +292,8 @@ Do not skip ahead: each **Pass** must be true before the next step. Use commands
 ### Generate draft (Mode 1)
 
 1. **Context gate — Pass:** Step 0 commands ran (or equivalent) and you recorded at least one concrete outcome: e.g. `docs/` listing snippet, or explicit note that `docs/` is missing and will be created.
-2. **Type gate — Pass:** Reference vs How-To is decided using the keyword table **or** the user’s explicit answer (quote or paraphrase with “user chose …”). Do not start **Step 3: Analyze Code** until this is locked.
-3. **Skills gate — Pass:** Before analysis, both are in play: [docs-style](../docs-style/SKILL.md) and the type skill ([reference-docs](../reference-docs/SKILL.md) or [howto-docs](../howto-docs/SKILL.md)). In your run, name the two skills loaded (paths)—not “I reviewed writing guidelines.”
+2. **Type gate — Pass:** Reference vs How-To vs Explanation is decided using the keyword table **or** the user’s explicit answer (quote or paraphrase with “user chose …”). Do not start **Step 3: Analyze Code** until this is locked.
+3. **Skills gate — Pass:** Before analysis, both are in play: [docs-style](../docs-style/SKILL.md) and the type skill ([reference-docs](../reference-docs/SKILL.md), [howto-docs](../howto-docs/SKILL.md), or [explanation-docs](../explanation-docs/SKILL.md)). In your run, name the two skills loaded (paths)—not “I reviewed writing guidelines.”
 4. **Write gate — Pass:** After writing the draft, `test -f docs/drafts/{slug}.md` succeeds (or `ls` shows the file). Only then emit the **Draft Created** block.
 
 ### Publish draft (Mode 2)

--- a/plugins/beagle-docs/skills/ensure-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/ensure-docs/SKILL.md
@@ -8,6 +8,11 @@ disable-model-invocation: true
 
 Verify documentation coverage across a codebase, report gaps, and generate missing docs. **If the agent supports subagents**, dispatch one verifier per detected language in parallel; **otherwise** run the same per-language verification sequentially — the output is identical either way.
 
+Coverage has two complementary lenses, and a healthy project needs both:
+
+1. **Symbol coverage** — are the functions, classes, and modules documented to the language's standard (docstrings, JSDoc, GoDoc)? This is the per-language verification below.
+2. **Diataxis type balance** — does the *doc set as a whole* serve all four user needs: a Tutorial to learn, How-To guides for tasks, Reference for lookups, and Explanation for understanding? A codebase can have 100% docstring coverage and still have no way for a newcomer to get started. See the [Diataxis balance check](#diataxis-type-balance-check) below.
+
 ## Workflow
 
 Complete steps in order. Do not advance until each step’s **Pass** is satisfied.
@@ -21,17 +26,42 @@ Complete steps in order. Do not advance until each step’s **Pass** is satisfie
 3. **Verification** — Verify each qualifying language using the verifier prompts and JSON output shape in the reference (Phase 2). If the agent supports subagents, run one verifier per language in parallel; otherwise run them sequentially.
    - **Pass:** Each completed verification returns parseable JSON including `language`, `files_scanned`, and `findings` (array, possibly empty).
 
-4. **Consolidated report** — Merge results per Phase 3 (summary table, severity grouping, detailed findings if requested).
-   - **Pass:** The user sees the merged report (inline or written to an agreed path) before you claim the audit is done or propose fixes.
+4. **Diataxis balance check** — Run the [Diataxis type balance check](#diataxis-type-balance-check) against the project's existing docs (e.g. a `docs/` tree, README, or wiki).
+   - **Pass:** You can state, for each of the four types (Tutorial, How-To, Reference, Explanation), whether the project has at least one document serving that need, and you have noted any missing or thin type.
 
-5. **Generation** — Only if `--report-only` is not set: offer choices per Phase 4; apply doc edits only after an explicit user choice to generate.
+5. **Consolidated report** — Merge results per Phase 3 (summary table, severity grouping, detailed findings if requested). Include the Diataxis balance alongside symbol coverage.
+   - **Pass:** The user sees the merged report (inline or written to an agreed path) — covering both symbol coverage and Diataxis type balance — before you claim the audit is done or propose fixes.
+
+6. **Generation** — Only if `--report-only` is not set: offer choices per Phase 4; apply doc edits only after an explicit user choice to generate. For a missing Diataxis type, route generation through [draft-docs](../draft-docs/SKILL.md) for the relevant type rather than generating inline.
    - **Pass:** No documentation edits for gaps until the user selects an option that includes generation; if they decline or choose report-only behavior, end after the report.
 
-6. **Post-edit verification** — After any generation, run or offer the linter commands in Phase 5 of the reference for languages you changed, when those tools exist in the repo.
+7. **Post-edit verification** — After any generation, run or offer the linter commands in Phase 5 of the reference for languages you changed, when those tools exist in the repo.
    - **Pass:** Linter run completed with output captured, or `N/A` with a one-line reason (e.g. tool not configured); remaining issues are listed or cleared.
+
+## Diataxis Type Balance Check
+
+Survey the project's prose documentation (a `docs/` tree, README, wiki, or doc site) and classify what exists into the four [Diataxis](https://diataxis.fr/) types. Use the compass to classify — *action or cognition? acquisition or application?* — per [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
+Report the balance as a table:
+
+| Type | Present? | Notes |
+|------|----------|-------|
+| **Tutorial** (learning) | yes / no / thin | e.g. "No getting-started / first-project guide" |
+| **How-To** (tasks) | yes / no / thin | e.g. "Several task guides under `docs/how-to/`" |
+| **Reference** (lookup) | yes / no / thin | e.g. "API reference generated, but no CLI reference" |
+| **Explanation** (understanding) | yes / no / thin | e.g. "No architecture / design-rationale docs" |
+
+Flag, in priority order:
+
+1. **A missing type** — the doc set serves none of that user need. The most common and most damaging gap is a missing **Tutorial**: a project can have exhaustive reference and still leave a newcomer with no way in.
+2. **A thin type** — present but doesn't cover the project's major features or surfaces.
+3. **Mixed documents** — a single page trying to be two types at once (e.g. reference tables embedded in a how-to). Recommend splitting via [improve-doc](../improve-doc/SKILL.md).
+
+Do **not** propose generating empty skeletons for missing types. Following the Diataxis "work by improvement" principle, recommend the single highest-value document to add or fix next, and offer to draft it via [draft-docs](../draft-docs/SKILL.md).
 
 ## Notes
 
 - Use `--report-only` to skip generation.
 - Avoid test files unless they are test helpers.
 - Keep report output aligned with the language-specific standards in the reference file.
+- The Diataxis balance check is about the doc set as a whole; per-language symbol coverage and type balance are independent — report both.

--- a/plugins/beagle-docs/skills/explanation-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/explanation-docs/SKILL.md
@@ -179,6 +179,14 @@ Explanations are read linearly, away from the keyboard. Structure them like essa
 - **Allow for depth** - it's okay if sections are longer than in how-to guides
 - **Include context** that would be distracting in task-focused docs
 
+### Keep Explanation Bounded
+
+Diátaxis warns that explanation is "the most easily neglected and most easily mistaken" type — it tends to absorb material that belongs elsewhere. A paragraph of setup steps creeps in, or a parameter table, and the document quietly stops being an explanation.
+
+Guard the boundary: if you find yourself writing instructions the reader should *follow*, that belongs in a How-To; if you're listing exact signatures or options to *consult*, that belongs in Reference. Link to those docs instead of inlining them. The discipline of staying within "why" and "how it works" is what makes an explanation worth reading away from the keyboard.
+
+A useful tell that you're on track: explanation reads naturally with discursive openings like "The reason for X is that historically…", "X is better than Y because…", or "Some teams prefer Z, which works well when… but…". If a section can't be phrased that way, it may not be explanation.
+
 ### Connect to the Bigger Picture
 
 Show how this concept relates to other parts of the system or to broader industry patterns.

--- a/plugins/beagle-docs/skills/explanation-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/explanation-docs/SKILL.md
@@ -8,6 +8,8 @@ user-invocable: false
 
 This skill provides patterns for writing effective explanation documents. Explanations are understanding-oriented content for readers who want to know why things work the way they do.
 
+**Dependency:** Use this skill with `docs-style` for core writing principles. To confirm explanation is the right type — rather than a tutorial, how-to, or reference — see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
 ## Purpose & Audience
 
 **Target readers:**
@@ -187,9 +189,13 @@ Guard the boundary: if you find yourself writing instructions the reader should 
 
 A useful tell that you're on track: explanation reads naturally with discursive openings like "The reason for X is that historically…", "X is better than Y because…", or "Some teams prefer Z, which works well when… but…". If a section can't be phrased that way, it may not be explanation.
 
+### Admit Opinion and Judgement
+
+Diataxis is explicit that explanation is the one type where opinion belongs: "all human activity and knowledge is invested with values, judgements, opinion — even, dare we say it, ideology." Reference and how-to must stay neutral, but an explanation that refuses to take a position fails to help the reader form their own. State recommendations and say why ("We prefer X over Y in most cases because…"), name the conditions under which the judgement flips, and attribute contested claims honestly. The goal is informed understanding, not false neutrality.
+
 ### Connect to the Bigger Picture
 
-Show how this concept relates to other parts of the system or to broader industry patterns.
+Show how this concept relates to other parts of the system or to broader industry patterns. Explanation is bounded by its *topic*, not by the machinery, so it is free to make connections outward — to adjacent systems, to history, even to ideas beyond the immediate codebase — where they deepen understanding.
 
 ```markdown
 ## Related Concepts
@@ -439,6 +445,8 @@ Run in order. **Do not skip ahead**; each step has an objective pass condition.
 | "What are the trade-offs of X?" | **Explanation** | Design rationale |
 | "How does X relate to Y?" | **Explanation** | Conceptual connections |
 
+For the full compass procedure and the other type distinctions, see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
 ### Explanation Signals
 
 Write an explanation when users:
@@ -459,6 +467,7 @@ If users need to accomplish something while reading, it's not an explanation:
 ## Related Skills
 
 - **[docs-style](../docs-style/SKILL.md)**: Core writing conventions and components
+- **[Diataxis compass](../docs-style/references/diataxis-compass.md)**: Type selection, the 2×2 map, and the quality model
 - **[howto-docs](../howto-docs/SKILL.md)**: How-To guide patterns for task-oriented content
 - **[reference-docs](../reference-docs/SKILL.md)**: Reference documentation patterns for lookups
 - **[tutorial-docs](../tutorial-docs/SKILL.md)**: Tutorial patterns for learning-oriented content

--- a/plugins/beagle-docs/skills/howto-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/howto-docs/SKILL.md
@@ -8,6 +8,8 @@ user-invocable: false
 
 This skill provides patterns for writing effective How-To guides in documentation. How-To guides are task-oriented content for users who have a specific goal in mind.
 
+**Dependency:** Use this skill with `docs-style` for core writing principles. To confirm a how-to is the right type — rather than a tutorial, reference, or explanation — see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
 ## Purpose & Audience
 
 **Target readers:**
@@ -109,6 +111,18 @@ Brief intro (1-2 sentences): what you'll accomplish and why it's useful.
 - Don't explain why things work - just show how to do them
 - Link to explanations for users who want deeper understanding
 - Keep each step focused on the immediate action
+
+### Use Conditional Imperatives and Address the Real World
+
+Unlike a tutorial — which controls a single, guaranteed path — a how-to meets the user in the messy real world. Diataxis frames steps as **conditional imperatives**: "*If you want X, do Y.*" This respects that the reader arrives with their own context and goal.
+
+- **Branch where reality branches.** When the right action depends on the user's situation, say so ("If you deploy to staging, set `ENV=staging`; for production, use…") rather than pretending one path fits all.
+- **Prepare for the unexpected.** Note the failure modes and detours a competent user will actually hit (the Troubleshooting section is where these live).
+- **Omit the unnecessary.** A how-to aims at practical usability, not completeness. Leave out anything that doesn't move the reader toward the goal; link to Reference for exhaustive detail.
+
+### Name the Guide by What It Achieves
+
+Titles state exactly what the guide accomplishes, using the user's goal: "How to integrate Stripe payments," not "Payments" or "The Stripe module." If you cannot name the concrete outcome, the scope is not yet clear enough to write.
 
 ### User Perspective
 
@@ -332,9 +346,12 @@ Before publishing, verify:
 | "I want to understand" | Explanation | "How our caching works" |
 | "I need to look up Y" | Reference | "API endpoint reference" |
 
+For the full compass procedure and the other type distinctions, see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
 ## Related Skills
 
 - **[docs-style](../docs-style/SKILL.md)**: Core writing conventions and components
+- **[Diataxis compass](../docs-style/references/diataxis-compass.md)**: Type selection, the 2×2 map, and the quality model
 - **[tutorial-docs](../tutorial-docs/SKILL.md)**: Tutorial patterns for learning-oriented content
 - **[reference-docs](../reference-docs/SKILL.md)**: Reference documentation patterns
 - **[explanation-docs](../explanation-docs/SKILL.md)**: Conceptual documentation patterns

--- a/plugins/beagle-docs/skills/improve-doc/SKILL.md
+++ b/plugins/beagle-docs/skills/improve-doc/SKILL.md
@@ -61,7 +61,7 @@ Load [docs-style](../docs-style/SKILL.md) for core writing principles that apply
 
 ### Step 3: Classify Each Section
 
-For each section, determine the Diataxis type using these indicators:
+For each section, determine the Diataxis type using these indicators (for the full decision procedure and the two key distinctions, see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md)):
 
 | Type | Indicators |
 |------|------------|

--- a/plugins/beagle-docs/skills/reference-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/reference-docs/SKILL.md
@@ -8,7 +8,7 @@ user-invocable: false
 
 Reference documentation is information-oriented - helping experienced users find precise technical details quickly. This skill provides patterns for writing clear, scannable reference pages.
 
-**Dependency:** Always use this skill in conjunction with `docs-style` for core writing principles.
+**Dependency:** Always use this skill in conjunction with `docs-style` for core writing principles. To confirm reference is the right type — rather than a tutorial, how-to, or explanation — see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
 
 ## Purpose and Audience
 
@@ -66,6 +66,16 @@ console.log(result);
 ```
 
 ## Writing Principles
+
+### Describe, and Only Describe
+
+Reference is austere, neutral, and authoritative — a map the reader can trust without independent verification. Its one job is to describe the machinery: commands, options, parameters, return values, limits, warnings. It does not instruct (that's How-To), teach (Tutorial), or argue (Explanation). When you feel the urge to explain *why* or walk the reader through a task, link out instead of inlining it; a digression interrupts and obscures the facts the reader came to consult.
+
+### Structure Mirrors the Product
+
+> "The structure of the documentation should mirror the structure of the product."
+
+Organise reference so a reader can navigate the code and the docs in parallel — one reference entry per module, class, endpoint, or command, in the product's own order. Don't impose a narrative or thematic structure the product doesn't have; consistency of placement is what makes reference fast to consult.
 
 ### Brevity Over Explanation
 
@@ -340,3 +350,22 @@ After the **Gates (completion order)** above, confirm:
 - [ ] Example uses realistic values
 - [ ] Related pages linked
 - [ ] Format matches other reference pages in the docs
+
+## When to Use Reference vs Other Doc Types
+
+| User's mindset | Doc type | Example |
+|---------------|----------|---------|
+| "I want to learn" | Tutorial | "Build your first integration" |
+| "I want to do X" | How-To | "How to configure SSO" |
+| "I want to understand" | Explanation | "How our caching works" |
+| "I need to look up Y" | **Reference** | "API endpoint reference" |
+
+Reference and Explanation are the two cognition-oriented types and are easily confused: Reference *states* neutral facts to consult while working; Explanation *discusses* reasoning to read while reflecting. For the full compass procedure and distinctions, see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
+## Related Skills
+
+- **[docs-style](../docs-style/SKILL.md)**: Core writing conventions and components
+- **[Diataxis compass](../docs-style/references/diataxis-compass.md)**: Type selection, the 2×2 map, and the quality model
+- **[tutorial-docs](../tutorial-docs/SKILL.md)**: Tutorial patterns for learning-oriented content
+- **[howto-docs](../howto-docs/SKILL.md)**: How-To guide patterns for task-oriented content
+- **[explanation-docs](../explanation-docs/SKILL.md)**: Conceptual documentation patterns

--- a/plugins/beagle-docs/skills/tutorial-docs/SKILL.md
+++ b/plugins/beagle-docs/skills/tutorial-docs/SKILL.md
@@ -8,6 +8,8 @@ user-invocable: false
 
 This skill provides patterns for writing effective tutorials following the Diataxis framework. Tutorials are learning-oriented content where the reader learns by doing under the guidance of a teacher.
 
+**Dependency:** Use this skill with `docs-style` for core writing principles. To confirm a tutorial is the right type — rather than a how-to, reference, or explanation — see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
 ## Purpose & Audience
 
 **Target readers:**
@@ -79,6 +81,15 @@ If you see "command not found", return to Step 2 to verify the installation.
 
 Repeating similar actions in slightly different contexts helps cement learning. Don't try to be efficient.
 
+### 6. Write in the First-Person Plural
+
+Diataxis prescribes the "we" voice for tutorials — "In this tutorial, we will build…", "Now we add…", "Let's check the output." It affirms the bond between teacher and learner: you are doing this *together*, and the teacher takes responsibility for the outcome. Reserve bare second-person imperatives ("Run this command") for the individual actions the reader performs; frame the journey itself with "we."
+
+| Avoid | Prefer |
+|-------|--------|
+| "You will build a dashboard." | "In this tutorial, we'll build a dashboard." |
+| "Next, configure the API." | "Now let's configure the API." |
+
 ## Tutorial Template
 
 Use this structure for all tutorials:
@@ -91,7 +102,7 @@ description: "Learn the basics of [product] by building a working [thing]"
 
 # Build Your First [Thing]
 
-In this tutorial, you'll build a [concrete deliverable]. By the end, you'll have a working [thing] that [does something visible].
+In this tutorial, we'll build a [concrete deliverable]. By the end, you'll have a working [thing] that [does something visible].
 
 <Note>
 This tutorial takes approximately [X] minutes to complete.
@@ -345,6 +356,8 @@ Run these **in order**. Start the next gate only after the previous **pass** is 
 | "I want to understand" | Explanation | "How our caching works" |
 | "I need to look up Y" | Reference | "API endpoint reference" |
 
+For the full compass procedure and the other type distinctions, see [docs-style/references/diataxis-compass.md](../docs-style/references/diataxis-compass.md).
+
 ### Tutorial vs How-To: Key Differences
 
 | Aspect | Tutorial | How-To |
@@ -360,6 +373,7 @@ Run these **in order**. Start the next gate only after the previous **pass** is 
 ## Related Skills
 
 - **[docs-style](../docs-style/SKILL.md)**: Core writing conventions and components
+- **[Diataxis compass](../docs-style/references/diataxis-compass.md)**: Type selection, the 2×2 map, and the quality model
 - **[howto-docs](../howto-docs/SKILL.md)**: How-To guide patterns for task-oriented content
 - **[reference-docs](../reference-docs/SKILL.md)**: Reference documentation patterns
 - **[explanation-docs](../explanation-docs/SKILL.md)**: Conceptual documentation patterns


### PR DESCRIPTION
## Summary

Brings the **entire** beagle-docs authoring suite into line with [diataxis.fr](https://diataxis.fr/), not just the skills originally touched. The suite can now **draft and refine all four Diataxis types** (Tutorial, How-To, Reference, Explanation), backed by a single canonical reference and a project-level type-balance check.

This PR began as "add Explanation content type to draft-docs" (Closes #3) and was then expanded — after a comprehensive subagent audit of every doc skill against the Diataxis source pages — to close the remaining gaps across the whole suite.

## What was broken

- **`draft-docs` could not draft Tutorials.** It only handled Reference / How-To / Explanation; `tutorial-docs` existed but nothing routed to it for drafting, so tutorials were effectively undraftable.
- **No canonical compass / map / quality model.** The "When to Use" tables were duplicated across four skills with no source of truth and no help choosing a type up front.
- **`ensure-docs` was Diataxis-blind** — it checked per-language symbol coverage but never whether the doc set served all four user needs.

## Changes

**New canonical reference — `docs-style/references/diataxis-compass.md`**
- Self-contained (no cross-skill dependencies) so it stays usable when skills are distributed individually (per-skill Codex installs).
- Covers the two axes, the 2×2 map, the compass decision procedure, the two ambiguity-resolving distinctions (Tutorial vs. How-To, Reference vs. Explanation), the functional-vs-deep quality model, and the "work by improvement" workflow.
- Kept as a reference file (not a new skill), so the 10-skill / 131-skill marketplace counts are unchanged.

**`draft-docs/SKILL.md` — Tutorial now fully supported** (added alongside the existing Explanation routing): keyword table, content-type detection, skill loading, generation block, report line, publish menu (`docs/tutorials/`), hard-gate type lock, and verification checklist.

**`docs-style/SKILL.md` — now the hub:** opens with type selection (compass mini-table) and a two-kinds-of-quality section; links the canonical reference.

**Fidelity polish on the four type skills** (each also links the compass):
- `tutorial-docs` — first-person-plural "we will" voice Diataxis prescribes.
- `howto-docs` — conditional imperatives, "prepare for the unexpected / omit the unnecessary," goal-based naming.
- `reference-docs` — "describe, and only describe," "structure mirrors the product," plus a When-to-Use table and Related Skills section it previously lacked.
- `explanation-docs` — "admit opinion and judgement," topic-bounded connections (in addition to the earlier "keep explanation bounded" principle).

**`ensure-docs/SKILL.md`** — adds a Diataxis type-balance lens alongside per-language symbol coverage (reporting table; flags missing/thin/mixed types, calling out a missing Tutorial as the most common gap); routes generation through `draft-docs`.

**`improve-doc/SKILL.md`** — links the canonical compass as the type-decision procedure.

## Verification

No build/test system exists (pure markdown marketplace), so validation was link integrity and structural sanity:
- All 8 `diataxis-compass.md` links resolve from their skill directories; the `ensure-docs` anchor exists; the renumbered `ensure-docs` workflow is steps 1–7 with no duplicates.
- Grep-confirmed no stale "three types / three quadrants" phrasing remains after adding Tutorial.
- Diataxis guidance sourced directly from diataxis.fr (home, foundations, all four type pages, compass, quality, how-to-use) — not from memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)