### PR TITLE
chore: gitignore review tooling artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ build/
 .planning/
 .beagle/
 skill_research/
+
+# Review tooling
+.daydream/
+.review-output.md


### PR DESCRIPTION
Ignore `.daydream/` and `.review-output.md` produced by the daydream review bot tooling so they stop appearing as untracked files in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)