### PR TITLE
chore(entire): use separate checkpoint storage

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,10 @@
+{
+  "enabled": true,
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "existential-birds/beagle-checkpoints"
+    }
+  },
+  "telemetry": true
+}


### PR DESCRIPTION
## Summary

Configure Entire to store Beagle checkpoint history in the dedicated private `existential-birds/beagle-checkpoints` repository. This follows Entire’s documented `checkpoint_remote` project setting so Entire.io and all clones can discover the storage location.

## Changes

### Added

- Added the shared `.entire/settings.json` configuration.
- Set `strategy_options.checkpoint_remote` to `github:existential-birds/beagle-checkpoints`.

## Motivation

Keep AI session and checkpoint metadata in a private repository separate from the public source repository.

## Testing

- [x] Verified the installed Entire CLI accepts and reports the configured checkpoint remote.
- [x] Verified the checkpoint repository exists and is private.
- [x] Reviewed the one-file diff against `origin/main`.

## Checklist

- [x] Self-review completed.
- [x] No checkpoint backend or agent-hook behavior changed.
- [x] Configuration matches Entire’s documented format.