### PR TITLE
docs: make README concise and agent-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Each plugin's README lists its skills. For every skill in one place, see the [fu
 | Plugin | Coverage |
 |--------|----------|
 | [beagle-core](plugins/beagle-core/README.md) | Shared workflows, verification, git, skill tooling |
-| [beagle-python](plugins/beagle-python/README.md) | Python, FastAPI, SQLAlchemy, pytest |
+| [beagle-python](plugins/beagle-python/README.md) | Python, FastAPI, SQLAlchemy, PostgreSQL, pytest |
 | [beagle-go](plugins/beagle-go/README.md) | Go, BubbleTea, Wish SSH, Prometheus |
 | [beagle-elixir](plugins/beagle-elixir/README.md) | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
 | [beagle-ios](plugins/beagle-ios/README.md) | Swift, SwiftUI, SwiftData, iOS frameworks |

--- a/README.md
+++ b/README.md
@@ -43,22 +43,24 @@ If a marketplace file is reported missing, remove stale entries from `~/.claude/
 
 ## Plugins
 
+Each plugin's README lists its skills. For every skill in one place, see the [full catalog](SKILLS.md).
+
 | Plugin | Coverage |
 |--------|----------|
-| beagle-core | Shared workflows, verification, git, skill tooling |
-| beagle-python | Python, FastAPI, SQLAlchemy, pytest |
-| beagle-go | Go, BubbleTea, Wish SSH, Prometheus |
-| beagle-elixir | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
-| beagle-ios | Swift, SwiftUI, SwiftData, iOS frameworks |
-| beagle-react | React, React Flow, shadcn/ui, Tailwind, Remix v2 |
-| beagle-rust | Rust, tokio, axum, sqlx, serde |
-| beagle-docs | Documentation quality, AI-writing detection (Diataxis) |
-| beagle-analysis | Brainstorming, ADRs, strategy, LLM-as-judge, TDD planning |
-| beagle-testing | Test plan generation and execution |
+| [beagle-core](plugins/beagle-core/README.md) | Shared workflows, verification, git, skill tooling |
+| [beagle-python](plugins/beagle-python/README.md) | Python, FastAPI, SQLAlchemy, pytest |
+| [beagle-go](plugins/beagle-go/README.md) | Go, BubbleTea, Wish SSH, Prometheus |
+| [beagle-elixir](plugins/beagle-elixir/README.md) | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
+| [beagle-ios](plugins/beagle-ios/README.md) | Swift, SwiftUI, SwiftData, iOS frameworks |
+| [beagle-react](plugins/beagle-react/README.md) | React, React Flow, shadcn/ui, Tailwind, Remix v2 |
+| [beagle-rust](plugins/beagle-rust/README.md) | Rust, tokio, axum, sqlx, serde |
+| [beagle-docs](plugins/beagle-docs/README.md) | Documentation quality, AI-writing detection (Diataxis) |
+| [beagle-analysis](plugins/beagle-analysis/README.md) | Brainstorming, ADRs, strategy, LLM-as-judge, TDD planning |
+| [beagle-testing](plugins/beagle-testing/README.md) | Test plan generation and execution |
 
 ## Key skills
 
-Your agent discovers every skill automatically; these are the headline ones.
+Your agent discovers every skill automatically; these are the headline ones. The [full catalog](SKILLS.md) lists them all.
 
 **Code review** — `review-python`, `review-frontend`, `review-remix-v2` (beagle-react); `review-go`, `review-tui` (beagle-go); `review-rust`, `review-elixir`, `review-ios`.
 

--- a/README.md
+++ b/README.md
@@ -6,129 +6,70 @@
 
 *Image: NASA, Public Domain. [Source](https://www.nasa.gov/multimedia/imagegallery/image_feature_572.html)*
 
-Beagle is a Claude Code plugin marketplace with 131 active skills across code review, documentation, testing, architectural analysis, and git workflows. Use it to review before you push, detect AI-generated artifacts, draft and improve docs, generate test plans, and analyze codebases — across Python, Go, Rust, Elixir, React, Remix v2, and iOS/Swift.
+Beagle is an [Agent Skills](https://agentskills.io/specification) marketplace: framework-aware code review, documentation, testing, architectural analysis, and git workflows for any compatible coding agent. Skills cover Python, Go, Rust, Elixir, React, Remix v2, and iOS/Swift.
 
-Used with [Amelia](https://github.com/existential-birds/amelia) for agent-based workflows and [Daydream](https://github.com/existential-birds/daydream) for automated review-fix-test loops.
+Pairs with [Amelia](https://github.com/existential-birds/amelia) for agent-based workflows and [Daydream](https://github.com/existential-birds/daydream) for automated review-fix-test loops.
 
 ## Installation
 
 **Prerequisites:**
-- [Claude Code](https://claude.ai/code) CLI installed
+- A coding agent that supports [Agent Skills](https://agentskills.io)
 - [agent-browser](https://github.com/vercel-labs/agent-browser) for the `run-test-plan` skill (optional)
 
-```bash
-# Add the marketplace
-claude plugin marketplace add https://github.com/existential-birds/beagle
+### Any coding agent
 
-# Install the plugins you need
-claude plugin install beagle-core@existential-birds
-claude plugin install beagle-python@existential-birds
-claude plugin install beagle-react@existential-birds
-```
-
-Verify installation by opening a new Claude Code session and running `/beagle-core:commit-push` — if the skill loads, the plugin is active.
-
-To update:
-```bash
-claude plugin marketplace update existential-birds && claude plugin update <plugin-name>
-```
-
-**Troubleshooting:**
-- "Marketplace file not found": Remove stale entries from `~/.claude/plugins/known_marketplaces.json` and restart Claude Code.
-- Plugin not updating: Run `claude plugin marketplace update existential-birds` to refresh the marketplace.
-
-### Other Agents
-
-Use the [skills CLI](https://skills.sh/docs/cli) to install beagle skills for other AI agents:
+Install with the [skills CLI](https://skills.sh/docs/cli):
 
 ```bash
 npx skills add existential-birds/beagle
 ```
 
-This downloads the skills and configures them for your agent.
+This downloads the skills and configures them for your agent. Codex users: see [.codex/INSTALL.md](.codex/INSTALL.md) and [docs/README.codex.md](docs/README.codex.md).
 
-**Codex users:** See [.codex/INSTALL.md](.codex/INSTALL.md) and [docs/README.codex.md](docs/README.codex.md) for setup instructions.
+### Claude Code
+
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-core@existential-birds
+```
+
+Install additional plugins as needed (for example `beagle-python@existential-birds`). Update with:
+
+```bash
+claude plugin marketplace update existential-birds && claude plugin update <plugin-name>
+```
+
+If a marketplace file is reported missing, remove stale entries from `~/.claude/plugins/known_marketplaces.json` and restart.
 
 ## Plugins
 
-| Plugin | Skills | Category |
-|--------|--------|----------|
-| **beagle-core** | 19 | Shared workflows, verification, git, skill tooling |
-| **beagle-python** | 7 | Python, FastAPI, SQLAlchemy, pytest |
-| **beagle-go** | 13 | Go, BubbleTea, Wish SSH, Prometheus |
-| **beagle-elixir** | 11 | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
-| **beagle-ios** | 16 | Swift, SwiftUI, SwiftData, iOS frameworks |
-| **beagle-react** | 28 | React, React Flow, shadcn/ui, Tailwind, Remix v2 |
-| **beagle-rust** | 12 | Rust, tokio, axum, sqlx, serde |
-| **beagle-docs** | 10 | Documentation quality, AI writing detection (Diataxis) |
-| **beagle-analysis** | 13 | Brainstorming, ADRs, strategy, LLM-as-judge, spec gap resolution, TDD plan writing |
-| **beagle-testing** | 2 | Test plan generation and execution |
-| **Total** | **131** | — |
+| Plugin | Coverage |
+|--------|----------|
+| beagle-core | Shared workflows, verification, git, skill tooling |
+| beagle-python | Python, FastAPI, SQLAlchemy, pytest |
+| beagle-go | Go, BubbleTea, Wish SSH, Prometheus |
+| beagle-elixir | Elixir, Phoenix, LiveView, ExUnit, ExDoc |
+| beagle-ios | Swift, SwiftUI, SwiftData, iOS frameworks |
+| beagle-react | React, React Flow, shadcn/ui, Tailwind, Remix v2 |
+| beagle-rust | Rust, tokio, axum, sqlx, serde |
+| beagle-docs | Documentation quality, AI-writing detection (Diataxis) |
+| beagle-analysis | Brainstorming, ADRs, strategy, LLM-as-judge, TDD planning |
+| beagle-testing | Test plan generation and execution |
 
-## Skills
+## Key skills
 
-These are the canonical skill entry points for Beagle.
+Your agent discovers every skill automatically; these are the headline ones.
 
-### beagle-core
+**Code review** — `review-python`, `review-frontend`, `review-remix-v2` (beagle-react); `review-go`, `review-tui` (beagle-go); `review-rust`, `review-elixir`, `review-ios`.
 
-| Skill | Description |
-|---------|-------------|
-| `review-plan <path>` | Review implementation plans |
-| `review-llm-artifacts` | Detect LLM coding artifacts |
-| `verify-llm-artifacts` | Confirm or reject review findings before deletes |
-| `fix-llm-artifacts` | Fix detected artifacts |
-| `commit-push` | Commit and push changes |
-| `create-pr` | Create PR with template |
-| `gen-release-notes <tag>` | Generate release notes |
-| `receive-feedback <path>` | Process review feedback |
-| `fetch-pr-feedback` | Fetch bot comments from PR |
-| `respond-pr-feedback` | Reply to bot comments |
-| `subagent-prompt` | Hand off the current session as an orchestrator-plus-subagents prompt for a fresh session |
-| `prompt-improver` | Optimize prompts |
+**Git & feedback** — `commit-push`, `create-pr`, `gen-release-notes`, `fetch-pr-feedback`, `respond-pr-feedback`, `receive-feedback`.
 
-### Code Review Skills
+**LLM artifacts** — `review-llm-artifacts`, `verify-llm-artifacts`, `fix-llm-artifacts`.
 
-| Skill | Plugin | Description |
-|---------|--------|-------------|
-| `review-python` | beagle-python | Python/FastAPI code review |
-| `review-frontend` | beagle-react | React/TypeScript code review |
-| `review-go` | beagle-go | Go code review |
-| `review-tui` | beagle-go | BubbleTea TUI code review |
-| `review-ios` | beagle-ios | iOS/SwiftUI code review |
-| `review-elixir` | beagle-elixir | Elixir/Phoenix code review |
-| `review-rust` | beagle-rust | Rust/tokio/axum code review |
-| `review-remix-v2` | beagle-react | Remix v2 code review (loaders, actions, forms, sessions) |
+**Docs** — `improve-doc`, `draft-docs`, `ensure-docs`, `review-ai-writing`, `humanize-beagle`.
 
-### Documentation & Analysis Skills
+**Analysis & planning** — `review-plan`, `write-adr`, `brainstorm-beagle`, `write-plan`, `quick-plan`, `llm-judge`, `strategy-interview`, `prfaq-beagle`, `web-research`.
 
-| Skill | Plugin | Description |
-|---------|--------|-------------|
-| `draft-docs <prompt>` | beagle-docs | Generate documentation drafts |
-| `improve-doc <path>` | beagle-docs | Improve docs using Diataxis |
-| `ensure-docs` | beagle-docs | Documentation coverage check |
-| `review-ai-writing` | beagle-docs | Detect AI writing patterns |
-| `humanize-beagle` | beagle-docs | Fix AI writing with safe/risky classification |
-| `llm-judge` | beagle-analysis | Compare implementations |
-| `write-adr` | beagle-analysis | Generate ADRs from decisions |
-| `brainstorm-beagle` | beagle-analysis | Turn fuzzy ideas into structured project specs |
-| `resolve-beagle` | beagle-analysis | Close Open Questions and latent gaps in a brainstorm-beagle spec |
-| `strategy-interview` | beagle-analysis | Build strategy through guided conversation |
-| `strategy-review` | beagle-analysis | Pressure-test existing strategy documents |
-| `prfaq-beagle` | beagle-analysis | Working Backwards PRFAQ filter — pass/fail concepts before brainstorming |
-| `web-research` | beagle-analysis | Parallel-subagent web research with cited synthesis report |
-| `artifact-analysis` | beagle-analysis | Parallel-subagent scan of local docs with cited extraction |
-| `write-plan` | beagle-analysis | Turn a finalized `brainstorm-beagle` spec into a TDD-driven implementation plan |
+**Testing** — `gen-test-plan`, `run-test-plan`.
 
-### Skill Tooling
-
-| Skill | Plugin | Description |
-|---------|--------|-------------|
-| `skill-builder` | beagle-core | Create new Claude Code skills with best practices |
-| `review-skill` | beagle-core | Automated skill PR review for structural validity, design quality, and marketplace consistency |
-
-### Testing Skills
-
-| Skill | Plugin | Description |
-|---------|--------|-------------|
-| `gen-test-plan` | beagle-testing | Generate YAML test plan |
-| `run-test-plan` | beagle-testing | Execute test plan |
+**Skill tooling** — `skill-builder`, `review-skill`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Beagle is an [Agent Skills](https://agentskills.io/specification) marketplace: framework-aware code review, documentation, testing, architectural analysis, and git workflows for any compatible coding agent. Skills cover Python, Go, Rust, Elixir, React, Remix v2, and iOS/Swift.
 
+Install for any agent: `npx skills add existential-birds/beagle`. Then your agent loads the right skill automatically, or you run one by name (for example `review-python`).
+
 Pairs with [Amelia](https://github.com/existential-birds/amelia) for agent-based workflows and [Daydream](https://github.com/existential-birds/daydream) for automated review-fix-test loops.
 
 ## Installation
@@ -60,7 +62,7 @@ Each plugin's README lists its skills. For every skill in one place, see the [fu
 
 ## Key skills
 
-Your agent discovers every skill automatically; these are the headline ones. The [full catalog](SKILLS.md) lists them all.
+Your agent discovers every skill automatically; these are the headline ones, grouped by task. The [full catalog](SKILLS.md) lists them all.
 
 **Code review** — `review-python`, `review-frontend`, `review-remix-v2` (beagle-react); `review-go`, `review-tui` (beagle-go); `review-rust`, `review-elixir`, `review-ios`.
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -6,7 +6,7 @@ Skills are invoked automatically by any compatible coding agent, or run directly
 
 ## beagle-core
 
-Shared workflows, verification, git, and skill tooling.
+Language-agnostic developer workflows: code review, git, PR/feedback handling, LLM-artifact cleanup, and skill tooling.
 
 | Skill | Description |
 |-------|-------------|
@@ -199,7 +199,7 @@ Brainstorming, ADRs, strategy, LLM-as-judge, planning, research.
 
 ## beagle-testing
 
-Test plan generation and execution.
+Generate and execute language-agnostic end-to-end test plans, including browser tests via agent-browser.
 
 | Skill | Description |
 |-------|-------------|

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,207 @@
+# Skill Catalog
+
+Every skill in the [beagle](README.md) Agent Skills marketplace, grouped by plugin. Each plugin's own README has fuller descriptions and install notes; this page is the at-a-glance index.
+
+Skills are invoked automatically by any compatible coding agent, or run directly by name (for example `review-python`). The deprecated `beagle-ai` plugin is not listed.
+
+## beagle-core
+
+Shared workflows, verification, git, and skill tooling.
+
+| Skill | Description |
+|-------|-------------|
+| `commit-push` | Commit and push local changes |
+| `create-pr` | Open a PR with a standardized description |
+| `gen-release-notes` | Generate release notes since a tag |
+| `review-plan` | Review an implementation plan before execution |
+| `review-structure` | Repo-wide structural-maintainability review |
+| `review-llm-artifacts` | Detect LLM coding artifacts across tests, dead code, abstraction, and style |
+| `verify-llm-artifacts` | Confirm or reject artifact findings before deletes |
+| `fix-llm-artifacts` | Apply fixes from a review-llm-artifacts run (safe/risky) |
+| `receive-feedback` | Process external review feedback, verifying claims first |
+| `fetch-pr-feedback` | Fetch unresolved PR review comments and evaluate them |
+| `respond-pr-feedback` | Reply to PR review comments after fixes |
+| `skill-builder` | Create Agent Skills with best practices and validation |
+| `review-skill` | Review PRs that add or modify Agent Skills |
+| `subagent-prompt` | Hand off the session to a fresh orchestrator-plus-subagents session |
+| `prompt-improver` | Optimize prompts for code-related tasks |
+| `llm-artifacts-detection` | Reference: detection patterns for LLM coding artifacts |
+| `review-feedback-schema` | Reference: schema for tracking review outcomes |
+| `review-skill-improver` | Reference: suggest review-skill improvements from feedback logs |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-python
+
+Python, FastAPI, SQLAlchemy, PostgreSQL, pytest.
+
+| Skill | Description |
+|-------|-------------|
+| `review-python` | Comprehensive Python/FastAPI code review |
+| `python-code-review` | Type safety, async patterns, error handling |
+| `fastapi-code-review` | Routing, dependency injection, validation, async handlers |
+| `sqlalchemy-code-review` | Sessions, relationships, N+1 queries, migrations |
+| `postgres-code-review` | Indexing, JSONB, connection pooling, transactions |
+| `pytest-code-review` | Async tests, fixtures, parametrize, mocking |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-go
+
+Go, BubbleTea, Wish SSH, Prometheus.
+
+| Skill | Description |
+|-------|-------------|
+| `review-go` | Comprehensive Go backend review (detects BubbleTea, Wish, Prometheus) |
+| `review-tui` | BubbleTea TUI review (Elm architecture, Lipgloss) |
+| `go-code-review` | Idiomatic patterns, error handling, concurrency safety |
+| `go-testing-code-review` | Table-driven tests, assertions, coverage |
+| `go-architect` | App architecture, routing, project layout, DI |
+| `go-web-expert` | Production-quality Go web development persona |
+| `go-concurrency-web` | Worker pools, rate limiting, race-safe shared state |
+| `go-data-persistence` | SQL, ORMs, pooling, migrations, transactions |
+| `go-middleware` | Context propagation, slog, error handling, recovery |
+| `bubbletea-code-review` | Model/update/view patterns and Lipgloss styling |
+| `wish-ssh-code-review` | SSH middleware, session handling, security |
+| `prometheus-go-code-review` | Metric types, labels, instrumentation patterns |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-rust
+
+Rust, tokio, axum, sqlx, serde.
+
+| Skill | Description |
+|-------|-------------|
+| `review-rust` | Comprehensive Rust review across detected tech areas |
+| `rust-code-review` | Ownership, borrowing, lifetimes, traits, unsafe |
+| `rust-testing-code-review` | Unit/integration/async tests, mocking, property tests |
+| `rust-best-practices` | Idiomatic Rust development guidance |
+| `rust-project-setup` | Scaffolding new projects, Cargo.toml, CI, workspaces |
+| `axum-code-review` | Routing, extractors, middleware, state, errors |
+| `tokio-async-code-review` | Tasks, sync primitives, channels, runtime config |
+| `sqlx-code-review` | Compile-time queries, pools, migrations, Postgres |
+| `serde-code-review` | Derive patterns, enum representations, custom impls |
+| `ffi-code-review` | Type safety and unsafe boundary correctness |
+| `macros-code-review` | Macro hygiene, fragments, proc-macro patterns |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-elixir
+
+Elixir, Phoenix, LiveView, ExUnit, ExDoc.
+
+| Skill | Description |
+|-------|-------------|
+| `review-elixir` | Comprehensive Elixir/Phoenix review |
+| `elixir-code-review` | Idiomatic patterns, OTP basics, documentation |
+| `phoenix-code-review` | Controllers, context boundaries, routing, plugs |
+| `liveview-code-review` | Lifecycle, assigns/streams, components, security |
+| `exunit-code-review` | Test patterns and boundary mocking with Mox |
+| `elixir-performance-review` | GenServer bottlenecks, memory, concurrency |
+| `elixir-security-review` | Code injection, atom exhaustion, secret handling |
+| `elixir-docs-review` | @moduledoc/@doc/@spec coverage and doctests |
+| `elixir-writing-docs` | Writing Elixir docs with metadata and cross-refs |
+| `exdoc-config` | Configure ExDoc generation |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-react
+
+React, React Flow, shadcn/ui, Tailwind, Vitest, Remix v2.
+
+| Skill | Description |
+|-------|-------------|
+| `review-frontend` | Comprehensive React/TypeScript review |
+| `review-remix-v2` | Comprehensive Remix v2 review |
+| `react-router-v7` | Data-driven routing best practices |
+| `react-router-code-review` | Data loading, mutations, navigation |
+| `react-flow` | Workflow visualization with custom nodes and edges |
+| `react-flow-implementation` | Build node-based UIs with @xyflow/react |
+| `react-flow-advanced` | Sub-flows, drag-and-drop, undo/redo |
+| `react-flow-architecture` | Designing node-based UI architecture |
+| `react-flow-code-review` | React Flow anti-patterns and performance |
+| `dagre-react-flow` | Automatic graph layout with dagre |
+| `shadcn-ui` | shadcn/ui component patterns with Radix + Tailwind |
+| `shadcn-code-review` | CVA patterns, composition, accessibility |
+| `tailwind-v4` | Tailwind v4 CSS-first config and design tokens |
+| `ai-elements` | Vercel AI Elements for workflow UI |
+| `zustand-state` | Zustand state management |
+| `vitest-testing` | Vitest patterns and best practices |
+| `remix-v2-routing` | Flat-routes v2 conventions and layouts |
+| `remix-v2-routing-review` | Route naming, layouts, resource-route shape |
+| `remix-v2-data-flow` | Loaders, actions, deferred data, revalidation |
+| `remix-v2-data-flow-review` | Mutations-in-loader, validation, return helpers |
+| `remix-v2-forms` | Form submissions, optimistic UI, uploads |
+| `remix-v2-forms-review` | Manual-fetch mutations, pending state, intents |
+| `remix-v2-meta-sessions` | Meta/SEO, sessions, auth, CSRF |
+| `remix-v2-meta-sessions-review` | v1 meta shape, cookie security, auth layer |
+| `remix-v2-perf-ssr` | Performance, streaming, caching, server/client split |
+| `remix-v2-perf-ssr-review` | Caching headers, hydration, prefetch hygiene |
+| `remix-v2-error-boundaries-review` | Unified ErrorBoundary and v1 holdovers |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-ios
+
+Swift, SwiftUI, SwiftData, iOS frameworks.
+
+| Skill | Description |
+|-------|-------------|
+| `review-ios` | Comprehensive iOS/SwiftUI review |
+| `swift-code-review` | Concurrency safety, error handling, memory |
+| `swiftui-code-review` | View composition, state, performance, accessibility |
+| `swiftdata-code-review` | Model design, queries, concurrency, migrations |
+| `swift-testing-code-review` | #expect/#require, parameterized and async tests |
+| `combine-code-review` | Memory leaks, operator misuse, error handling |
+| `urlsession-code-review` | Async networking, requests, caching, background |
+| `app-intents-code-review` | Intents, entities, shortcuts, parameters |
+| `cloudkit-code-review` | Containers, records, subscriptions, sharing |
+| `healthkit-code-review` | Authorization, queries, background delivery |
+| `widgetkit-code-review` | Timelines, view composition, configurable intents |
+| `watchos-code-review` | Lifecycle, complications, WatchConnectivity |
+| `ios-animation-design` | Plan and spec iOS animations |
+| `ios-animation-implementation` | Write SwiftUI/Core Animation/UIKit animations |
+| `ios-animation-code-review` | Animation correctness, performance, accessibility |
+| `review-verification-protocol` | Reference: mandatory verification steps for reviews |
+
+## beagle-docs
+
+Documentation quality and AI-writing detection (Diataxis).
+
+| Skill | Description |
+|-------|-------------|
+| `improve-doc` | Analyze and improve existing docs (Diataxis) |
+| `draft-docs` | Generate first-draft docs from code analysis |
+| `ensure-docs` | Check doc coverage and fill gaps interactively |
+| `review-ai-writing` | Detect AI-writing patterns in developer text |
+| `humanize-beagle` | Rewrite AI-generated text to sound human |
+| `docs-style` | Core documentation writing principles |
+| `tutorial-docs` | Patterns for learning-oriented tutorials |
+| `howto-docs` | Patterns for task-oriented how-to guides |
+| `reference-docs` | Patterns for API and reference docs |
+| `explanation-docs` | Patterns for conceptual explanation docs |
+
+## beagle-analysis
+
+Brainstorming, ADRs, strategy, LLM-as-judge, planning, research.
+
+| Skill | Description |
+|-------|-------------|
+| `brainstorm-beagle` | Shape a fuzzy idea into a concrete project spec |
+| `resolve-beagle` | Close open questions and gaps in a brainstorm spec |
+| `prfaq-beagle` | Working Backwards PRFAQ filter (pass/fail a concept) |
+| `write-plan` | Turn a brainstorm spec into a TDD implementation plan |
+| `quick-plan` | TDD plan with no spec, reconstructed from the conversation |
+| `write-adr` | Generate ADRs from the current session |
+| `adr-writing` | Write/format an ADR using the MADR template |
+| `adr-decision-extraction` | Mine a conversation for architectural decisions |
+| `agent-architecture-analysis` | Audit a codebase against 12-Factor Agents |
+| `strategy-interview` | Build strategy through guided conversation |
+| `strategy-review` | Pressure-test an existing strategy document |
+| `web-research` | Parallel web research with a cited synthesis report |
+| `artifact-analysis` | Cited, structured read of local docs |
+| `llm-judge` | Compare 2+ implementations against a spec with scoring |
+
+## beagle-testing
+
+Test plan generation and execution.
+
+| Skill | Description |
+|-------|-------------|
+| `gen-test-plan` | Detect stack, trace changes, generate an E2E YAML test plan |
+| `run-test-plan` | Execute a YAML test plan, stop on first failure |

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,30 @@
+# Beagle
+
+> Beagle is an Agent Skills marketplace: framework-aware code review, documentation, testing, architectural analysis, and git workflows for any compatible coding agent. It ships 10 plugins and 130+ skills covering Python, Go, Rust, Elixir, React, Remix v2, and iOS/Swift.
+
+Skills follow the [Agent Skills specification](https://agentskills.io/specification) and are invoked automatically by any compatible agent, or run by name (for example `review-python`). Install for any agent with `npx skills add existential-birds/beagle`; for Claude Code, `claude plugin marketplace add https://github.com/existential-birds/beagle`. Browse skills by task below — code review, test-plan generation, documentation, TDD planning, ADRs, LLM-artifact cleanup, and git/PR workflows.
+
+## Docs
+
+- [README](https://github.com/existential-birds/beagle/blob/main/README.md): What beagle is, installation for any agent and for Claude Code, and the plugin index.
+- [Skill catalog](https://github.com/existential-birds/beagle/blob/main/SKILLS.md): Every skill in the marketplace, grouped by plugin, each with a one-line description.
+
+## Plugins
+
+- [beagle-core](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-core/README.md): Cross-language workflows — commit/push, open PRs, generate release notes, review implementation plans and repo structure, detect and fix LLM coding artifacts, process PR/review feedback, and build new skills.
+- [beagle-python](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-python/README.md): Code review for Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest.
+- [beagle-go](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-go/README.md): Code review and architecture guidance for Go, BubbleTea TUIs, Wish SSH, and Prometheus.
+- [beagle-rust](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-rust/README.md): Code review and best practices for Rust, tokio, axum, sqlx, and serde.
+- [beagle-elixir](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-elixir/README.md): Code review for Elixir, Phoenix, LiveView, ExUnit, and ExDoc.
+- [beagle-react](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-react/README.md): Code review and implementation guidance for React, Remix v2, React Flow, shadcn/ui, Tailwind, Vitest, and Zustand.
+- [beagle-ios](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-ios/README.md): Code review for Swift, SwiftUI, SwiftData, and iOS frameworks (Combine, CloudKit, HealthKit, WidgetKit, watchOS).
+- [beagle-docs](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-docs/README.md): Write, improve, and audit documentation with Diataxis, and detect or humanize AI-generated writing.
+- [beagle-analysis](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-analysis/README.md): Brainstorm specs, write ADRs, run strategy interviews, plan TDD implementations, research the web, and compare implementations with LLM-as-judge.
+- [beagle-testing](https://github.com/existential-birds/beagle/blob/main/plugins/beagle-testing/README.md): Generate and execute language-agnostic end-to-end test plans, including browser tests via agent-browser.
+
+## Optional
+
+- [Agent Skills specification](https://agentskills.io/specification): The open spec these skills implement.
+- [skills CLI](https://skills.sh/docs/cli): Install skills into any compatible agent.
+- [Amelia](https://github.com/existential-birds/amelia): Agent-based workflows that pair with beagle.
+- [Daydream](https://github.com/existential-birds/daydream): Automated review-fix-test loops that pair with beagle.

--- a/plugins/beagle-analysis/README.md
+++ b/plugins/beagle-analysis/README.md
@@ -1,43 +1,49 @@
 # beagle-analysis
 
-Architecture analysis, 12-Factor compliance, ADR generation, and LLM-as-judge comparison for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Brainstorming, ADRs, strategy, LLM-as-judge, planning, and research. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-analysis@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **llm-judge** | `/beagle-analysis:llm-judge` | Compare code implementations across 2+ repos using LLM-as-judge methodology with weighted scoring |
-| **write-adr** | `/beagle-analysis:write-adr` | Generate ADRs from decisions made in the current session |
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-analysis@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **adr-decision-extraction** | Extract architectural decisions from conversations, identifying problem-solution pairs and trade-off discussions |
-| **adr-writing** | Write Architectural Decision Records following the MADR template with Definition of Done criteria |
-| **agent-architecture-analysis** | 12-Factor Agents compliance analysis for evaluating agent architecture and LLM-powered systems |
-| **llm-judge** | LLM-as-judge methodology for comparing code implementations using weighted rubrics across functionality, security, test quality, overengineering, and dead code |
-| **strategy-interview** | Structured strategy interview using kernel framework with landscape mapping, choice cascade, and value innovation lenses |
-| **strategy-review** | Pressure-test strategy documents for kernel integrity, bad-strategy patterns, coherence gaps, and untested assumptions |
+| `prfaq-beagle` | Working Backwards PRFAQ gauntlet that pressure-tests a concept to a binary pass/fail, handing survivors to brainstorm-beagle |
+| `brainstorm-beagle` | Shapes a fuzzy idea into a WHAT/WHY project spec through structured dialogue |
+| `resolve-beagle` | Closes open questions and latent gaps in a brainstorm spec, rewriting it implementation-ready |
+| `write-plan` | Turns a finalized spec into a bite-sized, TDD-driven implementation plan with exact paths and commands |
+| `quick-plan` | Produces the same TDD-driven plan from the conversation when no spec exists, fanning out exploration subagents |
+| `write-adr` | Orchestrates the full extract-confirm-write ADR workflow from the current session |
+| `adr-writing` | Writes and quality-checks an ADR using the MADR template and E.C.A.D.R. Definition of Done |
+| `adr-decision-extraction` | Mines a conversation or transcript for architectural decisions, trade-offs, and technology choices |
+| `strategy-interview` | Builds a strategy via guided conversation using the kernel framework and complementary lenses |
+| `strategy-review` | Pressure-tests an existing strategy document across seven dimensions for gaps and hidden failure paths |
+| `web-research` | Gathers cited, multi-angle web evidence via parallel subagents into an on-disk synthesis report |
+| `artifact-analysis` | Scans local docs and project knowledge into a cited, structured extraction on disk |
+| `agent-architecture-analysis` | Audits an agent codebase against the 12-Factor Agents methodology with file-level evidence |
+| `llm-judge` | Compares two or more implementations against a spec using weighted rubrics and structured scoring |
 
 ### Reference Material
 
-The **adr-writing** skill includes references for:
+The `adr-writing` skill includes references for:
 
 - `madr-template.md`: MADR (Markdown Any Decision Records) template structure
 - `definition-of-done.md`: E.C.A.D.R. criteria checklist for ADR completeness
 
-The **llm-judge** skill includes references for:
+The `llm-judge` skill includes references for:
 
 - `fact-schema.md`: JSON schema for structured facts gathered by repo agents
 - `judge-agents.md`: Instructions for Phase 2 scoring agents
@@ -47,4 +53,4 @@ The **llm-judge** skill includes references for:
 ## See Also
 
 - [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace

--- a/plugins/beagle-analysis/README.md
+++ b/plugins/beagle-analysis/README.md
@@ -36,21 +36,8 @@ claude plugin install beagle-analysis@existential-birds
 | `agent-architecture-analysis` | Audits an agent codebase against the 12-Factor Agents methodology with file-level evidence |
 | `llm-judge` | Compares two or more implementations against a spec using weighted rubrics and structured scoring |
 
-### Reference Material
-
-The `adr-writing` skill includes references for:
-
-- `madr-template.md`: MADR (Markdown Any Decision Records) template structure
-- `definition-of-done.md`: E.C.A.D.R. criteria checklist for ADR completeness
-
-The `llm-judge` skill includes references for:
-
-- `fact-schema.md`: JSON schema for structured facts gathered by repo agents
-- `judge-agents.md`: Instructions for Phase 2 scoring agents
-- `repo-agent.md`: Instructions for Phase 1 fact-gathering agents
-- `scoring-rubrics.md`: Detailed 1-5 rubrics for each judging dimension
-
 ## See Also
 
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-analysis/README.md
+++ b/plugins/beagle-analysis/README.md
@@ -1,6 +1,6 @@
 # beagle-analysis
 
-Brainstorming, ADRs, strategy, LLM-as-judge, planning, and research. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
+Pre-code thinking and decision tools: brainstorm a fuzzy idea into a spec, write ADRs, run strategy interviews, turn specs into TDD implementation plans, research the web with citations, audit agent architectures against 12-Factor Agents, and compare implementations with LLM-as-judge. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 

--- a/plugins/beagle-core/README.md
+++ b/plugins/beagle-core/README.md
@@ -1,56 +1,46 @@
 # beagle-core
 
-Shared code review workflows, verification protocol, git commands, and feedback handling for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace. Recommended as a base for all beagle plugins.
+Shared workflows, verification, git, and skill tooling. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-core@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **commit-push** | `/beagle-core:commit-push` | Commit and push all local changes using Conventional Commits format |
-| **create-pr** | `/beagle-core:create-pr` | Create a pull request with a standardized description template |
-| **review-plan** | `/beagle-core:review-plan` | Review implementation plans for parallelization, TDD, types, libraries, and security |
-| **review-llm-artifacts** | `/beagle-core:review-llm-artifacts` | Scan for LLM agent artifacts via 4 parallel subagents. Default: files changed since merge-base with main; `--all` opt-in for full-project scan |
-| **verify-llm-artifacts** | `/beagle-core:verify-llm-artifacts` | Confirm or reject review findings before deletes — reduces false positives |
-| **fix-llm-artifacts** | `/beagle-core:fix-llm-artifacts` | Apply fixes from a prior review (optionally after verification) with safe/risky classification |
-| **receive-feedback** | `/beagle-core:receive-feedback` | Process code review feedback from a file with verification-first discipline |
-| **fetch-pr-feedback** | `/beagle-core:fetch-pr-feedback` | Fetch bot review comments from a PR and evaluate with receive-feedback skill |
-| **respond-pr-feedback** | `/beagle-core:respond-pr-feedback` | Post replies to bot review comments after evaluation and fixes |
-| **gen-release-notes** | `/beagle-core:gen-release-notes` | Generate release notes for changes since a given tag |
-| **prompt-improver** | `/beagle-core:prompt-improver` | Optimize prompts for code-related tasks following Claude best practices |
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-core@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **review-verification-protocol** | Mandatory verification steps for all code reviews to reduce false positives |
-| **receive-feedback** | Process external code review feedback with technical rigor and verification-first discipline |
-| **review-feedback-schema** | Schema for tracking code review outcomes to enable feedback-driven skill improvement |
-| **review-skill-improver** | Analyzes feedback logs to identify patterns and suggest improvements to review skills |
-| **llm-artifacts-detection** | Detects common LLM coding agent artifacts: test quality issues, dead code, over-abstraction, and verbose style |
-| **verify-llm-artifacts** | Second-pass adjudication of review-llm-artifacts JSON; marks confirmed vs false positive vs inconclusive |
-| **skill-builder** | Guided skill creation workflow |
-| **review-skill** | Automated skill PR review for structural validity, design quality, and marketplace consistency |
-
-### Reference Material
-
-Each skill with a `references/` directory includes detailed reference documents:
-
-**llm-artifacts-detection**: dead code criteria, test quality criteria, abstraction criteria, style criteria
-
-**verify-llm-artifacts**: per-finding verification checklist (false positives vs confirmed issues)
-
-**receive-feedback**: skill integration patterns
+| `commit-push` | Commit and push all local changes using Conventional Commits format |
+| `create-pr` | Create a pull request with a standardized description template |
+| `gen-release-notes` | Generate release notes for changes since a given tag |
+| `review-plan` | Review implementation plans for parallelization, TDD, types, libraries, and security before execution |
+| `review-structure` | Repo-wide structural-maintainability review — code-judo restructurings, 1k-line file guard, anti-spaghetti branching, canonical-layer enforcement, anti-magic abstractions, explicit type and boundary contracts |
+| `review-skill` | Review PRs that add or modify Agent Skills for structural validity, design quality, and marketplace consistency |
+| `skill-builder` | Create Agent Skills with best-practice structure, references, validation, and testing |
+| `subagent-prompt` | Hand off the current session's work to a fresh session as a portable orchestrator-plus-subagents prompt with per-task verification |
+| `prompt-improver` | Optimize prompts for code-related tasks following prompt-engineering best practices |
+| `receive-feedback` | Process external code review feedback with verification-first discipline, verifying claims before implementing and tracking disposition |
+| `fetch-pr-feedback` | Fetch unresolved review comments from a PR and evaluate them with the `receive-feedback` skill |
+| `respond-pr-feedback` | Post replies to PR review comments after evaluation and fixes |
+| `review-llm-artifacts` | Scan for LLM coding-agent artifacts across tests, dead code, abstraction, and style — changed files by default, `--all` for full-project |
+| `verify-llm-artifacts` | Adjudicate `review-llm-artifacts` findings as confirmed, false positive, or inconclusive before deletes |
+| `fix-llm-artifacts` | Apply fixes from a prior `review-llm-artifacts` run with safe/risky classification, respecting verification output |
+| `llm-artifacts-detection` | Reference: detection criteria for test quality, dead code, over-abstraction, and verbose LLM style |
+| `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting any code review findings |
+| `review-feedback-schema` | Reference: schema for tracking code review outcomes to enable feedback-driven skill improvement |
+| `review-skill-improver` | Reference: analyzes feedback logs to surface patterns and suggest improvements to review skills |
 
 ## See Also
 
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 12 focused plugins
+- [beagle marketplace](https://github.com/existential-birds/beagle) — full Agent Skills marketplace

--- a/plugins/beagle-core/README.md
+++ b/plugins/beagle-core/README.md
@@ -43,4 +43,5 @@ claude plugin install beagle-core@existential-birds
 
 ## See Also
 
-- [beagle marketplace](https://github.com/existential-birds/beagle) — full Agent Skills marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-core/README.md
+++ b/plugins/beagle-core/README.md
@@ -1,6 +1,6 @@
 # beagle-core
 
-Shared workflows, verification, git, and skill tooling. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
+Language-agnostic developer workflows shared across every beagle plugin: commit and push, open pull requests, generate release notes, review implementation plans and repo structure, detect and fix LLM coding artifacts, process PR and reviewer feedback, and build new skills. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 

--- a/plugins/beagle-docs/README.md
+++ b/plugins/beagle-docs/README.md
@@ -1,6 +1,6 @@
 # beagle-docs
 
-Documentation quality and AI-writing detection, built on Diataxis. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
+Write, improve, and audit technical documentation using the Diataxis framework, and detect or humanize AI-generated writing. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 

--- a/plugins/beagle-docs/README.md
+++ b/plugins/beagle-docs/README.md
@@ -32,13 +32,8 @@ claude plugin install beagle-docs@existential-birds
 | `reference-docs` | Information-oriented patterns for API docs, parameter tables, and technical specs |
 | `explanation-docs` | Understanding-oriented patterns for conceptual guides that explain why things work |
 
-### Reference Material
-
-- `docs-style`: the Diataxis compass for choosing the right doc type before writing
-- `tutorial-docs`: a complete example tutorial demonstrating all tutorial writing principles
-- `review-ai-writing`: reference files covering content, vocabulary, formatting, communication, filler, and code-doc patterns
-
 ## See Also
 
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-docs/README.md
+++ b/plugins/beagle-docs/README.md
@@ -1,46 +1,44 @@
 # beagle-docs
 
-Documentation quality, generation, and improvement using [Diataxis](https://diataxis.fr/) principles for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Documentation quality and AI-writing detection, built on Diataxis. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-docs@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **draft-docs** | `/beagle-docs:draft-docs` | Generate first-draft technical documentation from code analysis. Outputs Reference or How-To drafts to `docs/drafts/` for review before publishing. |
-| **improve-doc** | `/beagle-docs:improve-doc` | Analyze an existing markdown document, classify sections by Diataxis type, identify issues, and interactively refine each section. |
-| **ensure-docs** | `/beagle-docs:ensure-docs` | Verify documentation coverage across a codebase, report gaps, and interactively generate missing documentation. |
-| **review-ai-writing** | `/beagle-docs:review-ai-writing` | Detect AI-generated writing patterns in docs, docstrings, commits, PR descriptions, and code comments using parallel subagents. |
-| **humanize-beagle** | `/beagle-docs:humanize-beagle` | Apply fixes from a prior review-ai-writing run to humanize AI-generated developer text with safe/risky classification. |
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-docs@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **docs-style** | Core technical documentation writing principles for voice, tone, structure, and LLM-friendly patterns |
-| **tutorial-docs** | Tutorial patterns for learning-oriented guides that teach through guided doing |
-| **howto-docs** | How-To guide patterns for task-oriented guides for users with specific goals |
-| **explanation-docs** | Explanation documentation patterns for understanding-oriented content: conceptual guides that explain why things work the way they do |
-| **reference-docs** | Reference documentation patterns for API and symbol documentation, parameter tables, and technical specifications |
-| **review-ai-writing** | Detect AI-generated writing patterns in developer text: inflated language, filler phrases, tautological docs, chat leaks, and robotic tone |
-| **humanize-beagle** | Rewrite AI-generated developer text to sound human: fix strategies by category with safe/risky classification and developer voice guidelines |
+| `improve-doc` | Classify an existing markdown doc by Diataxis type and interactively refine each section |
+| `draft-docs` | Generate first-draft Tutorial, How-To, Reference, or Explanation docs to `docs/drafts/` from code analysis |
+| `ensure-docs` | Verify symbol and Diataxis-balance coverage across a codebase, report gaps, and generate missing docs |
+| `review-ai-writing` | Detect AI-generated writing patterns in docs, docstrings, commits, PR descriptions, and code comments |
+| `humanize-beagle` | Rewrite AI-generated developer text to sound human, with safe/risky fix classification |
+| `docs-style` | Core writing principles for voice, tone, structure, and LLM-friendly patterns |
+| `tutorial-docs` | Learning-oriented patterns for guides that teach through guided doing |
+| `howto-docs` | Task-oriented patterns for guides that help users reach a specific goal |
+| `reference-docs` | Information-oriented patterns for API docs, parameter tables, and technical specs |
+| `explanation-docs` | Understanding-oriented patterns for conceptual guides that explain why things work |
 
 ### Reference Material
 
-**tutorial-docs**: complete example tutorial (Weather API Integration) demonstrating all tutorial writing principles
-
-**review-ai-writing**: 6 reference files covering content, vocabulary, formatting, communication, filler, and code docs patterns
+- `docs-style`: the Diataxis compass for choosing the right doc type before writing
+- `tutorial-docs`: a complete example tutorial demonstrating all tutorial writing principles
+- `review-ai-writing`: reference files covering content, vocabulary, formatting, communication, filler, and code-doc patterns
 
 ## See Also
 
 - [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace

--- a/plugins/beagle-elixir/README.md
+++ b/plugins/beagle-elixir/README.md
@@ -1,63 +1,39 @@
 # beagle-elixir
 
-Elixir, Phoenix, and LiveView code review and documentation skills for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Elixir, Phoenix, LiveView, ExUnit, and ExDoc code review. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-elixir@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **review-elixir** | `/beagle-elixir:review-elixir` | Comprehensive Elixir/Phoenix code review with automatic framework detection |
-
-Reviews changed `.ex`, `.exs`, and `.heex` files against `main`. Runs `mix format --check-formatted` and Credo (if configured) before flagging style issues. Use `--parallel` to spawn specialized subagents per technology area.
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-elixir@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **elixir-code-review** | Idiomatic patterns, OTP basics, and documentation |
-| **phoenix-code-review** | Controller patterns, context boundaries, routing, and plugs |
-| **liveview-code-review** | Lifecycle patterns, assigns/streams, components, and security |
-| **exunit-code-review** | Test patterns, boundary mocking with Mox, and test adapters |
-| **elixir-security-review** | Code injection, atom exhaustion, secret handling, process exposure |
-| **elixir-performance-review** | GenServer bottlenecks, ETS patterns, memory, and concurrency |
-| **elixir-writing-docs** | Writing @moduledoc, @doc, @typedoc, doctests, cross-references, and metadata |
-| **exdoc-config** | ExDoc project setup: mix.exs config, extras, groups, cheatsheets, livebooks |
-| **elixir-docs-review** | Documentation quality review: completeness, @spec coverage, doctest correctness |
-| **review-verification-protocol** | Mandatory verification steps to reduce false positives |
-
-### Reference Material
-
-Each review skill includes detailed reference documents:
-
-**elixir-code-review**: code style, pattern matching, OTP basics, documentation
-
-**phoenix-code-review**: contexts, controllers, routing, plugs
-
-**liveview-code-review**: lifecycle, assigns/streams, components, security
-
-**exunit-code-review**: ExUnit patterns, Mox boundaries, test adapters, integration tests
-
-**elixir-security-review**: code injection, atom exhaustion, secrets, process exposure
-
-**elixir-performance-review**: GenServer bottlenecks, ETS patterns, memory, concurrency
-
-**elixir-writing-docs**: doctests, cross-references, admonitions and formatting
-
-**exdoc-config**: extras formats (md, cheatmd, livemd), advanced configuration
-
-**elixir-docs-review**: documentation quality, spec coverage
+| `review-elixir` | Comprehensive Elixir/Phoenix review with framework detection and optional parallel subagents |
+| `elixir-code-review` | Idiomatic patterns, OTP basics, and module documentation |
+| `phoenix-code-review` | Controller patterns, context boundaries, routing, and plugs |
+| `liveview-code-review` | Lifecycle patterns, assigns/streams, components, and security |
+| `exunit-code-review` | Test patterns, boundary mocking with Mox, and test adapters |
+| `elixir-performance-review` | GenServer bottlenecks, ETS patterns, memory, and concurrency |
+| `elixir-security-review` | Code injection, atom exhaustion, secret handling, and process exposure |
+| `elixir-docs-review` | Documentation completeness, @spec coverage, and doctest correctness |
+| `elixir-writing-docs` | Writing @moduledoc, @doc, @typedoc, doctests, cross-references, and metadata |
+| `exdoc-config` | ExDoc setup: mix.exs config, extras, groups, cheatsheets, and livebooks |
+| `review-verification-protocol` | Reference: mandatory verification steps to reduce false positives |
 
 ## See Also
 
 - [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace

--- a/plugins/beagle-elixir/README.md
+++ b/plugins/beagle-elixir/README.md
@@ -35,5 +35,6 @@ claude plugin install beagle-elixir@existential-birds
 
 ## See Also
 
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-go/README.md
+++ b/plugins/beagle-go/README.md
@@ -35,16 +35,8 @@ claude plugin install beagle-go@existential-birds
 | `go-middleware` | HTTP middleware with context propagation, slog logging, centralized error handling, and panic recovery |
 | `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting any review findings |
 
-### Reference Material
-
-Each review skill includes detailed reference documents:
-
-- **go-code-review**: error handling, concurrency, interfaces, common mistakes
-- **go-testing-code-review**: test structure, mocking
-- **bubbletea-code-review**: Elm architecture, model/update, view/styling, composition, Bubbles components
-- **wish-ssh-code-review**: server setup/middleware, session handling/security
-
 ## See Also
 
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-go/README.md
+++ b/plugins/beagle-go/README.md
@@ -1,50 +1,50 @@
 # beagle-go
 
-Go, BubbleTea TUI, Wish SSH, and Prometheus code review skills for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Go, BubbleTea, Wish SSH, and Prometheus code review. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-go@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **review-go** | `/beagle-go:review-go` | Comprehensive Go backend code review with optional parallel agents |
-| **review-tui** | `/beagle-go:review-tui` | BubbleTea TUI code review with Elm architecture focus |
-
-Both commands review changed `.go` files against `main`, detect frameworks in use, and load appropriate skills. Use `--parallel` to spawn specialized subagents per technology area.
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-go@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **go-code-review** | Idiomatic patterns, error handling, concurrency safety, and common mistakes |
-| **go-testing-code-review** | Table-driven tests, assertions, mocking, and coverage patterns |
-| **bubbletea-code-review** | Elm architecture, model/update/view patterns, and Lipgloss styling |
-| **wish-ssh-code-review** | Wish SSH server middleware, session handling, and security patterns |
-| **prometheus-go-code-review** | Prometheus metric types, labels, naming conventions, and instrumentation |
-| **review-verification-protocol** | Mandatory verification steps to reduce false positives |
+| `review-go` | Comprehensive Go backend code review; detects BubbleTea, Wish SSH, and Prometheus and loads matching review skills |
+| `review-tui` | BubbleTea TUI code review with Elm architecture focus across bubbletea, lipgloss, bubbles, and Wish SSH |
+| `go-code-review` | Idiomatic patterns, error handling, concurrency safety, generics, errors.Join, slog, and Go 1.22 loop semantics |
+| `go-testing-code-review` | Table-driven tests, assertions, mocking, and coverage patterns |
+| `bubbletea-code-review` | Elm architecture, model/update/view patterns, and Lipgloss styling |
+| `wish-ssh-code-review` | Wish SSH server middleware, session handling, and security patterns |
+| `prometheus-go-code-review` | Prometheus metric types, labels, and instrumentation patterns |
+| `go-architect` | Go web architecture with net/http 1.22+ routing, project layout, graceful shutdown, and dependency injection |
+| `go-web-expert` | Production-quality Go web persona enforcing zero global state, explicit errors, input validation, and testability |
+| `go-concurrency-web` | Worker pools, rate limiting, race detection, and safe shared state for high-throughput web apps |
+| `go-data-persistence` | Raw SQL with sqlx/pgx, Ent/GORM ORMs, connection pooling, golang-migrate, and transaction management |
+| `go-middleware` | HTTP middleware with context propagation, slog logging, centralized error handling, and panic recovery |
+| `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting any review findings |
 
 ### Reference Material
 
 Each review skill includes detailed reference documents:
 
-**go-code-review**: error handling, concurrency, interfaces, common mistakes
-
-**go-testing-code-review**: test structure, mocking
-
-**bubbletea-code-review**: Elm architecture, model/update, view/styling, composition, Bubbles components
-
-**wish-ssh-code-review**: server setup/middleware, session handling/security
+- **go-code-review**: error handling, concurrency, interfaces, common mistakes
+- **go-testing-code-review**: test structure, mocking
+- **bubbletea-code-review**: Elm architecture, model/update, view/styling, composition, Bubbles components
+- **wish-ssh-code-review**: server setup/middleware, session handling/security
 
 ## See Also
 
 - [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- [beagle marketplace](https://github.com/existential-birds/beagle) - Full Agent Skills marketplace

--- a/plugins/beagle-ios/README.md
+++ b/plugins/beagle-ios/README.md
@@ -40,5 +40,6 @@ claude plugin install beagle-ios@existential-birds
 
 ## See Also
 
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-ios/README.md
+++ b/plugins/beagle-ios/README.md
@@ -1,69 +1,44 @@
 # beagle-ios
 
-Swift, SwiftUI, SwiftData, and iOS framework code review skills for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Swift, SwiftUI, SwiftData, and iOS framework code review. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-ios@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **review-ios** | `/beagle-ios:review-ios` | Comprehensive iOS/SwiftUI code review with optional parallel agents |
-
-Reviews changed `.swift` files against `main`. Runs SwiftLint (if configured) before flagging style issues. Use `--parallel` to spawn specialized subagents per technology area.
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-ios@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **swift-code-review** | Concurrency safety, error handling, memory management, and common mistakes |
-| **swiftui-code-review** | View composition, state management, performance, and accessibility |
-| **swiftdata-code-review** | Model design, queries, concurrency, and migrations |
-| **healthkit-code-review** | Authorization patterns, query usage, background delivery, and data types |
-| **cloudkit-code-review** | Container setup, record handling, subscriptions, and sharing |
-| **widgetkit-code-review** | Timeline management, view composition, configurable intents, and performance |
-| **watchos-code-review** | App lifecycle, complications, WatchConnectivity, and performance constraints |
-| **app-intents-code-review** | Intent structure, entities, shortcuts, and parameters |
-| **combine-code-review** | Memory leaks, operator misuse, and error handling |
-| **urlsession-code-review** | Async/await patterns, request building, error handling, and caching |
-| **swift-testing-code-review** | #expect/#require usage, parameterized tests, async testing, and organization |
-| **review-verification-protocol** | Mandatory verification steps to reduce false positives |
-
-### Reference Material
-
-Each review skill includes detailed reference documents:
-
-**swift-code-review**: concurrency, observable patterns, error handling, common mistakes
-
-**swiftui-code-review**: view composition, state management, performance, accessibility
-
-**swiftdata-code-review**: model design, queries, concurrency, migrations
-
-**healthkit-code-review**: authorization, queries, background delivery, data types
-
-**cloudkit-code-review**: container setup, records, subscriptions, sharing
-
-**widgetkit-code-review**: timeline, views, intents, performance
-
-**watchos-code-review**: lifecycle, complications, connectivity, performance
-
-**app-intents-code-review**: intent structure, entities, shortcuts, parameters
-
-**combine-code-review**: publishers, operators, memory, error handling
-
-**urlsession-code-review**: async networking, request building, error handling, caching
-
-**swift-testing-code-review**: expect macro, parameterized tests, async testing, organization
+| `review-ios` | Comprehensive iOS/SwiftUI code review with optional parallel per-technology subagents |
+| `swift-code-review` | Concurrency safety, actor isolation, Sendable, error handling, and memory management |
+| `swiftui-code-review` | View composition, state management, performance, and accessibility |
+| `swiftdata-code-review` | Model design, queries, concurrency, and migrations |
+| `swift-testing-code-review` | #expect/#require usage, parameterized tests, async testing, and organization |
+| `combine-code-review` | Publisher/operator misuse, retain cycles, and error handling |
+| `urlsession-code-review` | Async/await networking, request building, error handling, and caching |
+| `app-intents-code-review` | Intent structure, entities, shortcuts, and parameters |
+| `cloudkit-code-review` | Container setup, record handling, subscriptions, and sharing |
+| `healthkit-code-review` | Authorization, queries, background delivery, and data types |
+| `widgetkit-code-review` | Timeline management, view composition, configurable intents, and performance |
+| `watchos-code-review` | App lifecycle, complications, WatchConnectivity, and performance constraints |
+| `ios-animation-code-review` | Animation correctness, performance, accessibility, and Apple API best practices |
+| `ios-animation-design` | Plan and spec iOS animations covering transitions, micro-interactions, and gesture-driven motion |
+| `ios-animation-implementation` | Write Swift animation code with first-party SwiftUI, Core Animation, and UIKit APIs |
+| `review-verification-protocol` | Reference: mandatory verification steps to reduce false positives |
 
 ## See Also
 
 - [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace

--- a/plugins/beagle-python/README.md
+++ b/plugins/beagle-python/README.md
@@ -29,12 +29,8 @@ claude plugin install beagle-python@existential-birds
 | `pytest-code-review` | Async test patterns, fixtures, parametrize, and mocking |
 | `review-verification-protocol` | Reference: mandatory verification steps to reduce false positives |
 
-### Reference Material
+## See Also
 
-Each per-tech review skill ships detailed reference documents:
-
-- `python-code-review`: pep8 style, type safety, async patterns, error handling, common mistakes
-- `fastapi-code-review`: routes, dependencies, validation, async
-- `sqlalchemy-code-review`: sessions, relationships, queries, migrations
-- `postgres-code-review`: indexes, JSONB, connections, transactions
-- `pytest-code-review`: async testing, fixtures, parametrize, mocking
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-python/README.md
+++ b/plugins/beagle-python/README.md
@@ -1,51 +1,40 @@
 # beagle-python
 
-Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review skills for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Python, FastAPI, SQLAlchemy, PostgreSQL, and pytest code review. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-python@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **review-python** | `/beagle-python:review-python` | Review changed `.py` files against `main` with automatic framework detection |
-
-Reviews changed Python files against `main`, detects which frameworks you use, and loads the appropriate skills automatically. Pass `--parallel` to spawn specialized subagents per technology area.
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-python@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **python-code-review** | Type safety, async patterns, error handling, and common mistakes |
-| **fastapi-code-review** | Routing patterns, dependency injection, validation, and async handlers |
-| **sqlalchemy-code-review** | Session management, relationships, N+1 queries, and migration patterns |
-| **postgres-code-review** | Indexing strategies, JSONB operations, connection pooling, and transaction safety |
-| **pytest-code-review** | Async test patterns, fixtures, parametrize, and mocking |
-| **review-verification-protocol** | Mandatory verification steps to reduce false positives |
+| `review-python` | Comprehensive Python/FastAPI backend review against `main` with framework detection and optional parallel agents |
+| `python-code-review` | Type safety, async patterns, error handling, and common mistakes |
+| `fastapi-code-review` | Routing patterns, dependency injection, validation, and async handlers |
+| `sqlalchemy-code-review` | Session management, relationships, N+1 queries, and migration patterns |
+| `postgres-code-review` | Indexing strategies, JSONB operations, connection pooling, and transaction safety |
+| `pytest-code-review` | Async test patterns, fixtures, parametrize, and mocking |
+| `review-verification-protocol` | Reference: mandatory verification steps to reduce false positives |
 
 ### Reference Material
 
-Each review skill includes detailed reference documents:
+Each per-tech review skill ships detailed reference documents:
 
-**python-code-review**: pep8 style, type safety, async patterns, error handling, common mistakes
-
-**fastapi-code-review**: routes, dependencies, validation, async
-
-**sqlalchemy-code-review**: sessions, relationships, queries, migrations
-
-**postgres-code-review**: indexes, JSONB, connections, transactions
-
-**pytest-code-review**: async testing, fixtures, parametrize, mocking
-
-## See Also
-
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- `python-code-review`: pep8 style, type safety, async patterns, error handling, common mistakes
+- `fastapi-code-review`: routes, dependencies, validation, async
+- `sqlalchemy-code-review`: sessions, relationships, queries, migrations
+- `postgres-code-review`: indexes, JSONB, connections, transactions
+- `pytest-code-review`: async testing, fixtures, parametrize, mocking

--- a/plugins/beagle-react/README.md
+++ b/plugins/beagle-react/README.md
@@ -1,106 +1,56 @@
 # beagle-react
 
-React, React Flow, React Router, shadcn/ui, Tailwind v4, Vitest, and Zustand code review skills for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+React, React Flow, shadcn/ui, Tailwind, Vitest, and Remix v2 code review. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
-claude plugin install beagle-react@existential-birds
+```bash
+npx skills add existential-birds/beagle
 ```
 
-## Commands
+For Claude Code:
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **review-frontend** | `/beagle-react:review-frontend` | Comprehensive React/TypeScript frontend code review with optional parallel agents |
-
-Reviews changed `.tsx`, `.ts`, and `.css` files against `main`. Detects frameworks in use and loads appropriate skills. Use `--parallel` to spawn specialized subagents per technology area.
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-react@existential-birds
+```
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| **ai-elements** | Vercel AI Elements for workflow UI components (chat interfaces, tool execution, reasoning displays) |
-| **dagre-react-flow** | Automatic graph layout using dagre with React Flow for hierarchical and tree structures |
-| **react-flow** | React Flow (@xyflow/react) for workflow visualization with custom nodes and edges |
-| **react-flow-advanced** | Advanced React Flow patterns: sub-flows, custom connection lines, drag-and-drop, undo/redo |
-| **react-flow-architecture** | Architectural guidance for building node-based UIs with React Flow |
-| **react-flow-code-review** | Reviews React Flow code for anti-patterns, performance issues, and best practices |
-| **react-flow-implementation** | Implements React Flow node-based UIs: nodes, edges, handles, state management, viewport control |
-| **react-router-code-review** | Reviews React Router code for data loading, mutations, error handling, and navigation patterns |
-| **react-router-v7** | React Router v7 best practices for data-driven routing, loaders, actions, and navigation |
-| **review-verification-protocol** | Mandatory verification steps to reduce false positives in code reviews |
-| **shadcn-code-review** | Reviews shadcn/ui components for CVA patterns, composition, accessibility, and data-slot usage |
-| **shadcn-ui** | shadcn/ui component patterns with Radix primitives and Tailwind styling |
-| **tailwind-v4** | Tailwind CSS v4 with CSS-first configuration, OKLCH colors, and design tokens |
-| **vitest-testing** | Vitest testing framework patterns: mocking, snapshots, coverage, and configuration |
-| **remix-v2-data-flow** | Remix v2 data loading and mutations: loaders, actions, deferred data, revalidation, pending state |
-| **remix-v2-data-flow-review** | Reviews Remix v2 loaders and actions for mutations-in-loader, missing validation, leaked server fields, wrong return helpers |
-| **remix-v2-error-boundaries-review** | Reviews Remix v2 error-handling code for unified ErrorBoundary, isRouteErrorResponse narrowing, throw-vs-return, v1 holdovers |
-| **remix-v2-forms** | Remix v2 form submissions and mutations: forms, optimistic UI, file uploads, multi-action routes |
-| **remix-v2-forms-review** | Reviews Remix v2 form code for manual fetch() mutations, native form misuse, wrong useNavigation/useFetcher choice |
-| **remix-v2-meta-sessions** | Remix v2 meta/SEO, sessions, auth, and CSRF: document head, cookie sessions, auth gates |
-| **remix-v2-meta-sessions-review** | Reviews Remix v2 code for v1-shape meta exports, cookie security gaps, auth gates in wrong layer, missing CSRF |
-| **remix-v2-perf-ssr** | Remix v2 performance, streaming, caching, and server/client boundaries |
-| **remix-v2-perf-ssr-review** | Reviews Remix v2 code for caching header misuse, missing server/client split, hydration mismatches, prefetch hygiene |
-| **remix-v2-routing** | Remix v2 routing patterns: flat-routes v2 conventions, route file naming, nested layouts, resource routes |
-| **remix-v2-routing-review** | Reviews Remix v2 route files for naming convention violations, missing layouts, resource-route shape, v1 holdovers |
-| **review-remix-v2** | Comprehensive Remix v2 code review with optional parallel agents and verification protocol |
-| **zustand-state** | Zustand state management: stores, selectors, persistence, devtools, and middleware |
-
-### Reference Material
-
-Each skill includes detailed reference documents:
-
-**react-flow**: custom nodes, custom edges, events, viewport
-
-**react-flow-implementation**: additional components, edge paths
-
-**react-router-code-review**: data loading, mutations, error handling, navigation
-
-**react-router-v7**: loaders, actions, navigation, advanced patterns
-
-**shadcn-code-review**: CVA patterns, composition, accessibility, data-slot
-
-**shadcn-ui**: components, CVA, patterns
-
-**tailwind-v4**: setup, theming, dark mode
-
-**vitest-testing**: config, mocking, patterns
-
-**zustand-state**: middleware, patterns, TypeScript
-
-**ai-elements**: conversation, prompt input, visualization, workflow
-
-**dagre-react-flow**: reference
-
-**remix-v2-data-flow**: loaders, actions, deferred data, revalidation
-
-**remix-v2-data-flow-review**: data-flow anti-patterns, validation
-
-**remix-v2-error-boundaries-review**: error boundary patterns, v1 holdovers
-
-**remix-v2-forms**: form submissions, optimistic UI, file uploads
-
-**remix-v2-forms-review**: form anti-patterns, pending state
-
-**remix-v2-meta-sessions**: meta/SEO, sessions, auth, CSRF
-
-**remix-v2-meta-sessions-review**: meta/session anti-patterns
-
-**remix-v2-perf-ssr**: streaming, caching, server/client boundaries
-
-**remix-v2-perf-ssr-review**: caching misuse, hydration mismatches
-
-**remix-v2-routing**: flat-routes, nested layouts, resource routes
-
-**remix-v2-routing-review**: naming conventions, layout violations
+| `review-frontend` | Comprehensive React/TypeScript frontend code review, dispatching per-area review skills |
+| `review-remix-v2` | Comprehensive Remix v2 code review across all areas with verification protocol |
+| `react-flow` | React Flow (@xyflow/react) for workflow visualization with custom nodes and edges |
+| `react-flow-implementation` | Build React Flow node-based UIs: nodes, edges, handles, state, viewport control |
+| `react-flow-advanced` | Advanced React Flow patterns: sub-flows, custom connection lines, drag-and-drop, undo/redo |
+| `react-flow-architecture` | Architectural guidance for designing node-based UIs with React Flow |
+| `react-flow-code-review` | Reviews React Flow code for anti-patterns, performance issues, and best practices |
+| `dagre-react-flow` | Automatic hierarchical and tree graph layout using dagre with React Flow |
+| `react-router-v7` | React Router v7 data-driven routing: loaders, actions, fetchers, navigation |
+| `react-router-code-review` | Reviews React Router v6.4+ code for data loading, mutations, error handling, navigation |
+| `shadcn-ui` | shadcn/ui component patterns with CVA variants, Radix primitives, and Tailwind |
+| `shadcn-code-review` | Reviews shadcn/ui components for CVA, asChild composition, accessibility, data-slot |
+| `tailwind-v4` | Tailwind CSS v4 CSS-first config, OKLCH colors, design tokens, and dark mode |
+| `zustand-state` | Zustand state management: stores, selectors, persistence, devtools, middleware |
+| `vitest-testing` | Vitest patterns: mocking with vi.mock/vi.fn, snapshots, coverage, configuration |
+| `ai-elements` | Vercel AI Elements for workflow UI: chat, tool execution, reasoning, job queues |
+| `remix-v2-data-flow` | Remix v2 loaders, actions, deferred data, revalidation, and pending state |
+| `remix-v2-data-flow-review` | Reviews loaders/actions for mutations-in-loader, missing validation, leaked fields, wrong helpers |
+| `remix-v2-forms` | Remix v2 forms, optimistic UI, file uploads, and multi-action intent routes |
+| `remix-v2-forms-review` | Reviews form code for manual fetch mutations, native form misuse, wrong fetcher choice |
+| `remix-v2-routing` | Remix v2 flat-routes v2 conventions, file naming, nested layouts, resource routes |
+| `remix-v2-routing-review` | Reviews route files for naming violations, missing layouts, resource-route shape, v1 holdovers |
+| `remix-v2-meta-sessions` | Remix v2 meta/SEO, cookie sessions, auth gates, and CSRF protection |
+| `remix-v2-meta-sessions-review` | Reviews meta/session code for v1-shape meta, cookie security gaps, misplaced auth, missing CSRF |
+| `remix-v2-perf-ssr` | Remix v2 performance, streaming, HTTP caching, and server/client boundaries |
+| `remix-v2-perf-ssr-review` | Reviews code for caching misuse, missing server/client split, hydration mismatches, prefetch hygiene |
+| `remix-v2-error-boundaries-review` | Reviews error handling for unified ErrorBoundary, isRouteErrorResponse narrowing, v1 holdovers |
+| `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting code review findings |
 
 ## See Also
 
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+- [beagle-core](../beagle-core) — Shared workflows, verification protocol, and git commands
+- [beagle marketplace](https://github.com/existential-birds/beagle) — Full Agent Skills marketplace

--- a/plugins/beagle-react/README.md
+++ b/plugins/beagle-react/README.md
@@ -27,27 +27,27 @@ claude plugin install beagle-react@existential-birds
 | `react-flow-implementation` | Build React Flow node-based UIs: nodes, edges, handles, state, viewport control |
 | `react-flow-advanced` | Advanced React Flow patterns: sub-flows, custom connection lines, drag-and-drop, undo/redo |
 | `react-flow-architecture` | Architectural guidance for designing node-based UIs with React Flow |
-| `react-flow-code-review` | Reviews React Flow code for anti-patterns, performance issues, and best practices |
+| `react-flow-code-review` | Review React Flow code: anti-patterns, performance issues, best practices |
 | `dagre-react-flow` | Automatic hierarchical and tree graph layout using dagre with React Flow |
 | `react-router-v7` | React Router v7 data-driven routing: loaders, actions, fetchers, navigation |
-| `react-router-code-review` | Reviews React Router v6.4+ code for data loading, mutations, error handling, navigation |
+| `react-router-code-review` | Review React Router v6.4+ code: data loading, mutations, error handling, navigation |
 | `shadcn-ui` | shadcn/ui component patterns with CVA variants, Radix primitives, and Tailwind |
-| `shadcn-code-review` | Reviews shadcn/ui components for CVA, asChild composition, accessibility, data-slot |
+| `shadcn-code-review` | Review shadcn/ui components: CVA, asChild composition, accessibility, data-slot |
 | `tailwind-v4` | Tailwind CSS v4 CSS-first config, OKLCH colors, design tokens, and dark mode |
 | `zustand-state` | Zustand state management: stores, selectors, persistence, devtools, middleware |
 | `vitest-testing` | Vitest patterns: mocking with vi.mock/vi.fn, snapshots, coverage, configuration |
 | `ai-elements` | Vercel AI Elements for workflow UI: chat, tool execution, reasoning, job queues |
 | `remix-v2-data-flow` | Remix v2 loaders, actions, deferred data, revalidation, and pending state |
-| `remix-v2-data-flow-review` | Reviews loaders/actions for mutations-in-loader, missing validation, leaked fields, wrong helpers |
+| `remix-v2-data-flow-review` | Review loaders/actions: mutations-in-loader, missing validation, leaked fields, wrong helpers |
 | `remix-v2-forms` | Remix v2 forms, optimistic UI, file uploads, and multi-action intent routes |
-| `remix-v2-forms-review` | Reviews form code for manual fetch mutations, native form misuse, wrong fetcher choice |
+| `remix-v2-forms-review` | Review form code: manual fetch mutations, native form misuse, wrong fetcher choice |
 | `remix-v2-routing` | Remix v2 flat-routes v2 conventions, file naming, nested layouts, resource routes |
-| `remix-v2-routing-review` | Reviews route files for naming violations, missing layouts, resource-route shape, v1 holdovers |
+| `remix-v2-routing-review` | Review route files: naming violations, missing layouts, resource-route shape, v1 holdovers |
 | `remix-v2-meta-sessions` | Remix v2 meta/SEO, cookie sessions, auth gates, and CSRF protection |
-| `remix-v2-meta-sessions-review` | Reviews meta/session code for v1-shape meta, cookie security gaps, misplaced auth, missing CSRF |
+| `remix-v2-meta-sessions-review` | Review meta/session code: v1-shape meta, cookie security gaps, misplaced auth, missing CSRF |
 | `remix-v2-perf-ssr` | Remix v2 performance, streaming, HTTP caching, and server/client boundaries |
-| `remix-v2-perf-ssr-review` | Reviews code for caching misuse, missing server/client split, hydration mismatches, prefetch hygiene |
-| `remix-v2-error-boundaries-review` | Reviews error handling for unified ErrorBoundary, isRouteErrorResponse narrowing, v1 holdovers |
+| `remix-v2-perf-ssr-review` | Review perf/SSR code: caching misuse, missing server/client split, hydration mismatches, prefetch hygiene |
+| `remix-v2-error-boundaries-review` | Review error handling: unified ErrorBoundary, isRouteErrorResponse narrowing, v1 holdovers |
 | `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting code review findings |
 
 ## See Also

--- a/plugins/beagle-react/README.md
+++ b/plugins/beagle-react/README.md
@@ -52,5 +52,6 @@ claude plugin install beagle-react@existential-birds
 
 ## See Also
 
-- [beagle-core](../beagle-core) — Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) — Full Agent Skills marketplace
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-rust/README.md
+++ b/plugins/beagle-rust/README.md
@@ -33,3 +33,9 @@ claude plugin install beagle-rust@existential-birds
 | `ffi-code-review` | Reviews extern blocks, `#[repr(C)]` types, string handling, callbacks, and unsafe boundary correctness |
 | `macros-code-review` | Reviews `macro_rules!` and procedural, derive, and attribute macros for hygiene, fragment misuse, and compile-time impact |
 | `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting any review findings to reduce false positives |
+
+## See Also
+
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace

--- a/plugins/beagle-rust/README.md
+++ b/plugins/beagle-rust/README.md
@@ -1,0 +1,35 @@
+# beagle-rust
+
+Rust, tokio, axum, sqlx, and serde code review. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
+
+## Installation
+
+For any coding agent that supports [Agent Skills](https://agentskills.io):
+
+```bash
+npx skills add existential-birds/beagle
+```
+
+For Claude Code:
+
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
+claude plugin install beagle-rust@existential-birds
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `review-rust` | Comprehensive Rust review that fans out across detected technology areas, running in parallel when subagents are available |
+| `rust-code-review` | Reviews ownership, borrowing, lifetimes, error handling, trait design, and unsafe usage for Rust 2024 idioms |
+| `rust-best-practices` | Guidance for idiomatic Rust: borrowing vs cloning, Result-based errors, dispatch choices, perf, clippy, doc tests |
+| `rust-project-setup` | Scaffolds new Rust projects and workspaces with Cargo.toml, CI, and clippy/rustfmt configuration |
+| `tokio-async-code-review` | Reviews tokio runtime usage: task management, sync primitives, channels, runtime config, and tower/hyper integration |
+| `axum-code-review` | Reviews axum 0.7+ services for routing, extractors, middleware, state management, and error handling |
+| `sqlx-code-review` | Reviews sqlx code for compile-time query checking, pool management, migrations, offline mode, and PostgreSQL usage |
+| `serde-code-review` | Reviews serde code for derive patterns, enum representations, custom impls, and format-specific serialization bugs |
+| `rust-testing-code-review` | Reviews unit, integration, async, mock, and property-based tests including Rust 2024 testing changes |
+| `ffi-code-review` | Reviews extern blocks, `#[repr(C)]` types, string handling, callbacks, and unsafe boundary correctness |
+| `macros-code-review` | Reviews `macro_rules!` and procedural, derive, and attribute macros for hygiene, fragment misuse, and compile-time impact |
+| `review-verification-protocol` | Reference: mandatory verification steps loaded before reporting any review findings to reduce false positives |

--- a/plugins/beagle-testing/README.md
+++ b/plugins/beagle-testing/README.md
@@ -1,6 +1,6 @@
 # beagle-testing
 
-Test plan generation and execution. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
+Generate and execute language-agnostic end-to-end test plans: detect the stack, trace branch changes to user-facing flows, and run them step by step — including browser tests via [agent-browser](https://github.com/vercel-labs/agent-browser). Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 

--- a/plugins/beagle-testing/README.md
+++ b/plugins/beagle-testing/README.md
@@ -1,29 +1,29 @@
 # beagle-testing
 
-Language-agnostic test plan generation and execution for [Claude Code](https://claude.ai/code). Part of the [beagle](https://github.com/existential-birds/beagle) plugin marketplace.
+Test plan generation and execution. Part of the [beagle](https://github.com/existential-birds/beagle) Agent Skills marketplace — see the [full skill catalog](../../SKILLS.md).
 
 ## Installation
 
-```bash
-# Add the marketplace (if not already added)
-claude plugin marketplace add https://github.com/existential-birds/beagle
+For any coding agent that supports [Agent Skills](https://agentskills.io):
 
-# Install the plugin
+```bash
+npx skills add existential-birds/beagle
+```
+
+For Claude Code:
+
+```bash
+claude plugin marketplace add https://github.com/existential-birds/beagle
 claude plugin install beagle-testing@existential-birds
 ```
 
-## Commands
+## Prerequisites
 
-| Command | Usage | Description |
-|---------|-------|-------------|
-| **gen-test-plan** | `/beagle-testing:gen-test-plan` | Generate an executable YAML test plan from branch changes, focused on user-facing impact |
-| **run-test-plan** | `/beagle-testing:run-test-plan` | Execute a YAML test plan, stopping on first failure with rich debug output |
+Browser tests require the optional [agent-browser](https://github.com/vercel-labs/agent-browser) CLI tool to be available on `PATH`
 
-`gen-test-plan` diffs the current branch against a base branch (default: `main`), traces changes to user-facing entry points, and outputs a structured YAML test plan. Pass `--base <branch>` to change the base.
+## Skills
 
-`run-test-plan` runs setup commands, health checks, and each test sequentially. On failure, it produces a detailed debug prompt. Pass `--plan <path>` to specify a custom plan file. Browser tests require the `agent-browser:agent-browser` skill.
-
-## See Also
-
-- [beagle-core](../beagle-core) - Shared workflows, verification protocol, and git commands
-- [beagle marketplace](https://github.com/existential-birds/beagle) - Full plugin marketplace with 10 focused plugins
+| Skill | Description |
+|-------|-------------|
+| `gen-test-plan` | Detect the stack, trace branch changes to user-facing entry points, and generate an executable E2E YAML test plan |
+| `run-test-plan` | Execute a YAML test plan sequentially, stopping on first failure with a rich debug prompt |

--- a/plugins/beagle-testing/README.md
+++ b/plugins/beagle-testing/README.md
@@ -27,3 +27,9 @@ Browser tests require the optional [agent-browser](https://github.com/vercel-lab
 |-------|-------------|
 | `gen-test-plan` | Detect the stack, trace branch changes to user-facing entry points, and generate an executable E2E YAML test plan |
 | `run-test-plan` | Execute a YAML test plan sequentially, stopping on first failure with a rich debug prompt |
+
+## See Also
+
+- [Skill catalog](../../SKILLS.md) — every skill in the marketplace
+- [beagle-core](../beagle-core/README.md) — shared workflows, verification, and git skills
+- [beagle marketplace](https://github.com/existential-birds/beagle) — the full Agent Skills marketplace


### PR DESCRIPTION
## Summary

Rewrites `README.md` to frame Beagle as an [Agent Skills](https://agentskills.io/specification) marketplace usable by any compatible coding agent rather than Claude Code specifically, while cutting it from 145 to ~87 lines by removing stale skill counts and duplicated content.

## Changes

### Changed
- Intro now leads with "Agent Skills marketplace" and links the spec, instead of "Claude Code plugin marketplace"
- Installation leads with the agent-agnostic `npx skills` CLI; Claude Code is presented as one option among others
- Plugins table reduced to plugin + coverage (no per-plugin count column, no `Total` row)
- The four ~35-row Skills tables collapsed into a compact grouped "Key skills" list

### Removed
- All hardcoded skill counts (intro "131 active skills", per-plugin counts, `Total` row) — these go stale
- Per-stack code-review rows that duplicated the language coverage already in the Plugins table
- Redundant troubleshooting line that repeated the update command
- The Claude Code-specific verify-installation step

## Motivation

Beagle skills follow the Agent Skills spec and work with any compatible agent, but the README read as Claude Code-only. Skill counts and the exhaustive skill tables added length and maintenance burden without proportional value.

## Testing

- [x] Manual testing performed

### Manual Testing Steps

- Verified all referenced paths exist (`assets/Stafford_and_Snoopy.jpg`, `.codex/INSTALL.md`, `docs/README.codex.md`) and every named plugin directory is present
- No build/typecheck applies (pure-markdown repo)

## Checklist

- [x] Self-review completed
- [x] Documentation updated