### PR TITLE
chore(release): 4.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Framework-aware code review skills and workflows for modern development",
-    "version": "4.2.0"
+    "version": "4.3.0"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-06-16
+
+### Added
+- **beagle-docs:draft-docs**: Made the full Diataxis doc suite spec-compliant so it can draft and refine all four Diataxis types. `draft-docs` now drafts Tutorials and Explanations (previously only Reference/How-To) — keyword detection, ambiguity prompt, skill loading, generation guidance, publish menu, type gate, and checklist all cover the added types. Added a self-contained canonical reference (`docs-style/references/diataxis-compass.md`) with the two axes, 2×2 map, compass decision procedure, and quality model; `docs-style` now leads with type selection; `ensure-docs` gains a Diataxis type-balance lens; and the four type skills got fidelity polish ([#136](https://github.com/existential-birds/beagle/pull/136))
+
+### Changed
+- **beagle-analysis:brainstorm-beagle**: Added a Prior Art Check step — a neutral capability-keyword sweep across the whole workspace, run independent of issue/brief framing, so brownfield features can't be framed as new work that duplicates already-shipped, tested code. Treats "X was removed / doesn't exist" as a hypothesis to disprove, briefs any subagent with the keyword sweep rather than the narrative scope, and is wired into the workflow, self-review, and the spec-reviewer backstop checklist ([#135](https://github.com/existential-birds/beagle/pull/135))
+
 ### Fixed
-- **Codex install:** Reworked `.codex/INSTALL.md` to link each skill directory individually into Codex's flat `~/.agents/skills/` path instead of linking whole plugin `skills/` directories, so each skill resolves as a top-level entry in Codex's namespace-free discovery. The installer now fails on unexpected duplicate skill names and links the canonical `beagle-core` copy of `review-verification-protocol`; `docs/README.codex.md` updated to match
-- **Docs:** Corrected the marketplace skill count from 144 to 131 active skills in `README.md`, `CLAUDE.md`, and `AGENTS.md` (144 includes the 13 deprecated `beagle-ai` skills still on disk) and fixed the same counts in the 4.1.0 changelog entry. The commands → skills migration these docs describe shipped in [2.9.0]
+- **Codex install:** Reworked `.codex/INSTALL.md` to link each skill directory individually into Codex's flat `~/.agents/skills/` path instead of linking whole plugin `skills/` directories, so each skill resolves as a top-level entry in Codex's namespace-free discovery. The installer now fails on unexpected duplicate skill names and links the canonical `beagle-core` copy of `review-verification-protocol`; `docs/README.codex.md` updated to match ([#134](https://github.com/existential-birds/beagle/pull/134))
+- **Docs:** Corrected the marketplace skill count from 144 to 131 active skills in `README.md`, `CLAUDE.md`, and `AGENTS.md` (144 includes the 13 deprecated `beagle-ai` skills still on disk) and fixed the same counts in the 4.1.0 changelog entry. The commands → skills migration these docs describe shipped in [2.9.0] ([#134](https://github.com/existential-birds/beagle/pull/134))
 
 ## [4.2.0] - 2026-06-08
 
@@ -513,7 +521,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 - Development commands: `skill-builder`, `ensure-docs`
 - Cursor IDE command equivalents
 
-[Unreleased]: https://github.com/existential-birds/beagle/compare/v4.2.0...HEAD
+[Unreleased]: https://github.com/existential-birds/beagle/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/existential-birds/beagle/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/existential-birds/beagle/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/existential-birds/beagle/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/existential-birds/beagle/compare/v3.11.0...v4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Version
 ## [4.3.0] - 2026-06-16
 
 ### Added
+- **CI:** Added the daydream review bot as three GitHub Actions workflows under `.github/workflows/` (analyze → command → post), so beagle PRs are reviewed by [daydream](https://github.com/existential-birds/daydream) with findings posted as inline comments via a GitHub App. The review job is Codex-backed (`daydream --review --backend codex`); all jobs run on Blacksmith runners. This is repo infrastructure and does not change any installable plugin ([#138](https://github.com/existential-birds/beagle/pull/138))
 - **beagle-docs:draft-docs**: Made the full Diataxis doc suite spec-compliant so it can draft and refine all four Diataxis types. `draft-docs` now drafts Tutorials and Explanations (previously only Reference/How-To) — keyword detection, ambiguity prompt, skill loading, generation guidance, publish menu, type gate, and checklist all cover the added types. Added a self-contained canonical reference (`docs-style/references/diataxis-compass.md`) with the two axes, 2×2 map, compass decision procedure, and quality model; `docs-style` now leads with type selection; `ensure-docs` gains a Diataxis type-balance lens; and the four type skills got fidelity polish ([#136](https://github.com/existential-birds/beagle/pull/136))
 
 ### Changed

--- a/plugins/beagle-analysis/.claude-plugin/plugin.json
+++ b/plugins/beagle-analysis/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-analysis",
   "description": "Architecture analysis, brainstorming, ADR generation, LLM-as-judge comparison, and spec gap resolution.",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"

--- a/plugins/beagle-docs/.claude-plugin/plugin.json
+++ b/plugins/beagle-docs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "beagle-docs",
   "description": "Documentation quality, generation, and improvement using Diataxis principles. Pairs with beagle-core for full workflow.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": {
     "name": "Existential Birds, LLC",
     "email": "tech@existentialbirds.com"


### PR DESCRIPTION
## Summary

- Bump version to 4.3.0
- Update CHANGELOG.md with changes since v4.2.0
- Merge latest `main` (now includes the daydream review bot CI, #138) so the 4.3.0 tag and changelog are consistent

## Version Locations Updated

- [x] `.claude-plugin/marketplace.json` metadata.version → 4.3.0
- [x] `plugins/beagle-analysis/.claude-plugin/plugin.json` → 2.9.0 (prior-art capability check in brainstorm-beagle, #135)
- [x] `plugins/beagle-docs/.claude-plugin/plugin.json` → 2.4.0 (spec-compliant Diataxis doc suite, #136)

## Changes Since v4.2.0

- **Added** — daydream review bot CI workflows (analyze/command/post), Codex-backed, on Blacksmith runners (#138)
- **Added** — beagle-docs:draft-docs full Diataxis suite (Tutorials + Explanations, compass reference) (#136)
- **Changed** — beagle-analysis:brainstorm-beagle prior-art capability check (#135)
- **Fixed** — Codex per-skill install rework + skill-count doc corrections (#134)

> Note: #138 (daydream CI) merged to `main` after this PR was opened; it's repo infrastructure (not an installable plugin), so no plugin version was bumped for it — it's documented in the 4.3.0 changelog because the tag will include it.

## Post-merge Steps

After merging, run:
```
/release-tag 4.3.0
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)