### PR TITLE
ci: add daydream review bot workflows (codex backend)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,99 @@
+# Daydream review bot — workflow templates
+
+Three GitHub Actions workflows that turn daydream into a self-hosted PR review
+bot: a PR gets reviewed automatically on open (or on demand via
+`@<bot> review`) and the findings are posted as inline comments by your own
+GitHub App identity — no maintainer server, no third-party service.
+
+| File | Workflow | Role |
+|---|---|---|
+| `daydream-review.yml` | Daydream Review | Phase A — runs the reviewer over the PR head (unprivileged), uploads a `daydream-findings` artifact |
+| `daydream-command.yml` | Daydream Command | Gatekeeper — listens for `@<bot> review` PR comments and dispatches Daydream Review |
+| `daydream-post.yml` | Daydream Post | Phase B — fires when Daydream Review completes, validates the artifact, posts findings as your App bot |
+
+## Install
+
+1. **Register a GitHub App** (or reuse the one from your daydream App setup)
+   and install it on the target repository. The App must request these
+   repository permissions:
+   - **Pull requests: read & write** — posting and minimizing review comments
+   - **Contents: read** — required by the posting token's least-privilege trio
+   - **Metadata: read** — implicit baseline
+   - **Actions: read & write** — the command workflow mints a dispatch token
+     with `actions: write`, because a `workflow_dispatch` made with the
+     built-in `GITHUB_TOKEN` never fires the downstream `workflow_run`
+     trigger, so the post workflow would never run on the `@<bot> review`
+     path. (Chain verified PAT-vs-`GITHUB_TOKEN`; final live confirmation of
+     the App-token dispatch is tracked for the sandbox acceptance run.)
+2. **Copy the three workflow files** into the target repository's
+   `.github/workflows/` directory.
+3. **Add three repository secrets** (Settings → Secrets and variables →
+   Actions → Secrets):
+   - `DAYDREAM_APP_ID` — the App's numeric ID
+   - `DAYDREAM_APP_PRIVATE_KEY` — the App's PEM private key, pasted verbatim
+   - `OPENAI_API_KEY` — used only by the unprivileged review job (the Codex
+     backend authenticates the Codex CLI with this key)
+4. **Add one repository variable** (Settings → Secrets and variables →
+   Actions → Variables):
+   - `DAYDREAM_BOT_HANDLE` — the mention handle the command workflow matches,
+     without the `@` (e.g. `daydream-review` for `@daydream-review review`)
+   - Optional: `DAYDREAM_AUTO_REVIEW` — set to `false` to disable auto-review
+     on PR open; the `@<bot> review` command keeps working.
+
+## Trigger matrix
+
+| Trigger | Path | Notes |
+|---|---|---|
+| PR `opened` / `ready_for_review` | auto: Review → Post | Same-repo PRs only; disabled when `DAYDREAM_AUTO_REVIEW` is `false` |
+| `@<bot> review` PR comment | on demand: Command → Review → Post | Comment author must be OWNER / MEMBER / COLLABORATOR; bot comments are ignored |
+| Fork PRs | `@<bot> review` only by default | Auto-review is gated to same-repo PRs (fork runs get no secrets, so the reviewer cannot run) |
+
+**Private-repo limitation:** on private repositories GitHub runs **no
+workflows at all** for fork PRs (the "run workflows from fork pull requests"
+policy is off by default), so fork PRs there get no auto-review of any kind —
+only the `@<bot> review` command path can serve them.
+
+## Security model — the privilege split
+
+No single job ever holds both PR code and the App private key:
+
+- **Phase A (Daydream Review)** checks out and analyzes untrusted PR code,
+  so it is unprivileged: `contents: read` GITHUB_TOKEN, `OPENAI_API_KEY`
+  as its only secret, no App material anywhere. Its output is a passive data
+  artifact (`findings.json`), never code.
+- **Daydream Command** never checks out code, so it may hold App credentials:
+  it mints a short-lived App token with exactly `actions: write` to dispatch
+  the review (see Install step 1).
+- **Phase B (Daydream Post)** holds the App key but only ever checks out the
+  base repo's default branch (trusted code). It mints a token with exactly
+  `pull-requests: write, contents: read, metadata: read`, downloads the
+  artifact, validates it against a strict schema and against the live PR
+  (declared head SHA must match — a forged artifact cannot redirect the post),
+  and posts. Untrusted values reach shells via `env:` only, never `${{ }}`
+  interpolation.
+
+The binding security spec is the daydream repo's
+`.beagle/concepts/self-hosted-review-bot/roadmap.md` §"Sub-project #2
+security design — the privilege split"; these templates implement it.
+
+## Dedup limitations (v1)
+
+Re-reviews deduplicate against the bot's own prior comments via hidden
+fingerprint markers in each comment body:
+
+- **Exact fingerprint match only.** Identity is file + normalized title +
+  anchors + normalized description. A finding whose message drifts between
+  runs reads as one stale finding plus one new finding — expect an occasional
+  duplicate with rephrased wording.
+- **Matched findings are left untouched** — no comment editing.
+- **Stale findings are minimized as OUTDATED**, not thread-resolved: GitHub
+  App installation tokens cannot call `resolveReviewThread` at this permission
+  scope, so the prior comment is collapsed via `minimizeComment(classifier:
+  OUTDATED)` instead. The thread itself stays unresolved.
+- **A finding that reappears after a human minimized/dismissed it is treated
+  as matched** — the bot respects the dismissal and does not re-post.
+- **Body-only (non-inline) findings have no thread**; when stale they simply
+  stop appearing in the next run's review body.
+
+Comment format is unchanged from `daydream --comment` — these workflows add
+triggers and posting identity, not a new output format.

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -1,0 +1,78 @@
+# Daydream — `@<bot> review` gatekeeper.
+#
+# Listens for PR comments, gates on author trust, and dispatches
+# daydream-review.yml. This workflow NEVER checks out code — it may therefore
+# hold App credentials without violating the locked privilege split (no job
+# ever holds both PR code and the App key).
+#
+# Why the App token for the dispatch (Task 0 spike, Step 1): a run dispatched
+# with GITHUB_TOKEN completes without ever firing the downstream
+# `workflow_run` trigger, so daydream-post.yml would never run on the
+# `@<bot> review` path. The dispatch is therefore made with a short-lived App
+# installation token minted with exactly `actions: write` — the token reaches
+# `gh` via `env:` only and never appears in a `run:` body or log.
+#
+# GITHUB_TOKEN permissions (Task 0 spike, Step 4): the 👀 reaction on a PR
+# comment needs `pull-requests: write` (`issues: write` is neither sufficient
+# nor necessary, even though the endpoint lives under /issues/).
+#
+# Setup: repo variable DAYDREAM_BOT_HANDLE (the mention handle, no `@`),
+# secrets DAYDREAM_APP_ID / DAYDREAM_APP_PRIVATE_KEY; the App must request
+# the `actions: write` repository permission.
+
+name: Daydream Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      github.event.comment.user.type != 'Bot'
+    steps:
+      # Exact-command match. The comment body is untrusted: it enters the
+      # shell via env only, never `${{ }}` interpolation (footgun 2). A
+      # non-matching comment exits 0 (neutral) and the remaining steps skip.
+      - name: Match review command
+        id: match
+        env:
+          BODY: ${{ github.event.comment.body }}
+          BOT_HANDLE: ${{ vars.DAYDREAM_BOT_HANDLE }}
+        run: |
+          if printf '%s' "$BODY" | grep -Eq "(^|[[:space:]])@${BOT_HANDLE}[[:space:]]+review([[:space:]]|$)"; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Acknowledge with eyes reaction
+        if: steps.match.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api -X POST "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" -f content=eyes
+
+      - name: Mint dispatch token
+        id: token
+        if: steps.match.outputs.matched == 'true'
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DAYDREAM_APP_ID }}
+          private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
+          permission-actions: write
+
+      - name: Dispatch review workflow
+        if: steps.match.outputs.matched == 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        run: gh workflow run daydream-review.yml --repo "$REPO" -f pr_number="$PR_NUMBER"

--- a/.github/workflows/daydream-command.yml
+++ b/.github/workflows/daydream-command.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   dispatch:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: >-
       github.event.issue.pull_request &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -1,0 +1,174 @@
+# Daydream — Phase B: POST (privileged).
+#
+# Fires when "Daydream Review" (Phase A) completes, downloads its findings
+# artifact, and posts the findings to the PR as the operator's App bot. This
+# job holds the App key, so it NEVER checks out or executes PR code — only the
+# base repo's default branch (trusted), per the locked privilege split: no
+# single job ever holds both PR code and the App key. The artifact is passive
+# data, validated by `daydream post-findings` against a strict schema before
+# anything is posted.
+#
+# Target derivation (Task 0 spike, Step 2 — the event payload is NOT uniform):
+#   - pull_request runs: `workflow_run.head_sha` IS the PR head.
+#     `pull_requests[0].number` is populated for same-repo PRs but EMPTY for
+#     fork PRs, where the open-PR list filtered by head SHA resolves it.
+#   - workflow_dispatch runs (the `@<bot> review` path): `pull_requests` is
+#     empty and `head_sha` is the default-branch tip (useless). The PR number
+#     travels in the findings artifact; the LIVE PR fetched from the GitHub
+#     API is the trust anchor — `daydream post-findings` validates the
+#     artifact's declared head_sha against that live value and aborts on
+#     mismatch, so a forged artifact can only point at the real current head
+#     of the PR it names.
+#
+# Token (footgun 3): minted via actions/create-github-app-token with exactly
+# `pull-requests: write, contents: read, metadata: read`, reaches `gh` via
+# `env:` only, and never appears in a `run:` body or log.
+
+name: Daydream Post
+
+on:
+  workflow_run:
+    workflows: ["Daydream Review"]
+    types: [completed]
+
+# GITHUB_TOKEN only downloads the artifact; the App token carries the writes.
+permissions:
+  actions: read
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      # Trusted code only: the base repo's default branch, no ref override.
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install daydream
+        run: uv tool install git+https://github.com/existential-birds/daydream
+
+      - name: Mint posting token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DAYDREAM_APP_ID }}
+          private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-contents: read
+          permission-metadata: read
+
+      - name: Download findings artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: daydream-findings
+          path: findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # All event values enter the shell via env only (footgun 2). No PR
+      # resolvable -> fail the job (and surface below), never post blind.
+      - name: Derive target PR and head SHA
+        id: target
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          if [ "$RUN_EVENT" = "pull_request" ]; then
+            HEAD_SHA="$EVENT_HEAD_SHA"
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            if [ -z "$PR_NUMBER" ]; then
+              # Fork PRs leave pull_requests empty (spike Shape 2); the
+              # open-PR list filtered by head SHA resolves both PR shapes.
+              PR_NUMBER="$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+                --jq ".[] | select(.head.sha == \"${HEAD_SHA}\") | .number" | head -n 1)"
+            fi
+          else
+            # workflow_dispatch (spike Shape 3): the event cannot identify the
+            # PR — read pr_number from the artifact, then trust the LIVE PR
+            # head from the API; post-findings validates the artifact against
+            # it and aborts on mismatch.
+            PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
+            HEAD_SHA="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq .head.sha)"
+          fi
+          if [ -z "$PR_NUMBER" ] || [ -z "$HEAD_SHA" ]; then
+            echo "could not resolve a target PR for this run" >&2
+            exit 1
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+
+      # Validates the artifact (strict schema, size cap, PR/SHA match) and
+      # posts only new findings; validation failure exits non-zero.
+      - name: Post findings
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.target.outputs.head_sha }}
+        run: |
+          daydream post-findings findings/findings.json \
+            --pr "$PR_NUMBER" --head-sha "$HEAD_SHA" --repo "$REPO"
+
+      - name: Surface failure on the PR
+        if: failure()
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          DERIVED_PR_NUMBER: ${{ steps.target.outputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          PR_NUMBER="${DERIVED_PR_NUMBER:-$EVENT_PR_NUMBER}"
+          if [ -z "$PR_NUMBER" ] && [ -f findings/findings.json ]; then
+            PR_NUMBER="$(jq -r '.pr_number // empty' findings/findings.json)"
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            echo "no PR resolvable; cannot surface the failure" >&2
+            exit 0
+          fi
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -f body="daydream review failed — see run ${RUN_URL}"
+
+  # An analyze failure routes here instead of silently skipping the post job.
+  surface-analyze-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Mint posting token
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DAYDREAM_APP_ID }}
+          private-key: ${{ secrets.DAYDREAM_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+          permission-contents: read
+          permission-metadata: read
+
+      - name: Comment on the PR
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          EVENT_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          PR_NUMBER="$EVENT_PR_NUMBER"
+          if [ -z "$PR_NUMBER" ] && [ "$RUN_EVENT" = "pull_request" ]; then
+            PR_NUMBER="$(gh api "repos/${REPO}/pulls?state=open&per_page=100" \
+              --jq ".[] | select(.head.sha == \"${EVENT_HEAD_SHA}\") | .number" | head -n 1)"
+          fi
+          if [ -z "$PR_NUMBER" ]; then
+            # A failed dispatch run leaves no artifact and a default-branch
+            # head_sha, so there is nothing to resolve — log and stop.
+            echo "no PR resolvable for the failed analyze run; skipping comment" >&2
+            exit 0
+          fi
+          gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            -f body="daydream review failed — see run ${RUN_URL}"

--- a/.github/workflows/daydream-post.yml
+++ b/.github/workflows/daydream-post.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   post:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       # Trusted code only: the base repo's default branch, no ref override.
@@ -137,7 +137,7 @@ jobs:
 
   # An analyze failure routes here instead of silently skipping the post job.
   surface-analyze-failure:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
       - name: Mint posting token

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.head.repo.full_name == github.repository &&

--- a/.github/workflows/daydream-review.yml
+++ b/.github/workflows/daydream-review.yml
@@ -1,0 +1,127 @@
+# Daydream — Phase A: ANALYZE (unprivileged).
+#
+# Runs the daydream reviewer over the checked-out PR head and uploads a
+# findings artifact. This job touches untrusted PR code, so it holds NO App
+# credentials — `OPENAI_API_KEY` is the only secret in this file, and the
+# GITHUB_TOKEN is read-only (`contents: read`). Posting happens in the
+# separate privileged `daydream-post.yml` (workflow_run), per the locked
+# privilege split: no single job ever holds both PR code and the App key.
+#
+# Triggers:
+#   - pull_request (opened, ready_for_review): auto-review for same-repo PRs,
+#     unless the operator sets the repo variable DAYDREAM_AUTO_REVIEW=false.
+#   - workflow_dispatch (pr_number): on-demand review, dispatched by
+#     daydream-command.yml on `@<bot> review`. Dispatch runs sit on the
+#     default branch, so the PR head ref is fetched explicitly.
+
+name: Daydream Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Number of the pull request to review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      vars.DAYDREAM_AUTO_REVIEW != 'false')
+    steps:
+      - name: Check out PR head (pull_request)
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Check out repository (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Dispatch runs sit on the default branch and the PR number arrives as
+      # an input, so the PR head must be fetched explicitly (via env, never
+      # inline interpolation).
+      - name: Check out PR head (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          git fetch origin "refs/pull/${PR_NUMBER}/head"
+          git checkout --detach FETCH_HEAD
+
+      - name: Resolve PR number and base ref
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            PR_NUMBER="$INPUT_PR_NUMBER"
+            BASE_REF="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)"
+          else
+            PR_NUMBER="$EVENT_PR_NUMBER"
+            BASE_REF="$EVENT_BASE_REF"
+          fi
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "base_ref=${BASE_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch base ref
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install daydream
+        run: uv tool install git+https://github.com/existential-birds/daydream
+
+      # Codex backend: daydream spawns `codex exec` as a subprocess, so the CLI
+      # must be on PATH. Pinned because the backend parses `codex exec
+      # --experimental-json` output, whose event shape can change between CLI
+      # releases. Node/npm are preinstalled on the GitHub-hosted runner.
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex@0.139.0
+
+      # `codex exec` does NOT read OPENAI_API_KEY from the environment for its
+      # own model-API auth (verified against CLI 0.139.0): with the key set but
+      # no auth state on disk, `codex login status` reports "Not logged in" and
+      # requests go out with no bearer → 401. It requires persisted auth in
+      # $CODEX_HOME/auth.json. Pipe the key into `codex login --with-api-key`
+      # (the documented non-interactive path) so the review step authenticates
+      # with no ChatGPT login state on disk.
+      - name: Authenticate Codex CLI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: printenv OPENAI_API_KEY | codex login --with-api-key
+
+      - name: Run daydream review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+        run: |
+          mkdir -p findings
+          daydream --review --backend codex --non-interactive --pr-number "$PR_NUMBER" \
+            --findings-out findings/findings.json --base "origin/$BASE_REF" .
+
+      - name: Upload findings artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: daydream-findings
+          path: findings/


### PR DESCRIPTION
## Summary

Add the three-workflow daydream review bot to beagle so PRs get reviewed by [daydream](https://github.com/existential-birds/daydream) and findings are posted as inline comments via a GitHub App. The review job is **Codex-backed**. This is beagle's first CI under `.github/workflows/`.

## Changes

### Added
- `.github/workflows/daydream-review.yml` — Phase A (analyze, unprivileged). Installs `daydream` + Codex CLI, authenticates with `OPENAI_API_KEY`, runs `daydream --review --backend codex`, and uploads a `daydream-findings` artifact. Holds no App credentials (touches untrusted PR code).
- `.github/workflows/daydream-command.yml` — `@<bot> review` gatekeeper. Gates on author trust (OWNER/MEMBER/COLLABORATOR), mints a short-lived App token with `actions: write`, and dispatches the review. Never checks out code.
- `.github/workflows/daydream-post.yml` — Phase B (post, privileged). Validates the artifact against a strict schema and the live PR head SHA, then posts inline findings as the App bot. Only checks out the trusted base branch.
- `.github/workflows/README.md` — install + security-model documentation.

### Changed
- Corrected the template README's stale `ANTHROPIC_API_KEY` references to `OPENAI_API_KEY` (two places) so setup matches the Codex backend the review workflow actually uses.

## Motivation

Beagle had no CI. These workflows dogfood daydream — beagle's own skills power daydream's reviews — on beagle's PRs, with a privilege split so no single job ever holds both untrusted PR code and the App private key.

## Testing

- [x] All three workflow YAML files parse (`yaml.safe_load`)
- [x] Confirmed the review step is Codex-backed (`--backend codex`, Codex CLI install, `OPENAI_API_KEY` auth)
- [ ] End-to-end run requires repo secrets/variables and a GitHub App (see below) — not yet configured

### Required setup before these run (per `.github/workflows/README.md`)
- Secrets: `OPENAI_API_KEY`, `DAYDREAM_APP_ID`, `DAYDREAM_APP_PRIVATE_KEY`
- Variable: `DAYDREAM_BOT_HANDLE` (optional `DAYDREAM_AUTO_REVIEW=false` to make it `@<bot> review`-only)
- A GitHub App with the permissions listed in the README, installed on this repo

## Checklist

- [x] Self-review completed
- [x] YAML validates locally
- [x] Documentation included (workflows README)